### PR TITLE
M-W: multi-offset (windowed) sampling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,15 @@
 name: ci
 
-# Lint, type-check, and test on every push to main and every PR. The 3.12 job covers
-# the *full* suite -- every framework adapter (torch/JAX/TF) and the Icechunk handoff --
-# while 3.13 stays light (core + torch/bench), since the adapters are interpreter-
-# independent. A separate free-threaded job runs the core engine with the GIL disabled to
-# guard the scatter/gather concurrency.
+# Lint, type-check, and test on every push to main and every PR.
 #
-# torch, JAX and TF cannot share one interpreter: importing all three loads duplicate
-# OpenMP/XLA/protobuf runtimes and the process SIGSEGVs (exit 139). pytest imports every
-# collected test module up front, and `-m`/marker filtering runs *after* that import, so
-# the only way to keep a framework out of a process is to not collect its module. The 3.12
-# job therefore runs pytest three times -- torch+core, then JAX alone, then TF alone --
-# each a fresh process with at most one framework. (Forking is not an option: the parent
-# may hold a live obstore/tokio runtime, which a fork would corrupt.)
+# One framework per *environment*. torch, JAX and TensorFlow cannot coexist in one Python
+# process -- together they load duplicate OpenMP/XLA/protobuf runtimes and the process
+# crashes (SIGSEGV / abort). And it is not enough to run them in separate pytest processes
+# of one env: TF (via its bundled Keras 3) transitively imports JAX *when JAX is installed*,
+# so the two collide even when only the TF tests are selected. The fix is therefore to give
+# each framework its own job with only that framework installed; the others importorskip-skip.
+# A separate `lint` job installs every extra (so mypy sees the real framework types) but runs
+# no pytest -- mypy doesn't import the frameworks, so co-installation is harmless there.
 on:
   push:
     branches: [main]
@@ -27,6 +24,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Lint + types once, on 3.12 with every extra installed so mypy resolves the real
+  # torch/JAX/TF/icechunk types. No pytest here (that would co-import the frameworks).
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+      - run: uv sync --python 3.12 --extra torch --extra bench --extra jax --extra tf --extra icechunk
+      - run: |
+          uv run ruff check src tests bench examples
+          uv run ruff format --check src tests bench examples
+          uv run mypy src bench examples
+
+  # One job per framework: each env installs a single DL framework, so nothing it (or its
+  # deps, e.g. Keras->JAX) imports can collide with another framework. Tests for absent
+  # frameworks importorskip-skip.
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 20  # a hang fails fast instead of burning the 6h default
@@ -34,12 +50,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # 3.12: the full suite -- every framework (torch/JAX/TF) + Icechunk -- so the
-          # jax/tf/icechunk tests run instead of importorskip-skipping.
+          # torch + the cold-start bench deps + the Icechunk handoff (no jax/tf in this env).
           - python: "3.12"
-            extras: "--extra torch --extra bench --extra jax --extra tf --extra icechunk"
-          # 3.13: light (core + torch/bench); the adapters are interpreter-independent, so
-          # no need to pay the heavy JAX/TF/icechunk install twice.
+            extras: "--extra torch --extra bench --extra icechunk"
+          # JAX alone.
+          - python: "3.12"
+            extras: "--extra jax"
+          # TensorFlow alone (JAX absent, so Keras 3 stays on the TF backend).
+          - python: "3.12"
+            extras: "--extra tf"
+          # 3.13 re-confirms the torch adapter on the newer interpreter (adapters are
+          # interpreter-independent, so no need to pay the JAX/TF installs twice).
           - python: "3.13"
             extras: "--extra torch --extra bench"
     steps:
@@ -48,26 +69,7 @@ jobs:
         with:
           enable-cache: true
       - run: uv sync --python ${{ matrix.python }} ${{ matrix.extras }}
-      # Lint + types are interpreter-independent: run once (on 3.12, which has every extra
-      # so mypy sees the real framework types) to avoid 2x cost.
-      - if: matrix.python == '3.12'
-        run: |
-          uv run ruff check src tests bench examples
-          uv run ruff format --check src tests bench examples
-          uv run mypy src bench examples
-      # 3.12 has all three frameworks installed, so isolate each in its own process (see
-      # the header comment). --ignore keeps a module out of collection (and thus out of the
-      # process); --deselect drops the matching advection test whose import is lazy.
-      - if: matrix.python == '3.12'
-        run: |
-          uv run pytest -q --ignore=tests/test_jax.py --ignore=tests/test_tf.py \
-            --deselect tests/test_advection.py::test_jax_beats_persistence \
-            --deselect tests/test_advection.py::test_tf_beats_persistence
-          uv run pytest -q tests/test_jax.py tests/test_advection.py::test_jax_beats_persistence
-          uv run pytest -q tests/test_tf.py tests/test_advection.py::test_tf_beats_persistence
-      # 3.13 installs only torch/bench, so jax/tf importorskip-skip -- one process is fine.
-      - if: matrix.python != '3.12'
-        run: uv run --python ${{ matrix.python }} pytest -q
+      - run: uv run --python ${{ matrix.python }} pytest -q
 
   # Free-threaded 3.13t: the real test of the pool's lock-free disjoint scatter +
   # lock-published readiness. torch/bench have no free-threaded wheels yet, so this

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ name: ci
 # while 3.13 stays light (core + torch/bench), since the adapters are interpreter-
 # independent. A separate free-threaded job runs the core engine with the GIL disabled to
 # guard the scatter/gather concurrency.
+#
+# torch, JAX and TF cannot share one interpreter: importing all three loads duplicate
+# OpenMP/XLA/protobuf runtimes and the process SIGSEGVs (exit 139). pytest imports every
+# collected test module up front, and `-m`/marker filtering runs *after* that import, so
+# the only way to keep a framework out of a process is to not collect its module. The 3.12
+# job therefore runs pytest three times -- torch+core, then JAX alone, then TF alone --
+# each a fresh process with at most one framework. (Forking is not an option: the parent
+# may hold a live obstore/tokio runtime, which a fork would corrupt.)
 on:
   push:
     branches: [main]
@@ -47,7 +55,19 @@ jobs:
           uv run ruff check src tests bench examples
           uv run ruff format --check src tests bench examples
           uv run mypy src bench examples
-      - run: uv run --python ${{ matrix.python }} pytest -q
+      # 3.12 has all three frameworks installed, so isolate each in its own process (see
+      # the header comment). --ignore keeps a module out of collection (and thus out of the
+      # process); --deselect drops the matching advection test whose import is lazy.
+      - if: matrix.python == '3.12'
+        run: |
+          uv run pytest -q --ignore=tests/test_jax.py --ignore=tests/test_tf.py \
+            --deselect tests/test_advection.py::test_jax_beats_persistence \
+            --deselect tests/test_advection.py::test_tf_beats_persistence
+          uv run pytest -q tests/test_jax.py tests/test_advection.py::test_jax_beats_persistence
+          uv run pytest -q tests/test_tf.py tests/test_advection.py::test_tf_beats_persistence
+      # 3.13 installs only torch/bench, so jax/tf importorskip-skip -- one process is fine.
+      - if: matrix.python != '3.12'
+        run: uv run --python ${{ matrix.python }} pytest -q
 
   # Free-threaded 3.13t: the real test of the pool's lock-free disjoint scatter +
   # lock-published readiness. torch/bench have no free-threaded wheels yet, so this

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -526,6 +526,37 @@ Engine track (make it real for models — see [docs/architecture.md](docs/archit
   ("Windowed-sampling overhead"). Correctness was the bar for PR #4; the lever, if real-
   `c1`-on-S3 ever shows it matters, is a non-windowed `gather` fast-path.
 
+  **Phase 4 (examples) — the advected-field forecast, plan.** One `InSituDataset` feeds
+  three framework training loops, to show the numpy `Batch` + DLPack thesis end to end:
+    - **Task:** a *direct* 24-hour forecast. Inputs `{t2m, u10, v10}` at anchor `t`
+      (cross-variable, same index) → target `t2m` at `t + 24h` (`g.shift(horizon)`):
+      `horizon = 24` steps on the 1-hourly synthetic store, `4` on the 6-hourly
+      WeatherBench2 store. The 24 h displacement is what makes advection (and the wind
+      inputs) *matter* vs persistence. The input window is assembled with
+      `Batch.stack(["t2m","u10","v10"])` → `(B, 3, H, W)`; the target is
+      `batch.arrays["t2m_next"]`.
+    - **No autoregressive rollout.** Chaining `n+1 → n+2 …` is a modeling/operational
+      choice, not the data layer's job — insitu delivers `(inputs@t, target@t+h)` pairs;
+      composing forecasts at serving time is the user's. Inference is a single forward
+      pass: forecast 24 h from the last available data.
+    - **One dataset → torch / JAX / TF.** `examples/advection/data.py` builds the store +
+      the single `forecast_dataset()`; `train_{torch,jax,tf}.py` each define the *same*
+      tiny CNN (3→1 channels) and a framework-native loop over the shared dataset via the
+      adapters (`as_torch` / `to_jax` / `as_tf_dataset`). Near-identical files differing
+      only in framework calls — the parallelism is the message. Shared numpy eval
+      (`rmse`, persistence baseline) in `data.py`.
+    - **Two stores, honest framing.** Synthetic advected field (seeded, time-constant
+      spatially-varying wind; tests + the pedagogical "beats persistence" result, true by
+      construction). WeatherBench2 6-hourly ARCO (`--wb2`, the real cloud store the
+      existing `wb2_*` examples use) runs the *same code* on real ERA5 — claim "same
+      pipeline, real data, no reshard", **not** SOTA skill (t2m persistence at a 24 h
+      multiple is a strong baseline; don't over-claim). A third real source may be
+      swapped in by URL + variable names.
+    - **Tests:** torch is in CI (`--extra torch`) — test data-gen advects, the dataset
+      yields the right windowed pairs, and torch training beats persistence on the
+      synthetic. JAX/TF gated with `importorskip` (their extras), mirroring
+      `test_jax.py` / `test_tf.py`.
+
 Reach track (broaden + make a splash):
 - **M3 — framework surfaces (done).** The core `Batch` is numpy and the engine
   inherits no framework; handoff is thin DLPack adapters in `frameworks.py`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -493,6 +493,39 @@ Engine track (make it real for models — see [docs/architecture.md](docs/archit
   forecast where a tiny model beats persistence, then the WeatherBench framework
   examples ride on top.
 
+  **As built (PR #4, through Phase 3) — deviations from the sketch above.** The engine
+  stayed simpler than the role/lead-axis design:
+    - A variable is a `(label, path, offset)` **view**; a window is just several views
+      of one array (`{"x": g, "y": g.shift(1)}`). `Batch` stays a **flat `{label:
+      array}` dict** — *no* lead axis, *no* `input`/`target` roles in the engine. It
+      carries an `offsets` metadata dict; `Batch.read_indices(label)` and
+      `Batch.stack(labels)` are the projection helpers (the user composes the window).
+    - **No guard band.** The engine enforces *range validity only* (`anchor+offset ∈
+      [0,T)`, `valid_anchor_range` drops edge anchors); offset 0 is not special
+      ("relativity"). Partitioned anchors give disjoint train/val labels for any offset
+      (injective translation), and the shared boundary timestep is only ever a val
+      *input*, never scored — so a guard band is unnecessary. Task meaningfulness
+      (non-degenerate offset choices) is the **user's** responsibility, not the engine's.
+    - Residency is **reference-counted** (`pool._pinned: dict[key,int]`, not a boolean
+      set) because a windowed chunk can feed several blocks; a per-epoch `claimed` flag
+      orders pin→consume→release across the epoch boundary (fixes a cross-epoch
+      gather/leak race). windowed+shuffle holds the **whole split** resident (shuffle
+      spills reads into arbitrary blocks); bounded-residency windowed+shuffle (per-block
+      re-fetch) is deferred. Decode-once across views holds (slots key on `path`).
+
+  **Deferred — refcount hot-path cost (accept for now).** The refcounted residency +
+  offset-aware `gather` add ~**3.5%** to the *non-windowed* path at the **GRIB-end local
+  worst case** (one sample/chunk, ~36 KB blobs where decode is ≈ free, GIL build) — not
+  residency (`resident` unchanged) and not the per-block setup (a fast-path there moved
+  nothing); it is per-batch gather + per-chunk `dict`/`claimed` bookkeeping under
+  `pool._cv`. It shrinks toward noise with real chunk sizes (decode/IO dominate) and is
+  invisible on blob-store datasets. The deliberate microscope for this — and for any
+  future *locking* work — is a **tiny local store with negligible decode** under
+  **free-threading** (`PYTHON_GIL=0`, where `pool._cv` is the only contention point);
+  the harness recipe is in [bench/benchmark_plan.md](bench/benchmark_plan.md)
+  ("Windowed-sampling overhead"). Correctness was the bar for PR #4; the lever, if real-
+  `c1`-on-S3 ever shows it matters, is a non-windowed `gather` fast-path.
+
 Reach track (broaden + make a splash):
 - **M3 — framework surfaces (done).** The core `Batch` is numpy and the engine
   inherits no framework; handoff is thin DLPack adapters in `frameworks.py`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -512,6 +512,15 @@ Engine track (make it real for models — see [docs/architecture.md](docs/archit
       gather/leak race). windowed+shuffle holds the **whole split** resident (shuffle
       spills reads into arbitrary blocks); bounded-residency windowed+shuffle (per-block
       re-fetch) is deferred. Decode-once across views holds (slots key on `path`).
+    - **Splits are iterable views, not a constructor arg.** `InSituDataset` is
+      split-agnostic; you iterate `ds.train` (shuffled) / `ds.val` / `ds.test` / `ds.all`
+      (deterministic), all sharing **one** `ChunkPool`. This matters *because* of windows:
+      a windowed read near a split boundary spills into the adjacent split's chunk, so the
+      splits' *chunk reads* overlap even though no sample leaks (the disjoint-anchor proof
+      is about samples, not chunks) -- one shared pool decodes those boundary chunks once,
+      where separate per-split datasets would decode them twice. Per-split *config* (e.g.
+      train-only augmentation) is intentionally not supported on one instance -- make a
+      second dataset for that; the default path stays clean.
 
   **Deferred — refcount hot-path cost (accept for now).** The refcounted residency +
   offset-aware `gather` add ~**3.5%** to the *non-windowed* path at the **GRIB-end local

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -31,7 +31,7 @@ zarr v3 async store and builds the layer those projects stopped one step short o
 | Neighbor | Why insitubatch is different |
 |---|---|
 | **MosaicML Streaming / WebDataset** | They require **resharding** into a sample-oriented format (MDS/tar) — a full ETL copy, and a "sample" becomes an opaque blob. insitubatch trains **in place** on the existing ndim Zarr; splits/shuffle/batches live in **coordinate space**. |
-| **xbatcher + DataLoader (Earthmover stack)** | Great batch *definition*, **brute-force engine** — N torch worker **processes** (slow cold start, memory ∝ workers, no shared cache, redundant per-sample decode). Competitive only at the GRIB / one-sample-per-chunk end; a partial solution that doesn't generalize. We keep the ndim batch semantics and replace the engine with one async loop: better **cold start** (inference), and better **memory + cache + ops** across the chunk spectrum (training). |
+| **xbatcher + DataLoader (Earthmover stack)** | xbatcher (Earthmover / pangeo) is the standard, elegant way to *define* ndim batches; its torch-worker engine (N **processes**) is strongest at the GRIB / one-sample-per-chunk end, and elsewhere pays worker cold start, memory ∝ workers, no shared cache, and per-sample decode. insitubatch keeps those same ndim batch semantics and offers a *different engine* — one async loop — that wins **cold start** (inference) and **memory + cache + ops** across the chunk spectrum (training). Complementary tools; pick by regime (and we tune xbatcher well before any comparison). |
 | **DALI / kvikio / nvCOMP** | The GPU compute/decompress path — a *peer* we interop with (cupy→dlpack→torch, optional nvCOMP), not the orchestration. |
 | **anemoi-datasets** | Weather-locked, opinionated schema. We are general ndim arrays. |
 | **dask / Ray Data** | General compute schedulers. We deliberately keep dask **off the hot path** (its nested thread pools inside forked workers are the problem). |
@@ -526,8 +526,10 @@ Engine track (make it real for models — see [docs/architecture.md](docs/archit
   ("Windowed-sampling overhead"). Correctness was the bar for PR #4; the lever, if real-
   `c1`-on-S3 ever shows it matters, is a non-windowed `gather` fast-path.
 
-  **Phase 4 (examples) — the advected-field forecast, plan.** One `InSituDataset` feeds
-  three framework training loops, to show the numpy `Batch` + DLPack thesis end to end:
+  **Phase 4 (examples) — the advected-field forecast. ✅ implemented (`examples/advection/`).**
+  One `InSituDataset` feeds three framework training loops, showing the numpy `Batch` +
+  DLPack thesis end to end; on the synthetic field the same tiny CNN beats persistence
+  ~1.6× in torch, JAX, and TF (identical dataset + architecture). Plan as built:
     - **Task:** a *direct* 24-hour forecast. Inputs `{t2m, u10, v10}` at anchor `t`
       (cross-variable, same index) → target `t2m` at `t + 24h` (`g.shift(horizon)`):
       `horizon = 24` steps on the 1-hourly synthetic store, `4` on the 6-hourly

--- a/README.md
+++ b/README.md
@@ -91,22 +91,22 @@ uv run mypy src                               # types
 The torch-handoff tests skip unless torch is installed (`uv sync --extra torch`);
 the same is enforced in CI.
 
-> **One framework per interpreter.** torch, JAX and TensorFlow cannot be imported
-> into the same Python process — together they load duplicate OpenMP/XLA/protobuf
-> runtimes and the process hard-crashes (`SIGSEGV`, exit 139). So if you have more
-> than one adapter installed, run their tests in separate processes — pytest imports
-> every collected module up front, so `-m`/marker filtering is too late; only
-> `--ignore` keeps a framework out of the run:
+> **One framework per environment.** torch, JAX and TensorFlow cannot coexist in one
+> Python process — together they load duplicate OpenMP/XLA/protobuf runtimes and the
+> process crashes (`SIGSEGV` / abort). Separate pytest *processes* in one env are not
+> enough: TF (via its bundled Keras 3) transitively imports JAX whenever JAX is
+> *installed*, so the two collide even if only the TF tests are selected. So install
+> just one adapter at a time when running the framework tests:
 > ```bash
-> uv run pytest -q --ignore=tests/test_jax.py --ignore=tests/test_tf.py \
->   --deselect tests/test_advection.py::test_jax_beats_persistence \
->   --deselect tests/test_advection.py::test_tf_beats_persistence   # torch + core
-> uv run pytest -q tests/test_jax.py tests/test_advection.py::test_jax_beats_persistence  # JAX
-> uv run pytest -q tests/test_tf.py  tests/test_advection.py::test_tf_beats_persistence   # TF
+> uv sync --extra torch && uv run pytest -q   # torch adapter + core
+> uv sync --extra jax   && uv run pytest -q   # JAX adapter (others importorskip-skip)
+> uv sync --extra tf    && uv run pytest -q   # TF adapter
 > ```
-> CI does exactly this on the all-extras 3.12 job (the single-framework jobs run one
-> pass). This is a framework-coexistence limitation, not an insitubatch one — the
-> core engine and each adapter are independent.
+> CI does exactly this — one job per framework, each with a single adapter installed,
+> plus a separate lint/types job that installs every extra but runs no pytest (mypy
+> doesn't import the frameworks, so co-installation is harmless there). This is a
+> framework-coexistence limitation, not an insitubatch one — the core engine and each
+> adapter are independent.
 
 ### Free-threaded (3.13t)
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 **Train in place on n-dimensional cloud tensors.**
 
 `insitubatch` is the data-loader orchestration layer that sits on top of
-*already-solved* async cloud IO (obstore / zarr v3 / icechunk). It turns an
-existing Zarr archive into a shuffled, split-aware PyTorch source built to **keep
-the GPU fed** — **with no reshard** — and a Python hot path that scales with
-**chunks, not samples**.
+*already-solved* async cloud IO (obstore / zarr v3 / icechunk) for PyTorch,
+Jax and TensorFlow. It turns an existing Zarr archive into a shuffled,
+split-aware data source built to **keep the GPU fed** — **with no reshard**
+— and a Python hot path that scales with **chunks, not samples**.
 
 > The IO race is over (obstore/icechunk saturate the NIC). The *loader* race is
 > open. `insitubatch` builds the layer that projects like light-speed-io and
@@ -29,7 +29,7 @@ the pool doubles as the cache; torch runs `num_workers=0`.
 
 The payoff is being the **batteries-included** choice at both operating points: for
 **inference** it pays no worker-pool cold start (first batch in ~ms, not seconds — and a
-production service can't keep a hot pool alive); for **training** it uses far less memory
+production service hot pool is extremely challenging); for **training** it uses far less memory
 (one process, not 32), reads each chunk once, and caches across epochs, beating the
 tuned worker/xbatcher stacks across the chunk spectrum. The worker-process stacks are
 competitive only at the degenerate GRIB end (one sample per chunk) — a partial solution
@@ -37,7 +37,7 @@ that doesn't generalize. See [Benchmarks](https://emfdavid.github.io/insitubatch
 
 ## Status
 
-🚧 **Pre-alpha, but validated on real cloud IO.** On an in-region S3 run
+🚧 **alpha, but validated on real cloud IO.** On an in-region S3 run
 (`c6id.8xlarge`, ERA5-shaped `721×1440` fields, `sample_chunk=8`), insitubatch
 delivers **~8× the throughput** of a *tuned* `xbatcher`/worker `DataLoader`
 baseline (swept to 32 workers) and reaches its first batch **~10× sooner** — the

--- a/README.md
+++ b/README.md
@@ -91,6 +91,23 @@ uv run mypy src                               # types
 The torch-handoff tests skip unless torch is installed (`uv sync --extra torch`);
 the same is enforced in CI.
 
+> **One framework per interpreter.** torch, JAX and TensorFlow cannot be imported
+> into the same Python process — together they load duplicate OpenMP/XLA/protobuf
+> runtimes and the process hard-crashes (`SIGSEGV`, exit 139). So if you have more
+> than one adapter installed, run their tests in separate processes — pytest imports
+> every collected module up front, so `-m`/marker filtering is too late; only
+> `--ignore` keeps a framework out of the run:
+> ```bash
+> uv run pytest -q --ignore=tests/test_jax.py --ignore=tests/test_tf.py \
+>   --deselect tests/test_advection.py::test_jax_beats_persistence \
+>   --deselect tests/test_advection.py::test_tf_beats_persistence   # torch + core
+> uv run pytest -q tests/test_jax.py tests/test_advection.py::test_jax_beats_persistence  # JAX
+> uv run pytest -q tests/test_tf.py  tests/test_advection.py::test_tf_beats_persistence   # TF
+> ```
+> CI does exactly this on the all-extras 3.12 job (the single-framework jobs run one
+> pass). This is a framework-coexistence limitation, not an insitubatch one — the
+> core engine and each adapter are independent.
+
 ### Free-threaded (3.13t)
 
 The engine is free-threading-correct by construction: the `ChunkPool`'s scatter

--- a/README.md
+++ b/README.md
@@ -123,24 +123,27 @@ on the GIL is the point (see [DESIGN.md](DESIGN.md)).
 
 ## Shape of the API
 
-The core `InSituDataset` is a **framework-neutral iterable of numpy `Batch` objects** —
-it inherits nothing framework-specific. Handoff to torch / JAX / TF is a thin, optional
-DLPack adapter layer in `insitubatch.frameworks`; the core imports no framework.
+The core `InSituDataset` is a **framework-neutral source of numpy `Batch` objects** — it
+inherits nothing framework-specific. You iterate its split *views* (`ds.train` shuffled,
+`ds.val` / `ds.test` / `ds.all` deterministic), which all share **one** pool, so a chunk
+two splits both read decodes once. Handoff to torch / JAX / TF is a thin, optional DLPack
+adapter layer in `insitubatch.frameworks`; the core imports no framework.
 
 ```python
-from insitubatch import open_geometries, split_by_chunk, SplitName
+from insitubatch import open_geometries, split_by_chunk
 from insitubatch.source import InSituDataset
 
 url = "file:///data/era5.zarr"           # or "s3://bucket/era5.zarr" — same code
 geoms = open_geometries(url)             # {var: ArrayGeometry} from zarr metadata
 manifest = split_by_chunk(geoms["t2m"], fractions=(0.8, 0.1, 0.1))
 
-ds = InSituDataset(url, manifest, split=SplitName.TRAIN,
-                   batch_size=32, block_chunks=16)
+ds = InSituDataset(url, manifest, batch_size=32, block_chunks=16)
 
 for epoch in range(n_epochs):
     ds.set_epoch(epoch)
-    for batch in ds:                     # numpy Batch: {var: np.ndarray} + sample_indices
+    for batch in ds.train:               # numpy Batch: {var: np.ndarray} + sample_indices
+        ...
+    for batch in ds.val:                 # deterministic; shares the pool with train
         ...
 ```
 
@@ -152,12 +155,12 @@ from insitubatch.frameworks import as_torch, to_jax, as_tf_dataset
 from torch.utils.data import DataLoader
 
 # torch: parallelism is in our event loop, so num_workers=0, batch_size=None
-loader = DataLoader(as_torch(ds), batch_size=None, num_workers=0)   # {var: torch.Tensor}
+loader = DataLoader(as_torch(ds.train), batch_size=None, num_workers=0)  # {var: torch.Tensor}
 
-for batch in ds:            # JAX: iterate the dataset, convert each batch
+for batch in ds.train:      # JAX: iterate a view, convert each batch
     jbatch = to_jax(batch)  # {var: jax.Array}
 
-tfds = as_tf_dataset(ds)    # a tf.data.Dataset
+tfds = as_tf_dataset(ds.val)  # a tf.data.Dataset
 ```
 
 ## License

--- a/bench/benchmark_plan.md
+++ b/bench/benchmark_plan.md
@@ -446,9 +446,38 @@ PYTHON_GIL=0 UV_PROJECT_ENVIRONMENT=.venv-ft uv run --python 3.13t \
   --window 1 | tee bench/results/window_c1_w1_ft.log
 ```
 
-Local (free) shape check: `make_dataset --url file://… --sample-chunk 1 --inner 96,96`
-then the same `probe_decode --window 0/1` — proves the wiring and shows the residency
-widening, though absolute async wins need S3.
+**Local lock-stress harness (the deliberate microscope).** A *tiny* local store with
+**negligible decode** is the right tool to stress the pool's locking, precisely because
+it is unrealistic: with ~36 KB blobs at `sample_chunk=1`, fetch+decode is ≈ free, so the
+per-chunk Python bookkeeping under `pool._cv` (admit / pin / unpin / `claimed` / gather)
+becomes the *dominant* cost — the opposite of a blob-store dataset, where IO+decode bury
+it. Build it once and probe `--window 0` (plain) vs `--window 1` (forecast), on the GIL
+build and again under free-threading:
+
+```bash
+uv run python bench/make_dataset.py --url file:///tmp/probe_c1.zarr \
+  --n-samples 512 --inner 96,96 --sample-chunk 1 --variables t2m
+# GIL build: baseline vs forecast (median of 9; resident must stay flat across max_inflight)
+uv run python -m bench.probe_decode --url file:///tmp/probe_c1.zarr \
+  --max-chunks 256 --repeats 9 --no-raw --no-warm --max-inflight 32 --window 0
+uv run python -m bench.probe_decode --url file:///tmp/probe_c1.zarr \
+  --max-chunks 256 --repeats 9 --no-raw --no-warm --max-inflight 32 --window 1
+# free-threaded 3.13t: PYTHON_GIL=0 makes pool._cv the only contention point -- the real
+# locking test (the GIL otherwise serializes incidentally and hides _cv contention).
+PYTHON_GIL=0 UV_PROJECT_ENVIRONMENT=.venv-ft uv run --python 3.13t \
+  python -m bench.probe_decode --url file:///tmp/probe_c1.zarr \
+  --max-chunks 256 --repeats 9 --no-raw --no-warm --max-inflight 32 --window 1
+```
+
+Baseline reading (recorded for future work; **accepted, not fixed** — correctness was the
+M-W PR's bar): vs `main` (boolean pin set) on this store, the refcounted branch's
+`--window 0` ran ~**3.5%** slower (`137.5` → `132.6` MB/s, median of 9 over several
+interleaved passes; `resident=4` unchanged). It is **not** the per-block read-union setup
+(a fast-path there moved nothing) and **not** residency — it is the per-batch offset-aware
+`gather` plus per-chunk `dict`/`claimed` ops. On real `c1`-on-S3 (1 MB chunks) decode/IO
+dominate and this shrinks toward noise; the lever, if it ever matters there, is a
+non-windowed `gather` fast-path (old concatenate when every offset is 0). Compare this
+harness's `main`-vs-branch and GIL-vs-FT deltas before touching the lock.
 
 > **Known follow-up (not a regression, a sizing slack).** The residency budget sums
 > bytes *per label*; aliased views share one decoded slot, so an `N+1`-view window

--- a/bench/benchmark_plan.md
+++ b/bench/benchmark_plan.md
@@ -405,6 +405,57 @@ PYTHON_GIL=0 UV_PROJECT_ENVIRONMENT=.venv-ft uv run --python 3.13t \
 > it. numcodecs re-enabling the GIL on import only matters for Python-level
 > parallelism, which our GIL-releasing hot path doesn't rely on.
 
+### Windowed-sampling overhead (M-W refcount no-regression)
+
+Windowed sampling (a variable read at `anchor + offset`) added a *refcounted* residency
+(`pool._pinned: dict[key,int]` + a per-epoch `claimed` flag) in place of the boolean pin
+set. That bookkeeping runs **under `pool._cv`** and is **O(chunks), not O(samples)** — so
+any added lock-held work is largest where chunk-rate is highest (the **GRIB end, `c1`,
+one sample/chunk**) and most exposed under **free-threading**, where there is no GIL
+incidentally serialising and `pool._cv` is the only contention point. That is the config
+to watch for a regression.
+
+`probe_decode --window N` builds a forecast view-set (anchor input + `N` shifted targets,
+`geom.shift(1..N)`) and routes the sec-1 (`decode_threads`) and sec-1b (`max_inflight`)
+sweeps through it. `--window 0` is the exact plain-single-variable baseline. MB/s counts
+the anchor-input bytes either way, so the machinery's per-anchor overhead shows as a drop
+at equal anchor rate. Two reads:
+
+- **No-regression of the baseline.** `--window 0` on `c1` should match the pre-M-W
+  numbers (the refcount must not slow plain reads). Compare GIL vs FT — FT must still
+  *match* the GIL build (the project's GIL-independence result), not regress.
+- **What windowing costs.** `--window 1` (and higher) vs `--window 0`: the offset
+  gather + larger per-block read-union + cross-block refcount. Expect a small per-anchor
+  drop and a wider `resident=` (windowed working set), **flat across `max_inflight`** —
+  the V2 residency-decoupling must survive windowing.
+
+```bash
+# GRIB end, max chunk-rate: baseline vs forecast, GIL build
+uv run python -m bench.probe_decode --url s3://$BUCKET/era5_c1.zarr \
+  --decode-threads 1,2,4,8,16,32 --max-inflight 64 --max-chunks 256 --repeats 5 \
+  --window 0 | tee bench/results/window_c1_w0.log
+uv run python -m bench.probe_decode --url s3://$BUCKET/era5_c1.zarr \
+  --decode-threads 1,2,4,8,16,32 --max-inflight 64 --max-chunks 256 --repeats 5 \
+  --window 1 | tee bench/results/window_c1_w1.log
+
+# the lock-serialisation check: same on free-threaded 3.13t (GIL forced off). If the
+# refcount serialises, the decode_threads sweep will not scale (or w1 << w0) under FT.
+PYTHON_GIL=0 UV_PROJECT_ENVIRONMENT=.venv-ft uv run --python 3.13t \
+  python -m bench.probe_decode --url s3://$BUCKET/era5_c1.zarr \
+  --decode-threads 1,2,4,8,16,32 --max-inflight 64 --max-chunks 256 --repeats 5 \
+  --window 1 | tee bench/results/window_c1_w1_ft.log
+```
+
+Local (free) shape check: `make_dataset --url file://… --sample-chunk 1 --inner 96,96`
+then the same `probe_decode --window 0/1` — proves the wiring and shows the residency
+widening, though absolute async wins need S3.
+
+> **Known follow-up (not a regression, a sizing slack).** The residency budget sums
+> bytes *per label*; aliased views share one decoded slot, so an `N+1`-view window
+> over-allocates the working set ~`(N+1)×`. Safe (conservative, never deadlocks) but
+> bigger than needed — summing per *path* would tighten it. Visible as `resident=` higher
+> than the non-windowed run at the same `block_chunks`.
+
 ### S3 Express One Zone stress (story 4 on a directory bucket)
 
 ```bash

--- a/bench/engines.py
+++ b/bench/engines.py
@@ -156,7 +156,6 @@ def _run_insitu(
         cfg.url,
         manifest,
         geometries={cfg.var: geom},
-        split=SplitName.TRAIN,
         batch_size=cfg.batch_size,
         block_chunks=cfg.block_chunks,
         max_inflight=cfg.max_inflight,
@@ -171,7 +170,7 @@ def _run_insitu(
     for epoch in range(cfg.epochs):
         ds.set_epoch(epoch)
         sec, n, ttfb = _drive(
-            iter(ds), lambda b: b.arrays[cfg.var].shape[0], cfg.compute_ms, cfg.max_batches
+            iter(ds.train), lambda b: b.arrays[cfg.var].shape[0], cfg.compute_ms, cfg.max_batches
         )
         out.append(_result(cfg, geom, epoch, sec, n, ttfb))
     return out

--- a/bench/ops_aws.md
+++ b/bench/ops_aws.md
@@ -325,7 +325,7 @@ chunk cache, not FLOPs.
 ```bash
 export AWS_REGION=us-east-1
 export KEY_NAME=emfdavid_ed25519
-export INSTANCE_TYPE=g6.2xlarge          # 1x L4 24 GB, 8 vCPU, ~450 GB NVMe instance store
+export INSTANCE_TYPE=g6.8xlarge          # 1x L4 24 GB, 32 vCPU, 25gb/s, 2x450 GB NVMe instance store
 ```
 
 **AMI — the Deep Learning *Base* GPU AMI (Ubuntu).** "Base" ships the NVIDIA driver
@@ -339,14 +339,13 @@ AMI=$(aws ssm get-parameters --region "$AWS_REGION" \
 ```
 
 Launch with the **same** key/SG/profile from sections 1–6 (drop the S3 bits if you
-only need Arraylake). Give the root EBS ~60 GB (the CUDA toolkit + driver are large):
+only need Arraylake). Give the root EBS ~100 GB (the CUDA toolkit + driver are large):
 
 ```bash
 IID=$(aws ec2 run-instances --region "$AWS_REGION" \
   --image-id "$AMI" --instance-type "$INSTANCE_TYPE" --key-name "$KEY_NAME" \
   --security-group-ids "$SG" \
-  --instance-market-options 'MarketType=spot' \
-  --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=60,VolumeType=gp3}' \
+  --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=100,VolumeType=gp3}' \
   --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=insitubatch-gpu}]' \
   --query 'Instances[0].InstanceId' --output text)
 aws ec2 wait instance-running --region "$AWS_REGION" --instance-ids "$IID"
@@ -393,10 +392,12 @@ uv run al auth login                    # opens a device-code flow
 
 # --- train on a finite window of real ERA5, on the GPU, cache on NVMe ---
 uv run python -m examples.advection.train_torch \
-  --source arraylake --sample-range 0,2920 \   # ~2 years at 6-hourly (4/day)
+  --source arraylake --sample-range 0,2920 \
   --device cuda --epochs 8 --batch-size 32 \
   --cache-dir /mnt/nvme/cache
 ```
+Training set is ~2 years at 6-hourly (4/day)
+
 
 **Sizing caveats (learned the hard way):**
 

--- a/bench/ops_aws.md
+++ b/bench/ops_aws.md
@@ -311,6 +311,107 @@ The actual Express comparison datasets + probe commands live in the benchmark pl
 (`bench/benchmark_plan.md`).
 
 
+## 10. GPU box — advection examples on real ERA5 (G6 + NVMe, Arraylake)
+
+The advection examples (`examples/advection/train_{torch,jax,tf}.py`) train a tiny
+forecast CNN on real ERA5 read **in place** from the Arraylake/Icechunk
+`earthmover-public/weatherbench2` repo. `--source arraylake` + `--sample-range`
+gives a finite training window; `--device cuda` moves each batch to the GPU in the
+training loop (the dataset stays numpy — placement is the loop's job).
+
+**Instance.** A G6 (NVIDIA L4) is plenty for this CNN; the win is fast NVMe for the
+chunk cache, not FLOPs.
+
+```bash
+export AWS_REGION=us-east-1
+export KEY_NAME=emfdavid_ed25519
+export INSTANCE_TYPE=g6.2xlarge          # 1x L4 24 GB, 8 vCPU, ~450 GB NVMe instance store
+```
+
+**AMI — the Deep Learning *Base* GPU AMI (Ubuntu).** "Base" ships the NVIDIA driver
++ CUDA toolkit but *no* frameworks — exactly right, since we bring torch/jax/tf via
+`uv`. (The full DLAMI's preinstalled conda torch would just fight the uv env.)
+
+```bash
+AMI=$(aws ssm get-parameters --region "$AWS_REGION" \
+  --names /aws/service/deeplearning/ami/x86_64/base-oss-nvidia-driver-gpu-ubuntu-22.04/latest/ami-id \
+  --query 'Parameters[0].Value' --output text)
+```
+
+Launch with the **same** key/SG/profile from sections 1–6 (drop the S3 bits if you
+only need Arraylake). Give the root EBS ~60 GB (the CUDA toolkit + driver are large):
+
+```bash
+IID=$(aws ec2 run-instances --region "$AWS_REGION" \
+  --image-id "$AMI" --instance-type "$INSTANCE_TYPE" --key-name "$KEY_NAME" \
+  --security-group-ids "$SG" \
+  --instance-market-options 'MarketType=spot' \
+  --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=60,VolumeType=gp3}' \
+  --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=insitubatch-gpu}]' \
+  --query 'Instances[0].InstanceId' --output text)
+aws ec2 wait instance-running --region "$AWS_REGION" --instance-ids "$IID"
+IP=$(aws ec2 describe-instances --region "$AWS_REGION" --instance-ids "$IID" \
+  --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
+echo "ssh -A ubuntu@$IP"               # Ubuntu AMI -> user is 'ubuntu', not 'ec2-user'
+```
+
+**On the box — NVMe, install, GPU torch, run.**
+
+```bash
+nvidia-smi                              # confirm the driver sees the L4 before anything else
+
+# --- mount the instance-store NVMe for the chunk cache (ephemeral scratch) ---
+lsblk                                   # instance store is usually /dev/nvme1n1 (root = nvme0n1)
+sudo mkfs -t xfs /dev/nvme1n1
+sudo mkdir -p /mnt/nvme && sudo mount /dev/nvme1n1 /mnt/nvme && sudo chown "$USER" /mnt/nvme
+
+# --- install ---
+curl -LsSf https://astral.sh/uv/install.sh | sh && source "$HOME/.bashrc"
+git clone https://github.com/emfdavid/insitubatch.git && cd insitubatch
+git checkout multi-offset-sampling      # until merged to main
+
+# Pick your framework's extra (torch | jax | tf) + arraylake for the real store.
+uv sync --extra torch --extra arraylake
+
+# --- CUDA torch (the catch) -----------------------------------------------------
+# PyPI's `torch` is the CPU build; `uv sync` installed that. uv 0.11+ swaps it for the
+# matching CUDA wheel from the PyTorch index, auto-detecting the driver's CUDA:
+uv pip install torch --torch-backend=auto      # or pin: --torch-backend=cu124
+uv run python -c "import torch; print(torch.cuda.is_available())"   # -> True
+#
+# Why not bake CUDA torch into an extra? `[tool.uv.sources]` index pins are GLOBAL
+# per-package, so pinning torch -> the cu124 index would drag the CPU `torch` extra,
+# CI's Linux runners, AND the 3.13t free-threaded job (which the cu index has no
+# wheels for) onto CUDA. Keeping the lock CPU-clean and swapping at install time on
+# the box is the one-obvious-way. (jax: `uv pip install "jax[cuda12]"`; tf already
+# auto-uses the GPU once the driver is visible — `tensorflow[and-cuda]` if you need
+# the bundled CUDA libs.)
+
+# --- Arraylake auth (one of) ---
+uv run al auth login                    # opens a device-code flow
+# or non-interactive: export ARRAYLAKE_TOKEN=...
+
+# --- train on a finite window of real ERA5, on the GPU, cache on NVMe ---
+uv run python -m examples.advection.train_torch \
+  --source arraylake --sample-range 0,2920 \   # ~2 years at 6-hourly (4/day)
+  --device cuda --epochs 8 --batch-size 32 \
+  --cache-dir /mnt/nvme/cache
+```
+
+**Sizing caveats (learned the hard way):**
+
+- **`--sample-range` is not optional for the real store.** The Arraylake fields are
+  full-resolution; without a window the split spans the whole multi-decade archive
+  and the resident cache is hundreds of GB. Start small (a year or two) and grow.
+- **Run full epochs, not `--max-batches`.** The cross-epoch NVMe cache only pays off
+  when epoch *N+1* re-reads chunks epoch *N* already cached; a truncated, reshuffled
+  epoch keeps missing uncached chunks and never warms up.
+- **High cold TTFB over a high-latency network is expected** (first batch waits on
+  the first GET + decode with no warm cache). A large resident budget removes
+  read-ahead backpressure so the scheduler fetches eagerly and starves block 0 of
+  bandwidth — this is the bounded-read-ahead item (**M-RA**) on the roadmap, not a
+  bug. Keep `--max-inflight` modest if cold latency matters more than steady-state.
+
 ## External reproducers (a different AWS account)
 ```python
 from insitubatch import open_geometries, split_by_chunk

--- a/bench/probe_decode.py
+++ b/bench/probe_decode.py
@@ -77,18 +77,30 @@ def _insitu(
     max_chunks: int,
     block_chunks: int = 2,
     max_inflight: int = 32,
+    window: int = 0,
 ) -> tuple[float, int]:
     """One insitu pass over the first ``max_chunks`` chunks; (MB/s, peak resident chunks).
 
     ``block_chunks`` sets the shuffle window / residency; ``max_inflight`` is the
     single network-concurrency dial (V2 -- no nested ``read_concurrency`` cap).
+
+    ``window`` adds a forecast view-set: the anchor input plus ``window`` shifted
+    targets (``geom.shift(1..window)``) read from the same array. With ``window=0`` it
+    is the plain single-variable baseline; ``window>0`` exercises the offset gather,
+    per-block read-union, and *refcounted* residency that plain reads do not -- the cost
+    most exposed at the GRIB end (one sample/chunk = max chunk-rate = max pin/unpin/lock
+    churn) and under free-threading. MB/s counts the anchor-input bytes either way, so
+    the windowing machinery's overhead shows as a drop at equal anchor rate.
     """
     geom = open_geometries(url, variables=[var], **kw)[var]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
+    geoms = {var: geom}
+    for k in range(1, window + 1):
+        geoms[f"{var}_t{k}"] = geom.shift(k)
     ds = InSituDataset(
         url,
         manifest,
-        geometries={var: geom},
+        geometries=geoms,
         split=SplitName.TRAIN,
         batch_size=16,
         block_chunks=block_chunks,
@@ -216,6 +228,14 @@ def main() -> None:
         help="fixed shuffle window / residency for the max_inflight sweep (sec 1b)",
     )
     p.add_argument("--max-inflight", default="8,16,32,64", help="sec 1b sweep (the V2 dial)")
+    p.add_argument(
+        "--window",
+        type=int,
+        default=0,
+        help="forecast views: anchor input + N shifted targets (0 = plain single var). "
+        "Exercises the windowed offset-gather + refcounted residency; pair with a c1 "
+        "store (max chunk-rate) and/or PYTHON_GIL=0 to surface any lock serialization.",
+    )
     p.add_argument("--concurrency", default="1,4,8,16,32", help="sec 2 raw-GET sweep")
     p.add_argument(
         "--profile",
@@ -283,10 +303,14 @@ def main() -> None:
                 max_chunks=a.max_chunks,
                 block_chunks=bc,
                 max_inflight=mi_warm,
+                window=a.window,
             )
         except Exception as exc:  # noqa: BLE001 - prewarm is best-effort
             print(f"   prewarm failed: {type(exc).__name__}: {exc}")
         print()
+
+    if a.window:
+        print(f"(windowed: anchor input + {a.window} shifted target view(s); MB/s = input bytes)\n")
 
     if not a.no_decode_sweep:
         print(f"1) insitu MB/s vs decode_threads (median of {a.repeats}, block_chunks={bc}):")
@@ -301,6 +325,7 @@ def main() -> None:
                     decode_threads=dt,
                     max_chunks=a.max_chunks,
                     block_chunks=bc,
+                    window=a.window,
                 ),
             )
 
@@ -318,6 +343,7 @@ def main() -> None:
                     max_chunks=a.max_chunks,
                     block_chunks=bc,
                     max_inflight=mi,
+                    window=a.window,
                 )
                 for _ in range(a.repeats)
             )

--- a/bench/probe_decode.py
+++ b/bench/probe_decode.py
@@ -101,7 +101,6 @@ def _insitu(
         url,
         manifest,
         geometries=geoms,
-        split=SplitName.TRAIN,
         batch_size=16,
         block_chunks=block_chunks,
         max_inflight=max_inflight,
@@ -113,7 +112,7 @@ def _insitu(
     limit = max_chunks * geom.sample_chunk_size
     n = 0
     t = time.perf_counter()
-    for b in ds:
+    for b in ds.train:
         n += b.arrays[var].shape[0]
         if n >= limit:
             break
@@ -158,7 +157,6 @@ def _insitu_cache(
         url,
         manifest,
         geometries={var: geom},
-        split=SplitName.TRAIN,
         batch_size=16,
         block_chunks=block_chunks,
         shuffle=False,
@@ -172,7 +170,7 @@ def _insitu_cache(
         ds.set_epoch(epoch)
         n = 0
         t = time.perf_counter()
-        for b in ds:
+        for b in ds.train:
             n += b.arrays[var].shape[0]
         return n * bps / 1e6 / (time.perf_counter() - t)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -271,7 +271,7 @@ def fill_nan(chunk):                      # your policy: climatology, interpolat
     return chunk
 
 ds = InSituDataset(url, manifest, on_bad_chunk="nan", chunk_transforms=[fill_nan])
-for batch in ds:
+for batch in ds.train:
     ...
 print(ds.bad_chunks)   # the (array, chunk_index, inner_coord) reads that were bad this epoch
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,10 +3,10 @@
 **Train in place on n-dimensional cloud tensors.**
 
 `insitubatch` is the data-loader orchestration layer that sits on top of
-*already-solved* async cloud IO (obstore / zarr v3 / icechunk). It turns an
-existing Zarr archive into a shuffled, split-aware PyTorch source built to **keep
-the GPU fed** — **with no reshard** — and a Python hot path that scales with
-**chunks, not samples**.
+*already-solved* async cloud IO (obstore / zarr v3 / icechunk) for PyTorch, Jax
+and TensorFlow. It turns an existing Zarr archive into a shuffled, split-aware
+data source built to **keep the GPU fed** — **with no reshard** — and a Python
+hot path that scales with **chunks, not samples**.
 
 !!! quote
     The IO race is over (obstore/icechunk saturate the NIC). The *loader* race is
@@ -76,6 +76,10 @@ loader = DataLoader(as_torch(ds.train), batch_size=None, num_workers=0)  # torch
 jbatch = to_jax(next(iter(ds.train)))                                    # JAX:   {var: jax.Array}
 tfds = as_tf_dataset(ds.val)                                             # TF:    tf.data.Dataset
 ```
+
+See [`examples/advection`](https://github.com/emfdavid/insitubatch/blob/main/examples/advection) for
+working CNN forecast models using insituBatch implemented with Torch, Jax and Tensorflow with
+real ERA5 data.
 
 A runnable, network-free version of this — paralleling the Earthmover
 `dataloader-demo`, with a spatial subregion pulled out by a `batch_transform` —

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ The core `InSituDataset` is a framework-neutral iterable of numpy `Batch` object
 torch / JAX / TF handoff is a thin optional DLPack adapter in `insitubatch.frameworks`.
 
 ```python
-from insitubatch import open_geometries, split_by_chunk, SplitName
+from insitubatch import open_geometries, split_by_chunk
 from insitubatch.source import InSituDataset
 from insitubatch.frameworks import as_torch, to_jax, as_tf_dataset
 from torch.utils.data import DataLoader
@@ -62,18 +62,19 @@ url = "file:///data/era5.zarr"           # or "s3://bucket/era5.zarr" — same c
 geoms = open_geometries(url)             # {var: ArrayGeometry} from zarr metadata
 manifest = split_by_chunk(geoms["t2m"], fractions=(0.8, 0.1, 0.1))
 
-ds = InSituDataset(url, manifest, split=SplitName.TRAIN,
-                   batch_size=32, block_chunks=16)
+ds = InSituDataset(url, manifest, batch_size=32, block_chunks=16)
 
 for epoch in range(n_epochs):
     ds.set_epoch(epoch)
-    for batch in ds:                     # numpy Batch: {var: np.ndarray} + sample_indices
+    for batch in ds.train:               # numpy Batch: {var: np.ndarray} + sample_indices
+        ...
+    for batch in ds.val:                 # deterministic; shares the pool with train
         ...
 
 # Framework handoff (zero-copy on CPU via DLPack):
-loader = DataLoader(as_torch(ds), batch_size=None, num_workers=0)  # torch: {var: torch.Tensor}
-jbatch = to_jax(next(iter(ds)))                                    # JAX:   {var: jax.Array}
-tfds = as_tf_dataset(ds)                                           # TF:    tf.data.Dataset
+loader = DataLoader(as_torch(ds.train), batch_size=None, num_workers=0)  # torch
+jbatch = to_jax(next(iter(ds.train)))                                    # JAX:   {var: jax.Array}
+tfds = as_tf_dataset(ds.val)                                             # TF:    tf.data.Dataset
 ```
 
 A runnable, network-free version of this — paralleling the Earthmover

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,47 @@
+# insitubatch examples
+
+Runnable examples (not shipped in the wheel). Run from the repo root, e.g.
+`python -m examples.advection.train_torch`.
+
+## advection/ — a 24-hour forecast, one dataset, three frameworks
+
+The M-W showcase: **multi-variable, windowed, train-in-place** sampling driving a real
+forecast — and the framework-neutral payoff. One [`InSituDataset`](advection/data.py)
+reads three fields at time *t* (temperature `t2m` and the 10 m wind `u10`, `v10`) and the
+target `t2m` 24 h later (`g.shift(horizon)`) — input and target are **offset views of the
+same in-place array**, the inputs are arrays gathered at the **same anchor**, and *nothing
+is resharded*. The same numpy `Batch` then trains the **same tiny CNN** in three frameworks
+via the zero-copy DLPack adapters — the files differ only in framework calls:
+
+```bash
+python -m examples.advection.train_torch   # PyTorch   (torch.nn)
+python -m examples.advection.train_jax     # JAX       (flax + optax)   [uv sync --extra jax]
+python -m examples.advection.train_tf      # TensorFlow (Keras)         [uv sync --extra tf]
+```
+
+Each prints the 24-hour forecast skill on held-out data — the model (which *reads the wind*
+to predict the advection) vs the persistence baseline. The default is a fast offline
+**synthetic advected field**; `--wb2` runs the *same code* on the public **WeatherBench2**
+ERA5 store (`gs://`, anonymous — `uv sync --extra bench` for gcsfs) — real cloud data, no
+reshard. (On real ERA5 the claim is "same pipeline, real data", not SOTA skill: 24 h
+persistence of temperature is a strong baseline.)
+
+**The pattern to take away:** point insitu at an existing cloud zarr, declare your inputs
+and a shifted target as `(label, path, offset)` views, and train in your framework — the
+windowing (`Batch.offsets`, `Batch.stack`, `Batch.read_indices`) and the no-reshard,
+chunk-once IO are the engine's job.
+
+## The WeatherBench2 cold-start pair (with Earthmover's xbatcher)
+
+The same task two ways — complementary engines for the same ndim-batch problem — so you
+can see the cold-start trade-off and pick what fits your workload:
+
+- [`wb2_dataloader.py`](wb2_dataloader.py) — the insitu single-event-loop loader.
+- [`wb2_xbatcher.py`](wb2_xbatcher.py) — Earthmover's `dataloader-demo` stack (xbatcher
+  defines the batches, torch `DataLoader` runs them), with a focus on cold-start latency
+  and how `forkserver-preload` cuts it (useful whichever loader you ship).
+
+## Normalization
+
+- [`fit_scaler.py`](fit_scaler.py) — fit a `StandardScaler` over the loader with sklearn
+  `partial_fit` (warms the cache), the recommended pattern vs caching scaled chunks.

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,11 @@
 Runnable examples (not shipped in the wheel). Run from the repo root, e.g.
 `python -m examples.advection.train_torch`.
 
+The InsituDataset is a general purpose, batteries included, tool for batching zarr compatible 
+data into the python ML ecosystem. The examples are forecasting focused because there are large
+public zarr datasets available and the time shifting on insitu data is an added challenge that
+shows the generalization.
+
 ## advection/ — a 24-hour forecast, one dataset, three frameworks
 
 The M-W showcase: **multi-variable, windowed, train-in-place** sampling driving a real

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,16 +17,23 @@ target `t2m` 24 h later (`g.shift(horizon)`) — input and target are **offset v
 same in-place array**, the inputs are arrays gathered at the **same anchor**, and *nothing
 is resharded*. The same numpy `Batch` then trains the **same tiny CNN** in three frameworks
 via the zero-copy DLPack adapters — the files differ only in framework calls:
-
 ```bash
-python -m examples.advection.train_torch   # PyTorch   (torch.nn)
-python -m examples.advection.train_jax     # JAX       (flax + optax)   [uv sync --extra jax]
-python -m examples.advection.train_tf      # TensorFlow (Keras)         [uv sync --extra tf]
+uv sync --extra bench --extra torch               # PyTorch   (torch.nn)
+uv run python -m examples.advection.train_torch   #
+
+uv sync --extra bench --extra jax                 # JAX       (flax + optax)
+uv run python -m examples.advection.train_jax     #
+
+uv sync --extra bench --extra tf                  # TensorFlow (Keras)
+uv run python -m examples.advection.train_tf      #
 ```
 
 Each prints the 24-hour forecast skill on held-out data — the model (which *reads the wind*
 to predict the advection) vs the persistence baseline. All three share one CLI
 ([`data.py`](advection/data.py)); the files differ only in framework calls.
+
+Make sure only one ML toolkit is installed at a time when running the models. Having multiple
+present in the uv venv can cause segfaults.
 
 ### Data sources (`--source`)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,11 +25,36 @@ python -m examples.advection.train_tf      # TensorFlow (Keras)         [uv sync
 ```
 
 Each prints the 24-hour forecast skill on held-out data — the model (which *reads the wind*
-to predict the advection) vs the persistence baseline. The default is a fast offline
-**synthetic advected field**; `--wb2` runs the *same code* on the public **WeatherBench2**
-ERA5 store (`gs://`, anonymous — `uv sync --extra bench` for gcsfs) — real cloud data, no
-reshard. (On real ERA5 the claim is "same pipeline, real data", not SOTA skill: 24 h
-persistence of temperature is a strong baseline.)
+to predict the advection) vs the persistence baseline. All three share one CLI
+([`data.py`](advection/data.py)); the files differ only in framework calls.
+
+### Data sources (`--source`)
+
+| `--source` | store | extra | notes |
+| --- | --- | --- | --- |
+| `synthetic` *(default)* | a fast offline **advected field** written to a temp zarr | — | beats persistence by construction; `--n-steps` sets the trajectory length |
+| `wb2` | public **WeatherBench2** ERA5, `gs://` (anonymous) | `--extra bench` (gcsfs) | the *same code* on real cloud data, no reshard |
+| `arraylake` | the same ERA5 as an **Arraylake/Icechunk** repo | `--extra arraylake` | needs `al auth login` / `ARRAYLAKE_TOKEN`; `--repo` / `--group` select it |
+
+On real ERA5 the claim is "same pipeline, real data", **not** SOTA skill — 24 h persistence
+of temperature is a strong baseline.
+
+### Flags
+
+- `--device cpu|cuda` — where the **training loop** moves each batch. The dataset stays
+  numpy (placement is the loop's job, not the loader's); torch does an explicit `.to(device)`,
+  JAX/TF auto-place on the accelerator and `--device cpu` forces/hides it.
+- `--sample-range START,STOP` — a **finite training window** on the time axis, so you can
+  subset a multi-decade real store (e.g. `0,2920` ≈ 2 years at 6-hourly).
+- `--cache-dir DIR` — spill the decoded-chunk cache to fast local disk (NVMe) for
+  **cross-epoch reuse** over a high-latency network.
+- `--max-inflight N` — throttle read-ahead depth (lower ⇒ lower cold time-to-first-batch
+  when the network is the bottleneck).
+- `--epochs`, `--batch-size`, `--repo`, `--group`, `--url` round out the CLI (`--help`).
+
+Running the examples on a GPU box against real ERA5 (G6 + NVMe, the Deep Learning Base AMI,
+CUDA torch via `--torch-backend`, Arraylake auth) is documented in
+[`bench/ops_aws.md`](../bench/ops_aws.md) §10.
 
 **The pattern to take away:** point insitu at an existing cloud zarr, declare your inputs
 and a shifted target as `(label, path, offset)` views, and train in your framework — the

--- a/examples/advection/__init__.py
+++ b/examples/advection/__init__.py
@@ -1,0 +1,7 @@
+"""Advected-field 24-hour forecast: one insitu dataset, three framework training loops.
+
+The same :class:`~insitubatch.source.InSituDataset` (a numpy ``Batch``) feeds torch, JAX,
+and TensorFlow via the thin DLPack adapters in :mod:`insitubatch.frameworks` -- see
+``train_torch.py`` / ``train_jax.py`` / ``train_tf.py`` (near-identical but for the
+framework calls). ``data.py`` builds the store, the dataset, and the shared eval.
+"""

--- a/examples/advection/data.py
+++ b/examples/advection/data.py
@@ -27,6 +27,7 @@ import numpy as np
 import zarr
 
 from insitubatch import (
+    StoreLike,
     ensure_local_dir,
     open_geometries,
     split_by_chunk,
@@ -42,10 +43,22 @@ WB2_URL = (
 WB2_VARS = ("2m_temperature", "10m_u_component_of_wind", "10m_v_component_of_wind")
 WB2_HORIZON = 4  # 4 steps x 6 h = 24 h
 
+# The same data as an Arraylake/Icechunk repo (real ERA5; grouped by resolution).
+ARRAYLAKE_REPO = "earthmover-public/weatherbench2"
+ARRAYLAKE_GROUP = "era5/6h_240x121"
+
 SYNTH_VARS = ("t2m", "u10", "v10")
 SYNTH_HORIZON = 24  # 24 steps x 1 h = 24 h
 
 LABELS = ("t2m", "u10", "v10")  # canonical input labels (store-independent)
+
+
+def open_arraylake_store(repo: str, *, branch: str = "main") -> StoreLike:
+    """Read-only Icechunk session store for an Arraylake repo (needs ``--extra arraylake``
+    + ``al auth login`` / ``ARRAYLAKE_TOKEN``). Passed straight to ``InSituDataset``."""
+    from arraylake import Client
+
+    return Client().get_repo(repo).readonly_session(branch).store
 
 
 def _advect(field: np.ndarray, u: np.ndarray, v: np.ndarray) -> np.ndarray:
@@ -125,32 +138,43 @@ def make_advection_store(url: str, *, n_steps: int = 768, size: int = 48, seed: 
 
 
 def forecast_dataset(
-    url: str,
+    store: StoreLike,
     *,
     variables: tuple[str, str, str] = SYNTH_VARS,
     horizon: int = SYNTH_HORIZON,
+    sample_range: tuple[int, int] | None = None,
     batch_size: int = 32,
     shuffle: bool = True,
+    cache_dir: str | None = None,
+    max_inflight: int | None = None,
     **store_kwargs: Any,
 ) -> InSituDataset:
     """One windowed dataset: inputs ``{t2m, u10, v10}@t`` + ``target = t2m@(t+horizon)``.
 
-    ``variables`` names the three input arrays in the store (synthetic short names or the
-    WeatherBench2 long names); the dataset's labels are always ``t2m, u10, v10, target`` so
-    the model code is store-agnostic. The target is the first variable shifted by
-    ``horizon`` -- two views of one array, no reshard. Iterate its ``.train`` / ``.val``
-    views; ``split_by_chunk`` partitions the time axis (contiguous, the time-series default).
+    ``store`` is a URL or a prebuilt zarr Store (e.g. an Arraylake/Icechunk session store).
+    ``variables`` names the three input arrays in the store (synthetic short names, the
+    WeatherBench2 long names, or group-qualified paths); the dataset's labels are always
+    ``t2m, u10, v10, target`` so the model code is store-agnostic. The target is the first
+    variable shifted by ``horizon`` -- two views of one array, no reshard. ``sample_range``
+    restricts the split to a finite time window (subset a multi-decade store).
+    ``cache_dir`` spills the decoded-chunk cache to NVMe (fast cross-epoch reuse over a
+    high-latency network); ``max_inflight`` throttles read-ahead. Iterate the returned
+    dataset's ``.train`` / ``.val`` views.
     """
-    opened = open_geometries(url, variables=list(variables), **store_kwargs)
+    opened = open_geometries(store, variables=list(variables), **store_kwargs)
     geoms = {label: opened[var] for label, var in zip(LABELS, variables, strict=True)}
     geoms["target"] = opened[variables[0]].shift(horizon)
-    manifest = split_by_chunk(opened[variables[0]], fractions=(0.8, 0.1, 0.1))
+    manifest = split_by_chunk(
+        opened[variables[0]], fractions=(0.8, 0.1, 0.1), sample_range=sample_range
+    )
     return InSituDataset(
-        url,
+        store,
         manifest,
         geometries=geoms,
         batch_size=batch_size,
         shuffle=shuffle,
+        cache_dir=cache_dir,
+        max_inflight=max_inflight,
         **store_kwargs,
     )
 
@@ -192,28 +216,76 @@ def evaluate(view: Iterable[Batch], predict: Callable[[Batch], np.ndarray]) -> t
     return rmse(pred, target), rmse(persistence, target)
 
 
+def _range(s: str) -> tuple[int, int]:
+    start, stop = (int(x) for x in s.split(","))
+    return (start, stop)
+
+
 def cli() -> argparse.Namespace:
     """Shared CLI for the three training files (only the model + loop differ)."""
     p = argparse.ArgumentParser(description="advected-field 24 h forecast")
-    p.add_argument("--wb2", action="store_true", help="read the public WeatherBench2 ARCO store")
+    p.add_argument(
+        "--source",
+        choices=("synthetic", "wb2", "arraylake"),
+        default="synthetic",
+        help="offline synthetic | WeatherBench2 gs:// | Arraylake/Icechunk (real ERA5)",
+    )
+    p.add_argument(
+        "--device",
+        default="cpu",
+        help="cpu or cuda -- the train loop moves tensors there",
+    )
+    p.add_argument(
+        "--sample-range",
+        type=_range,
+        default=None,
+        metavar="START,STOP",
+        help="finite training window on the time axis (subset a multi-decade real store)",
+    )
+    p.add_argument("--repo", default=ARRAYLAKE_REPO, help="Arraylake repo (--source arraylake)")
+    p.add_argument("--group", default=ARRAYLAKE_GROUP, help="resolution group (--source arraylake)")
     p.add_argument("--epochs", type=int, default=8)
     p.add_argument("--batch-size", type=int, default=32)
     p.add_argument("--n-steps", type=int, default=768, help="synthetic trajectory length (hours)")
     p.add_argument("--url", default=None, help="synthetic store path (default: a temp file)")
+    p.add_argument(
+        "--cache-dir",
+        default=None,
+        help="spill the decoded-chunk cache here (e.g. NVMe) for cross-epoch reuse",
+    )
+    p.add_argument(
+        "--max-inflight",
+        type=int,
+        default=None,
+        help="throttle read-ahead depth (lower = lower cold TTFB over a high-latency network)",
+    )
     return p.parse_args()
 
 
 def build_datasets(args: argparse.Namespace) -> InSituDataset:
-    """One forecast dataset from CLI args -- iterate ``ds.train`` / ``ds.val``. Synthetic by
-    default (written fresh -- deterministic, offline); ``--wb2`` reads the public
-    WeatherBench2 store (anonymous ``gs://``, real ERA5, 6-hourly so the 24 h horizon is 4
-    steps)."""
-    if args.wb2:
-        url, variables, horizon, kw = WB2_URL, WB2_VARS, WB2_HORIZON, {"skip_signature": True}
+    """One forecast dataset from CLI args -- iterate ``ds.train`` / ``ds.val``. ``--source``
+    picks offline synthetic (written fresh), the public WeatherBench2 ``gs://`` store, or the
+    Arraylake/Icechunk repo (real ERA5; pass ``--sample-range`` to subset the archive)."""
+    store: StoreLike
+    if args.source == "arraylake":
+        store = open_arraylake_store(args.repo)
+        a, b, c = WB2_VARS
+        variables = (f"{args.group}/{a}", f"{args.group}/{b}", f"{args.group}/{c}")
+        horizon, kw = WB2_HORIZON, {}
+    elif args.source == "wb2":
+        store, variables, horizon, kw = WB2_URL, WB2_VARS, WB2_HORIZON, {"skip_signature": True}
     else:
-        url = args.url or "file:///tmp/insitu_advection.zarr"
-        make_advection_store(url, n_steps=args.n_steps)
+        store = args.url or "file:///tmp/insitu_advection.zarr"
+        make_advection_store(store, n_steps=args.n_steps)
         variables, horizon, kw = SYNTH_VARS, SYNTH_HORIZON, {}
     return forecast_dataset(
-        url, variables=variables, horizon=horizon, batch_size=args.batch_size, shuffle=True, **kw
+        store,
+        variables=variables,
+        horizon=horizon,
+        sample_range=args.sample_range,
+        batch_size=args.batch_size,
+        shuffle=True,
+        cache_dir=args.cache_dir,
+        max_inflight=args.max_inflight,
+        **kw,
     )

--- a/examples/advection/data.py
+++ b/examples/advection/data.py
@@ -1,0 +1,236 @@
+"""Shared data for the advected-field forecast: the store, the one dataset, the eval.
+
+**The task — a direct 24-hour forecast.** Inputs are three fields at time ``t`` --
+temperature ``t2m`` and the 10 m wind ``u10`` / ``v10`` -- and the target is ``t2m`` 24 h
+later. Nothing is resharded: input and target are two *views* of the same in-place array
+read at different sample-axis offsets (``g`` and ``g.shift(horizon)``), and the three
+inputs are three arrays gathered at the *same* anchor. That is the whole M-W unlock.
+
+Persistence -- predict ``t2m(t+24h) = t2m(t)`` -- is wrong by exactly the advection the
+wind drives over 24 h. A tiny CNN that *sees* the wind can do better, so the models learn
+the **tendency** (the change on top of persistence), the pattern weather-ML uses in
+practice. On the synthetic store that beats persistence by construction; on the real
+WeatherBench2 store the same code runs on real ERA5 (we claim "same pipeline, real data,
+no reshard" -- not SOTA skill: t2m persistence at a 24 h multiple is a strong baseline).
+
+``forecast_dataset`` returns one dataset whose labels are always ``t2m, u10, v10, target``
+regardless of the store, so the training files are store-agnostic.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import zarr
+
+from insitubatch import (
+    SplitName,
+    ensure_local_dir,
+    open_geometries,
+    split_by_chunk,
+    store_from_url,
+)
+from insitubatch.source import InSituDataset
+from insitubatch.types import Batch
+
+# The public WeatherBench2 ERA5 (6-hourly) ARCO store the wb2_* examples use.
+WB2_URL = (
+    "gs://weatherbench2/datasets/era5/1959-2022-6h-128x64_equiangular_with_poles_conservative.zarr"
+)
+WB2_VARS = ("2m_temperature", "10m_u_component_of_wind", "10m_v_component_of_wind")
+WB2_HORIZON = 4  # 4 steps x 6 h = 24 h
+
+SYNTH_VARS = ("t2m", "u10", "v10")
+SYNTH_HORIZON = 24  # 24 steps x 1 h = 24 h
+
+LABELS = ("t2m", "u10", "v10")  # canonical input labels (store-independent)
+
+
+def _advect(field: np.ndarray, u: np.ndarray, v: np.ndarray) -> np.ndarray:
+    """One semi-Lagrangian advection step on a periodic grid (bilinear backtrace).
+
+    ``out[y, x] = field[y - v, x - u]`` -- each cell pulls from where the flow came from.
+    Periodic wrap keeps the field in-domain; the displacement is small (sub-cell) so 24
+    steps move features a few cells -- enough that persistence is clearly wrong.
+    """
+    h, w = field.shape
+    ys, xs = np.mgrid[0:h, 0:w].astype(np.float64)
+    sy, sx = (ys - v) % h, (xs - u) % w
+    fy, fx = np.floor(sy), np.floor(sx)
+    wy, wx = sy - fy, sx - fx  # fractional part, always in [0, 1) -- robust to fp modulo == h
+    y0, x0 = fy.astype(int) % h, fx.astype(int) % w
+    y1, x1 = (y0 + 1) % h, (x0 + 1) % w
+    return (
+        field[y0, x0] * (1 - wy) * (1 - wx)
+        + field[y0, x1] * (1 - wy) * wx
+        + field[y1, x0] * wy * (1 - wx)
+        + field[y1, x1] * wy * wx
+    )
+
+
+def make_advection_store(url: str, *, n_steps: int = 768, size: int = 48, seed: int = 0) -> None:
+    """Write a synthetic 3-variable advected-field zarr (``t2m``, ``u10``, ``v10``).
+
+    A smooth, time-*constant* deformation wind advects the temperature field; every hour is
+    one sample. The process is kept *stationary* (advect, replenish small scales, renormalize
+    -- see below) so every timestep has the same statistics and a contiguous split is honest.
+    ``u10`` / ``v10`` are stored over time (broadcast) so all three arrays share the sample
+    axis the engine batches along. Fields are ~unit-scale (no normalization needed). Chunked
+    at 48 steps so there are several chunks to split/shuffle.
+    """
+    rng = np.random.default_rng(seed)
+    yy, xx = np.mgrid[0:size, 0:size] / size
+    # A smooth, spatially-varying deformation wind (a couple of low modes), ~0.2 cells/step
+    # peak so the 24 h displacement is ~5 cells -- visible, within a small CNN's receptive
+    # field, and varying enough that the model must *read* the wind, not memorize a shift.
+    u = 0.20 * (np.sin(2 * np.pi * yy) * np.cos(2 * np.pi * xx))
+    v = 0.20 * (np.cos(2 * np.pi * yy) * np.sin(2 * np.pi * xx))
+
+    def smooth_field() -> np.ndarray:
+        """A random unit-scale field of mid-frequency modes (a ~5-cell shift is visible)."""
+        f = np.zeros((size, size))
+        for _ in range(12):
+            kx, ky = rng.integers(2, 6, size=2)
+            f += rng.normal() * np.cos(2 * np.pi * (kx * xx + ky * yy) + rng.uniform(0, 2 * np.pi))
+        return (f - f.mean()) / f.std()
+
+    # A *stationary* forced-advection process: each step advects the field by the wind, then
+    # adds a little fresh structure to replenish what bilinear interpolation dissipates, and
+    # renormalizes. Every timestep then has the same statistics (so a contiguous split is
+    # honest), and t2m(t+24) is the field advected 24 steps -- predictable from t2m(t) + the
+    # wind (the model beats persistence by learning the displacement) up to the small forcing.
+    field = smooth_field()
+    t2m = np.empty((n_steps, size, size), dtype="f4")
+    for t in range(n_steps):
+        t2m[t] = field
+        field = _advect(field, u, v) + 0.12 * smooth_field()
+        field = (field - field.mean()) / field.std()
+
+    wind_u = np.broadcast_to(u.astype("f4"), (n_steps, size, size))
+    wind_v = np.broadcast_to(v.astype("f4"), (n_steps, size, size))
+
+    ensure_local_dir(url)
+    group = zarr.open_group(store=store_from_url(url, read_only=False), mode="w")
+    for name, data in (("t2m", t2m), ("u10", wind_u), ("v10", wind_v)):
+        arr = group.create_array(
+            name,
+            shape=data.shape,
+            chunks=(48, size, size),
+            dtype="f4",
+            dimension_names=("time", "lat", "lon"),
+        )
+        arr[:] = data
+
+
+def forecast_dataset(
+    url: str,
+    *,
+    variables: tuple[str, str, str] = SYNTH_VARS,
+    horizon: int = SYNTH_HORIZON,
+    split: SplitName = SplitName.TRAIN,
+    batch_size: int = 32,
+    shuffle: bool = True,
+    **store_kwargs: Any,
+) -> InSituDataset:
+    """One windowed dataset: inputs ``{t2m, u10, v10}@t`` + ``target = t2m@(t+horizon)``.
+
+    ``variables`` names the three input arrays in the store (synthetic short names or the
+    WeatherBench2 long names); the dataset's labels are always ``t2m, u10, v10, target`` so
+    the model code is store-agnostic. The target is the first variable shifted by
+    ``horizon`` -- two views of one array, no reshard. ``split_by_chunk`` partitions the
+    time axis (contiguous, the time-series default).
+    """
+    opened = open_geometries(url, variables=list(variables), **store_kwargs)
+    geoms = {label: opened[var] for label, var in zip(LABELS, variables, strict=True)}
+    geoms["target"] = opened[variables[0]].shift(horizon)
+    manifest = split_by_chunk(opened[variables[0]], fractions=(0.8, 0.1, 0.1))
+    return InSituDataset(
+        url,
+        manifest,
+        geometries=geoms,
+        split=split,
+        batch_size=batch_size,
+        shuffle=shuffle,
+        **store_kwargs,
+    )
+
+
+def inputs_and_targets(batch: Batch) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Split a windowed ``Batch`` into ``(x, persistence, target)`` numpy arrays.
+
+    ``x`` is the stacked 3-channel input ``(B, 3, H, W)`` (``Batch.stack`` -- the Phase 3
+    helper), ``persistence`` is ``t2m(t)`` ``(B, 1, H, W)`` (the no-skill forecast), and
+    ``target`` is ``t2m(t+horizon)`` ``(B, 1, H, W)``. Models predict a tendency added to
+    ``persistence``; the framework loops only ever touch these three.
+    """
+    x = batch.stack(["t2m", "u10", "v10"])  # (B, 3, H, W)
+    persistence = batch.arrays["t2m"][:, None]  # (B, 1, H, W)
+    target = batch.arrays["target"][:, None]  # (B, 1, H, W)
+    return x, persistence, target
+
+
+def rmse(pred: np.ndarray, target: np.ndarray) -> float:
+    return float(np.sqrt(np.mean((pred - target) ** 2)))
+
+
+def evaluate(ds: InSituDataset, predict: Callable[[Batch], np.ndarray]) -> tuple[float, float]:
+    """24-hour-forecast skill on a held-out split: ``(model_rmse, persistence_rmse)``.
+
+    ``predict`` maps a windowed ``Batch`` to the model's ``t2m(t+horizon)`` forecast
+    ``(B, 1, H, W)`` (each framework supplies its own, so this stays framework-neutral).
+    Persistence -- predict no change -- is the baseline a useful model must beat.
+    """
+    ds.set_epoch(0)
+    preds, targets, persists = [], [], []
+    for batch in ds:
+        _x, persistence, target = inputs_and_targets(batch)
+        preds.append(predict(batch))
+        targets.append(target)
+        persists.append(persistence)
+    pred, target, persistence = (np.concatenate(a) for a in (preds, targets, persists))
+    return rmse(pred, target), rmse(persistence, target)
+
+
+def cli() -> argparse.Namespace:
+    """Shared CLI for the three training files (only the model + loop differ)."""
+    p = argparse.ArgumentParser(description="advected-field 24 h forecast")
+    p.add_argument("--wb2", action="store_true", help="read the public WeatherBench2 ARCO store")
+    p.add_argument("--epochs", type=int, default=8)
+    p.add_argument("--batch-size", type=int, default=32)
+    p.add_argument("--n-steps", type=int, default=768, help="synthetic trajectory length (hours)")
+    p.add_argument("--url", default=None, help="synthetic store path (default: a temp file)")
+    return p.parse_args()
+
+
+def build_datasets(args: argparse.Namespace) -> tuple[InSituDataset, InSituDataset]:
+    """``(train, val)`` forecast datasets from CLI args. Synthetic by default (written
+    fresh -- deterministic, offline); ``--wb2`` reads the public WeatherBench2 store
+    (anonymous ``gs://``, real ERA5, 6-hourly so the 24 h horizon is 4 steps)."""
+    if args.wb2:
+        url, variables, horizon, kw = WB2_URL, WB2_VARS, WB2_HORIZON, {"skip_signature": True}
+    else:
+        url = args.url or "file:///tmp/insitu_advection.zarr"
+        make_advection_store(url, n_steps=args.n_steps)
+        variables, horizon, kw = SYNTH_VARS, SYNTH_HORIZON, {}
+    train = forecast_dataset(
+        url,
+        variables=variables,
+        horizon=horizon,
+        split=SplitName.TRAIN,
+        batch_size=args.batch_size,
+        shuffle=True,
+        **kw,
+    )
+    val = forecast_dataset(
+        url,
+        variables=variables,
+        horizon=horizon,
+        split=SplitName.VAL,
+        batch_size=args.batch_size,
+        shuffle=False,
+        **kw,
+    )
+    return train, val

--- a/examples/advection/data.py
+++ b/examples/advection/data.py
@@ -20,14 +20,13 @@ regardless of the store, so the training files are store-agnostic.
 from __future__ import annotations
 
 import argparse
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import Any
 
 import numpy as np
 import zarr
 
 from insitubatch import (
-    SplitName,
     ensure_local_dir,
     open_geometries,
     split_by_chunk,
@@ -130,7 +129,6 @@ def forecast_dataset(
     *,
     variables: tuple[str, str, str] = SYNTH_VARS,
     horizon: int = SYNTH_HORIZON,
-    split: SplitName = SplitName.TRAIN,
     batch_size: int = 32,
     shuffle: bool = True,
     **store_kwargs: Any,
@@ -140,8 +138,8 @@ def forecast_dataset(
     ``variables`` names the three input arrays in the store (synthetic short names or the
     WeatherBench2 long names); the dataset's labels are always ``t2m, u10, v10, target`` so
     the model code is store-agnostic. The target is the first variable shifted by
-    ``horizon`` -- two views of one array, no reshard. ``split_by_chunk`` partitions the
-    time axis (contiguous, the time-series default).
+    ``horizon`` -- two views of one array, no reshard. Iterate its ``.train`` / ``.val``
+    views; ``split_by_chunk`` partitions the time axis (contiguous, the time-series default).
     """
     opened = open_geometries(url, variables=list(variables), **store_kwargs)
     geoms = {label: opened[var] for label, var in zip(LABELS, variables, strict=True)}
@@ -151,7 +149,6 @@ def forecast_dataset(
         url,
         manifest,
         geometries=geoms,
-        split=split,
         batch_size=batch_size,
         shuffle=shuffle,
         **store_kwargs,
@@ -176,16 +173,17 @@ def rmse(pred: np.ndarray, target: np.ndarray) -> float:
     return float(np.sqrt(np.mean((pred - target) ** 2)))
 
 
-def evaluate(ds: InSituDataset, predict: Callable[[Batch], np.ndarray]) -> tuple[float, float]:
-    """24-hour-forecast skill on a held-out split: ``(model_rmse, persistence_rmse)``.
+def evaluate(view: Iterable[Batch], predict: Callable[[Batch], np.ndarray]) -> tuple[float, float]:
+    """24-hour-forecast skill on a held-out split view (e.g. ``ds.val``): ``(model_rmse,
+    persistence_rmse)``.
 
     ``predict`` maps a windowed ``Batch`` to the model's ``t2m(t+horizon)`` forecast
     ``(B, 1, H, W)`` (each framework supplies its own, so this stays framework-neutral).
-    Persistence -- predict no change -- is the baseline a useful model must beat.
+    Persistence -- predict no change -- is the baseline a useful model must beat. The view
+    is deterministic (eval splits don't shuffle), so no epoch is set.
     """
-    ds.set_epoch(0)
     preds, targets, persists = [], [], []
-    for batch in ds:
+    for batch in view:
         _x, persistence, target = inputs_and_targets(batch)
         preds.append(predict(batch))
         targets.append(target)
@@ -205,32 +203,17 @@ def cli() -> argparse.Namespace:
     return p.parse_args()
 
 
-def build_datasets(args: argparse.Namespace) -> tuple[InSituDataset, InSituDataset]:
-    """``(train, val)`` forecast datasets from CLI args. Synthetic by default (written
-    fresh -- deterministic, offline); ``--wb2`` reads the public WeatherBench2 store
-    (anonymous ``gs://``, real ERA5, 6-hourly so the 24 h horizon is 4 steps)."""
+def build_datasets(args: argparse.Namespace) -> InSituDataset:
+    """One forecast dataset from CLI args -- iterate ``ds.train`` / ``ds.val``. Synthetic by
+    default (written fresh -- deterministic, offline); ``--wb2`` reads the public
+    WeatherBench2 store (anonymous ``gs://``, real ERA5, 6-hourly so the 24 h horizon is 4
+    steps)."""
     if args.wb2:
         url, variables, horizon, kw = WB2_URL, WB2_VARS, WB2_HORIZON, {"skip_signature": True}
     else:
         url = args.url or "file:///tmp/insitu_advection.zarr"
         make_advection_store(url, n_steps=args.n_steps)
         variables, horizon, kw = SYNTH_VARS, SYNTH_HORIZON, {}
-    train = forecast_dataset(
-        url,
-        variables=variables,
-        horizon=horizon,
-        split=SplitName.TRAIN,
-        batch_size=args.batch_size,
-        shuffle=True,
-        **kw,
+    return forecast_dataset(
+        url, variables=variables, horizon=horizon, batch_size=args.batch_size, shuffle=True, **kw
     )
-    val = forecast_dataset(
-        url,
-        variables=variables,
-        horizon=horizon,
-        split=SplitName.VAL,
-        batch_size=args.batch_size,
-        shuffle=False,
-        **kw,
-    )
-    return train, val

--- a/examples/advection/train_jax.py
+++ b/examples/advection/train_jax.py
@@ -1,0 +1,98 @@
+"""Forecast t2m 24 h ahead with a tiny CNN, in **JAX** (flax + optax), on one insitu dataset.
+
+    python -m examples.advection.train_jax          # synthetic advected field (offline)
+    python -m examples.advection.train_jax --wb2    # WeatherBench2 (real ERA5, gs://)
+
+Same shared, framework-neutral data layer as ``train_torch.py`` / ``train_tf.py`` -- the
+numpy ``Batch`` is handed to JAX zero-copy via ``to_jax`` (DLPack). Only this file is JAX.
+The model learns the **tendency** (the change on persistence); beating persistence means it
+learned the wind-driven advection. JAX/TF use channels-last (``B, H, W, C``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import flax.linen as fnn
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+
+from insitubatch.frameworks import to_jax
+from insitubatch.source import InSituDataset
+from insitubatch.types import Batch
+
+from .data import build_datasets, cli, evaluate
+
+
+class AdvectionCNN(fnn.Module):
+    """3 input channels (t2m, u10, v10) -> 1 channel tendency. Inputs standardized per
+    channel; four 3x3 circular convs (receptive field 9) cover the ~5-cell displacement."""
+
+    hidden: int = 32
+
+    @fnn.compact
+    def __call__(self, x: jax.Array) -> jax.Array:  # x: (B, H, W, 3) -> tendency (B, H, W, 1)
+        xn = (x - x.mean((0, 1, 2), keepdims=True)) / (x.std((0, 1, 2), keepdims=True) + 1e-6)
+        for _ in range(3):
+            xn = fnn.relu(fnn.Conv(self.hidden, (3, 3), padding="CIRCULAR")(xn))
+        return fnn.Conv(1, (3, 3), padding="CIRCULAR")(xn)
+
+
+def _channels(batch: Batch) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """``(x, persistence, target)`` as channels-last JAX arrays, zero-copy via DLPack."""
+    d = to_jax(batch)  # {label: (B, H, W)}
+    x = jnp.stack([d["t2m"], d["u10"], d["v10"]], axis=-1)  # (B, H, W, 3)
+    return x, d["t2m"][..., None], d["target"][..., None]  # (B, H, W, 1) each
+
+
+def train(train_ds: InSituDataset, val_ds: InSituDataset, *, epochs: int) -> tuple[float, float]:
+    """Train the CNN; return ``(model_rmse, persistence_rmse)`` -- 24 h forecast skill on val."""
+    model = AdvectionCNN()
+    opt = optax.adam(1e-3)
+    train_ds.set_epoch(0)
+    sample_x, _, _ = _channels(next(iter(train_ds)))
+    params = model.init(jax.random.key(0), sample_x)
+    opt_state = opt.init(params)
+
+    @jax.jit
+    def step(
+        params: Any, opt_state: Any, x: jax.Array, persistence: jax.Array, target: jax.Array
+    ) -> tuple[Any, Any, jax.Array]:
+        def loss_fn(p: Any) -> jax.Array:
+            pred = persistence + jnp.asarray(model.apply(p, x))
+            return jnp.mean((pred - target) ** 2)
+
+        loss, grads = jax.value_and_grad(loss_fn)(params)
+        updates, opt_state = opt.update(grads, opt_state)
+        return optax.apply_updates(params, updates), opt_state, loss
+
+    for epoch in range(epochs):
+        train_ds.set_epoch(epoch)
+        last = 0.0
+        for batch in train_ds:
+            params, opt_state, loss = step(params, opt_state, *_channels(batch))
+            last = float(loss)
+        print(f"epoch {epoch}  train mse {last:.4f}")
+
+    def predict(batch: Batch) -> np.ndarray:  # (B, 1, H, W) to match the shared eval
+        x, persistence, _ = _channels(batch)
+        forecast = persistence + jnp.asarray(model.apply(params, x))  # (B, H, W, 1)
+        return np.asarray(forecast).transpose(0, 3, 1, 2)
+
+    return evaluate(val_ds, predict)
+
+
+def main() -> None:
+    args = cli()
+    train_ds, val_ds = build_datasets(args)
+    model_rmse, persistence_rmse = train(train_ds, val_ds, epochs=args.epochs)
+    print(
+        f"\n24 h forecast RMSE on held-out data: model {model_rmse:.3f}  vs  "
+        f"persistence {persistence_rmse:.3f}  ({persistence_rmse / model_rmse:.1f}x better)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advection/train_jax.py
+++ b/examples/advection/train_jax.py
@@ -47,12 +47,12 @@ def _channels(batch: Batch) -> tuple[jax.Array, jax.Array, jax.Array]:
     return x, d["t2m"][..., None], d["target"][..., None]  # (B, H, W, 1) each
 
 
-def train(train_ds: InSituDataset, val_ds: InSituDataset, *, epochs: int) -> tuple[float, float]:
+def train(ds: InSituDataset, *, epochs: int) -> tuple[float, float]:
     """Train the CNN; return ``(model_rmse, persistence_rmse)`` -- 24 h forecast skill on val."""
     model = AdvectionCNN()
     opt = optax.adam(1e-3)
-    train_ds.set_epoch(0)
-    sample_x, _, _ = _channels(next(iter(train_ds)))
+    ds.set_epoch(0)
+    sample_x, _, _ = _channels(next(iter(ds.train)))
     params = model.init(jax.random.key(0), sample_x)
     opt_state = opt.init(params)
 
@@ -69,9 +69,9 @@ def train(train_ds: InSituDataset, val_ds: InSituDataset, *, epochs: int) -> tup
         return optax.apply_updates(params, updates), opt_state, loss
 
     for epoch in range(epochs):
-        train_ds.set_epoch(epoch)
+        ds.set_epoch(epoch)
         last = 0.0
-        for batch in train_ds:
+        for batch in ds.train:
             params, opt_state, loss = step(params, opt_state, *_channels(batch))
             last = float(loss)
         print(f"epoch {epoch}  train mse {last:.4f}")
@@ -81,13 +81,13 @@ def train(train_ds: InSituDataset, val_ds: InSituDataset, *, epochs: int) -> tup
         forecast = persistence + jnp.asarray(model.apply(params, x))  # (B, H, W, 1)
         return np.asarray(forecast).transpose(0, 3, 1, 2)
 
-    return evaluate(val_ds, predict)
+    return evaluate(ds.val, predict)
 
 
 def main() -> None:
     args = cli()
-    train_ds, val_ds = build_datasets(args)
-    model_rmse, persistence_rmse = train(train_ds, val_ds, epochs=args.epochs)
+    ds = build_datasets(args)
+    model_rmse, persistence_rmse = train(ds, epochs=args.epochs)
     print(
         f"\n24 h forecast RMSE on held-out data: model {model_rmse:.3f}  vs  "
         f"persistence {persistence_rmse:.3f}  ({persistence_rmse / model_rmse:.1f}x better)"

--- a/examples/advection/train_jax.py
+++ b/examples/advection/train_jax.py
@@ -1,12 +1,9 @@
 """Forecast t2m 24 h ahead with a tiny CNN, in **JAX** (flax + optax), on one insitu dataset.
 
-    python -m examples.advection.train_jax          # synthetic advected field (offline)
-    python -m examples.advection.train_jax --wb2    # WeatherBench2 (real ERA5, gs://)
-
-Same shared, framework-neutral data layer as ``train_torch.py`` / ``train_tf.py`` -- the
-numpy ``Batch`` is handed to JAX zero-copy via ``to_jax`` (DLPack). Only this file is JAX.
-The model learns the **tendency** (the change on persistence); beating persistence means it
-learned the wind-driven advection. JAX/TF use channels-last (``B, H, W, C``).
+Same shared, framework-neutral data layer as ``train_torch.py`` -- the numpy ``Batch`` is
+handed to JAX zero-copy via ``to_jax`` (DLPack). Only this file is JAX; JAX auto-places on
+the accelerator it finds (``--device cpu`` forces CPU). JAX/TF use channels-last
+(``B, H, W, C``). Usage, sources and flags: ``examples/README.md``.
 """
 
 from __future__ import annotations
@@ -47,8 +44,14 @@ def _channels(batch: Batch) -> tuple[jax.Array, jax.Array, jax.Array]:
     return x, d["t2m"][..., None], d["target"][..., None]  # (B, H, W, 1) each
 
 
-def train(ds: InSituDataset, *, epochs: int) -> tuple[float, float]:
-    """Train the CNN; return ``(model_rmse, persistence_rmse)`` -- 24 h forecast skill on val."""
+def train(ds: InSituDataset, *, epochs: int, device: str = "cpu") -> tuple[float, float]:
+    """Train the CNN; return ``(model_rmse, persistence_rmse)`` -- 24 h forecast skill on val.
+
+    JAX auto-places on the accelerator it finds (install ``jax[cuda12]`` for GPU); ``device
+    == "cpu"`` forces CPU. Either way the dataset stays numpy and ``to_jax`` is a per-batch
+    DLPack hand-off."""
+    if device == "cpu":
+        jax.config.update("jax_platform_name", "cpu")
     model = AdvectionCNN()
     opt = optax.adam(1e-3)
     ds.set_epoch(0)
@@ -87,7 +90,7 @@ def train(ds: InSituDataset, *, epochs: int) -> tuple[float, float]:
 def main() -> None:
     args = cli()
     ds = build_datasets(args)
-    model_rmse, persistence_rmse = train(ds, epochs=args.epochs)
+    model_rmse, persistence_rmse = train(ds, epochs=args.epochs, device=args.device)
     print(
         f"\n24 h forecast RMSE on held-out data: model {model_rmse:.3f}  vs  "
         f"persistence {persistence_rmse:.3f}  ({persistence_rmse / model_rmse:.1f}x better)"

--- a/examples/advection/train_tf.py
+++ b/examples/advection/train_tf.py
@@ -1,9 +1,9 @@
 """Forecast t2m 24 h ahead with a tiny CNN, in **TensorFlow** (Keras), on one insitu dataset.
 
 Same shared, framework-neutral data layer as ``train_torch.py`` -- the numpy ``Batch`` is
-handed to TF zero-copy via ``to_tf`` (DLPack). Only this file is TF; TF auto-uses a visible
-GPU (``--device cpu`` hides it). JAX/TF use channels-last (``B, H, W, C``). Usage, sources
-and flags: ``examples/README.md``.
+handed to TF via ``to_tf`` (a per-batch copy; TF's experimental DLPack is unreliable, see
+``to_tf``). Only this file is TF; TF auto-uses a visible GPU (``--device cpu`` hides it).
+JAX/TF use channels-last (``B, H, W, C``). Usage, sources and flags: ``examples/README.md``.
 """
 
 from __future__ import annotations
@@ -56,7 +56,7 @@ def build_model(hidden: int = 32) -> keras.Model:
 
 
 def _channels(batch: Batch) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
-    """``(x, persistence, target)`` as channels-last TF tensors, zero-copy via DLPack."""
+    """``(x, persistence, target)`` as channels-last TF tensors (``to_tf`` copies per batch)."""
     d = to_tf(batch)  # {label: (B, H, W)}
     x = tf.stack([d["t2m"], d["u10"], d["v10"]], axis=-1)  # (B, H, W, 3)
     return x, d["t2m"][..., None], d["target"][..., None]  # (B, H, W, 1) each

--- a/examples/advection/train_tf.py
+++ b/examples/advection/train_tf.py
@@ -1,12 +1,9 @@
 """Forecast t2m 24 h ahead with a tiny CNN, in **TensorFlow** (Keras), on one insitu dataset.
 
-    python -m examples.advection.train_tf          # synthetic advected field (offline)
-    python -m examples.advection.train_tf --wb2    # WeatherBench2 (real ERA5, gs://)
-
-Same shared, framework-neutral data layer as ``train_torch.py`` / ``train_jax.py`` -- the
-numpy ``Batch`` is handed to TF zero-copy via ``to_tf`` (DLPack). Only this file is TF. The
-model learns the **tendency** (the change on persistence); beating persistence means it
-learned the wind-driven advection. JAX/TF use channels-last (``B, H, W, C``).
+Same shared, framework-neutral data layer as ``train_torch.py`` -- the numpy ``Batch`` is
+handed to TF zero-copy via ``to_tf`` (DLPack). Only this file is TF; TF auto-uses a visible
+GPU (``--device cpu`` hides it). JAX/TF use channels-last (``B, H, W, C``). Usage, sources
+and flags: ``examples/README.md``.
 """
 
 from __future__ import annotations
@@ -65,8 +62,13 @@ def _channels(batch: Batch) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
     return x, d["t2m"][..., None], d["target"][..., None]  # (B, H, W, 1) each
 
 
-def train(ds: InSituDataset, *, epochs: int) -> tuple[float, float]:
-    """Train the CNN; return ``(model_rmse, persistence_rmse)`` -- 24 h forecast skill on val."""
+def train(ds: InSituDataset, *, epochs: int, device: str = "cpu") -> tuple[float, float]:
+    """Train the CNN; return ``(model_rmse, persistence_rmse)`` -- 24 h forecast skill on val.
+
+    TF auto-places on a visible GPU (install ``tensorflow[and-cuda]``); ``device == "cpu"``
+    hides the GPU. Either way the dataset stays numpy and ``to_tf`` is a per-batch hand-off."""
+    if device == "cpu":
+        tf.config.set_visible_devices([], "GPU")
     model = build_model()
     opt = keras.optimizers.Adam(1e-3)
     for epoch in range(epochs):
@@ -91,7 +93,7 @@ def train(ds: InSituDataset, *, epochs: int) -> tuple[float, float]:
 def main() -> None:
     args = cli()
     ds = build_datasets(args)
-    model_rmse, persistence_rmse = train(ds, epochs=args.epochs)
+    model_rmse, persistence_rmse = train(ds, epochs=args.epochs, device=args.device)
     print(
         f"\n24 h forecast RMSE on held-out data: model {model_rmse:.3f}  vs  "
         f"persistence {persistence_rmse:.3f}  ({persistence_rmse / model_rmse:.1f}x better)"

--- a/examples/advection/train_tf.py
+++ b/examples/advection/train_tf.py
@@ -65,14 +65,14 @@ def _channels(batch: Batch) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
     return x, d["t2m"][..., None], d["target"][..., None]  # (B, H, W, 1) each
 
 
-def train(train_ds: InSituDataset, val_ds: InSituDataset, *, epochs: int) -> tuple[float, float]:
+def train(ds: InSituDataset, *, epochs: int) -> tuple[float, float]:
     """Train the CNN; return ``(model_rmse, persistence_rmse)`` -- 24 h forecast skill on val."""
     model = build_model()
     opt = keras.optimizers.Adam(1e-3)
     for epoch in range(epochs):
-        train_ds.set_epoch(epoch)
+        ds.set_epoch(epoch)
         last = 0.0
-        for batch in train_ds:
+        for batch in ds.train:
             x, persistence, target = _channels(batch)
             with tf.GradientTape() as tape:
                 loss = tf.reduce_mean((persistence + model(x, training=True) - target) ** 2)
@@ -85,13 +85,13 @@ def train(train_ds: InSituDataset, val_ds: InSituDataset, *, epochs: int) -> tup
         x, persistence, _ = _channels(batch)
         return (persistence + model(x)).numpy().transpose(0, 3, 1, 2)
 
-    return evaluate(val_ds, predict)
+    return evaluate(ds.val, predict)
 
 
 def main() -> None:
     args = cli()
-    train_ds, val_ds = build_datasets(args)
-    model_rmse, persistence_rmse = train(train_ds, val_ds, epochs=args.epochs)
+    ds = build_datasets(args)
+    model_rmse, persistence_rmse = train(ds, epochs=args.epochs)
     print(
         f"\n24 h forecast RMSE on held-out data: model {model_rmse:.3f}  vs  "
         f"persistence {persistence_rmse:.3f}  ({persistence_rmse / model_rmse:.1f}x better)"

--- a/examples/advection/train_tf.py
+++ b/examples/advection/train_tf.py
@@ -1,0 +1,102 @@
+"""Forecast t2m 24 h ahead with a tiny CNN, in **TensorFlow** (Keras), on one insitu dataset.
+
+    python -m examples.advection.train_tf          # synthetic advected field (offline)
+    python -m examples.advection.train_tf --wb2    # WeatherBench2 (real ERA5, gs://)
+
+Same shared, framework-neutral data layer as ``train_torch.py`` / ``train_jax.py`` -- the
+numpy ``Batch`` is handed to TF zero-copy via ``to_tf`` (DLPack). Only this file is TF. The
+model learns the **tendency** (the change on persistence); beating persistence means it
+learned the wind-driven advection. JAX/TF use channels-last (``B, H, W, C``).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import tensorflow as tf
+from tensorflow import keras
+
+from insitubatch.frameworks import to_tf
+from insitubatch.source import InSituDataset
+from insitubatch.types import Batch
+
+from .data import build_datasets, cli, evaluate
+
+
+class CircularConv(keras.layers.Layer):
+    """3x3 convolution with circular (periodic) padding -- the synthetic field wraps, and
+    it matches the torch/jax ``padding_mode="circular"`` so the three models are the same."""
+
+    def __init__(self, filters: int, **kw: object) -> None:
+        super().__init__(**kw)
+        self.conv = keras.layers.Conv2D(filters, 3, padding="valid")
+
+    def call(self, x: tf.Tensor) -> tf.Tensor:
+        x = tf.concat([x[:, -1:], x, x[:, :1]], axis=1)  # wrap rows
+        x = tf.concat([x[:, :, -1:], x, x[:, :, :1]], axis=2)  # wrap cols
+        return self.conv(x)
+
+
+def _standardize(z: tf.Tensor) -> tf.Tensor:
+    mean = tf.reduce_mean(z, axis=[0, 1, 2], keepdims=True)
+    std = tf.math.reduce_std(z, axis=[0, 1, 2], keepdims=True)
+    return (z - mean) / (std + 1e-6)
+
+
+def build_model(hidden: int = 32) -> keras.Model:
+    """3 input channels -> 1 channel tendency; four circular convs (receptive field 9)."""
+    return keras.Sequential(
+        [
+            keras.layers.Lambda(_standardize),
+            CircularConv(hidden),
+            keras.layers.ReLU(),
+            CircularConv(hidden),
+            keras.layers.ReLU(),
+            CircularConv(hidden),
+            keras.layers.ReLU(),
+            CircularConv(1),
+        ]
+    )
+
+
+def _channels(batch: Batch) -> tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
+    """``(x, persistence, target)`` as channels-last TF tensors, zero-copy via DLPack."""
+    d = to_tf(batch)  # {label: (B, H, W)}
+    x = tf.stack([d["t2m"], d["u10"], d["v10"]], axis=-1)  # (B, H, W, 3)
+    return x, d["t2m"][..., None], d["target"][..., None]  # (B, H, W, 1) each
+
+
+def train(train_ds: InSituDataset, val_ds: InSituDataset, *, epochs: int) -> tuple[float, float]:
+    """Train the CNN; return ``(model_rmse, persistence_rmse)`` -- 24 h forecast skill on val."""
+    model = build_model()
+    opt = keras.optimizers.Adam(1e-3)
+    for epoch in range(epochs):
+        train_ds.set_epoch(epoch)
+        last = 0.0
+        for batch in train_ds:
+            x, persistence, target = _channels(batch)
+            with tf.GradientTape() as tape:
+                loss = tf.reduce_mean((persistence + model(x, training=True) - target) ** 2)
+            grads = tape.gradient(loss, model.trainable_variables)
+            opt.apply_gradients(zip(grads, model.trainable_variables, strict=True))
+            last = float(loss)
+        print(f"epoch {epoch}  train mse {last:.4f}")
+
+    def predict(batch: Batch) -> np.ndarray:  # (B, 1, H, W) to match the shared eval
+        x, persistence, _ = _channels(batch)
+        return (persistence + model(x)).numpy().transpose(0, 3, 1, 2)
+
+    return evaluate(val_ds, predict)
+
+
+def main() -> None:
+    args = cli()
+    train_ds, val_ds = build_datasets(args)
+    model_rmse, persistence_rmse = train(train_ds, val_ds, epochs=args.epochs)
+    print(
+        f"\n24 h forecast RMSE on held-out data: model {model_rmse:.3f}  vs  "
+        f"persistence {persistence_rmse:.3f}  ({persistence_rmse / model_rmse:.1f}x better)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advection/train_torch.py
+++ b/examples/advection/train_torch.py
@@ -1,0 +1,91 @@
+"""Forecast t2m 24 h ahead with a tiny CNN, in **PyTorch**, on one insitu dataset.
+
+    python -m examples.advection.train_torch          # synthetic advected field (offline)
+    python -m examples.advection.train_torch --wb2    # WeatherBench2 (real ERA5, gs://)
+
+The data layer (``examples/advection/data.py``) is framework-neutral -- a numpy ``Batch``
+read in place from the store, inputs ``{t2m, u10, v10}@t`` and target ``t2m@(t+24h)`` as
+offset views of the same arrays, no reshard. Only this file is torch: ``to_torch`` is a
+zero-copy DLPack hand-off. ``train_jax.py`` / ``train_tf.py`` train the *same* model on
+the *same* dataset. The model learns the **tendency** (the change on top of persistence),
+so beating the persistence baseline means it learned the wind-driven advection.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from insitubatch.frameworks import to_torch
+from insitubatch.source import InSituDataset
+from insitubatch.types import Batch
+
+from .data import build_datasets, cli, evaluate
+
+
+class AdvectionCNN(nn.Module):
+    """3 input channels (t2m, u10, v10) -> 1 channel tendency. Inputs are standardized per
+    channel; the forecast is ``persistence + tendency`` (predict the change, not the field).
+    Four 3x3 circular convolutions -- receptive field 9 -- cover the ~5-cell displacement."""
+
+    def __init__(self, hidden: int = 32) -> None:
+        super().__init__()
+
+        def conv(i: int, o: int) -> nn.Conv2d:
+            return nn.Conv2d(i, o, 3, padding=1, padding_mode="circular")
+
+        self.net = nn.Sequential(
+            conv(3, hidden),
+            nn.ReLU(),
+            conv(hidden, hidden),
+            nn.ReLU(),
+            conv(hidden, hidden),
+            nn.ReLU(),
+            conv(hidden, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # x: (B, 3, H, W) -> tendency (B, 1, H, W)
+        xn = (x - x.mean((0, 2, 3), keepdim=True)) / (x.std((0, 2, 3), keepdim=True) + 1e-6)
+        return self.net(xn)
+
+
+def _forecast(model: AdvectionCNN, batch: Batch) -> torch.Tensor:
+    """t2m(t+24h) forecast for one batch: persistence + the model's predicted tendency."""
+    d = to_torch(batch)  # {label: (B, H, W) tensor}, zero-copy via DLPack
+    x = torch.stack([d["t2m"], d["u10"], d["v10"]], dim=1)  # (B, 3, H, W)
+    return d["t2m"][:, None] + model(x)  # (B, 1, H, W)
+
+
+def train(train_ds: InSituDataset, val_ds: InSituDataset, *, epochs: int) -> tuple[float, float]:
+    """Train the CNN; return ``(model_rmse, persistence_rmse)`` -- 24 h forecast skill on val."""
+    model = AdvectionCNN()
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    for epoch in range(epochs):
+        train_ds.set_epoch(epoch)
+        model.train()
+        last = 0.0
+        for batch in train_ds:
+            target = to_torch(batch)["target"][:, None]
+            loss = nn.functional.mse_loss(_forecast(model, batch), target)
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            last = loss.item()
+        print(f"epoch {epoch}  train mse {last:.4f}")
+    model.eval()
+    with torch.no_grad():
+        return evaluate(val_ds, lambda b: _forecast(model, b).detach().numpy())
+
+
+def main() -> None:
+    args = cli()
+    train_ds, val_ds = build_datasets(args)
+    model_rmse, persistence_rmse = train(train_ds, val_ds, epochs=args.epochs)
+    print(
+        f"\n24 h forecast RMSE on held-out data: model {model_rmse:.3f}  vs  "
+        f"persistence {persistence_rmse:.3f}  ({persistence_rmse / model_rmse:.1f}x better)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/advection/train_torch.py
+++ b/examples/advection/train_torch.py
@@ -56,15 +56,15 @@ def _forecast(model: AdvectionCNN, batch: Batch) -> torch.Tensor:
     return d["t2m"][:, None] + model(x)  # (B, 1, H, W)
 
 
-def train(train_ds: InSituDataset, val_ds: InSituDataset, *, epochs: int) -> tuple[float, float]:
+def train(ds: InSituDataset, *, epochs: int) -> tuple[float, float]:
     """Train the CNN; return ``(model_rmse, persistence_rmse)`` -- 24 h forecast skill on val."""
     model = AdvectionCNN()
     opt = torch.optim.Adam(model.parameters(), lr=1e-3)
     for epoch in range(epochs):
-        train_ds.set_epoch(epoch)
+        ds.set_epoch(epoch)
         model.train()
         last = 0.0
-        for batch in train_ds:
+        for batch in ds.train:
             target = to_torch(batch)["target"][:, None]
             loss = nn.functional.mse_loss(_forecast(model, batch), target)
             opt.zero_grad()
@@ -74,13 +74,13 @@ def train(train_ds: InSituDataset, val_ds: InSituDataset, *, epochs: int) -> tup
         print(f"epoch {epoch}  train mse {last:.4f}")
     model.eval()
     with torch.no_grad():
-        return evaluate(val_ds, lambda b: _forecast(model, b).detach().numpy())
+        return evaluate(ds.val, lambda b: _forecast(model, b).detach().numpy())
 
 
 def main() -> None:
     args = cli()
-    train_ds, val_ds = build_datasets(args)
-    model_rmse, persistence_rmse = train(train_ds, val_ds, epochs=args.epochs)
+    ds = build_datasets(args)
+    model_rmse, persistence_rmse = train(ds, epochs=args.epochs)
     print(
         f"\n24 h forecast RMSE on held-out data: model {model_rmse:.3f}  vs  "
         f"persistence {persistence_rmse:.3f}  ({persistence_rmse / model_rmse:.1f}x better)"

--- a/examples/advection/train_torch.py
+++ b/examples/advection/train_torch.py
@@ -1,14 +1,13 @@
 """Forecast t2m 24 h ahead with a tiny CNN, in **PyTorch**, on one insitu dataset.
 
-    python -m examples.advection.train_torch          # synthetic advected field (offline)
-    python -m examples.advection.train_torch --wb2    # WeatherBench2 (real ERA5, gs://)
+Only this file is torch: ``to_torch`` is a zero-copy DLPack hand-off and the train loop
+moves each batch to ``--device``. ``train_jax.py`` / ``train_tf.py`` train the *same* model
+on the *same* numpy ``Batch``. The model learns the **tendency** (the change on top of
+persistence), so beating persistence means it read the wind-driven advection.
 
-The data layer (``examples/advection/data.py``) is framework-neutral -- a numpy ``Batch``
-read in place from the store, inputs ``{t2m, u10, v10}@t`` and target ``t2m@(t+24h)`` as
-offset views of the same arrays, no reshard. Only this file is torch: ``to_torch`` is a
-zero-copy DLPack hand-off. ``train_jax.py`` / ``train_tf.py`` train the *same* model on
-the *same* dataset. The model learns the **tendency** (the change on top of persistence),
-so beating the persistence baseline means it learned the wind-driven advection.
+Sources (``--source``), the finite training window (``--sample-range``), GPU placement and
+the NVMe cache flags are documented in ``examples/README.md``; the framework-neutral data
+layer is ``examples/advection/data.py``.
 """
 
 from __future__ import annotations
@@ -49,24 +48,28 @@ class AdvectionCNN(nn.Module):
         return self.net(xn)
 
 
-def _forecast(model: AdvectionCNN, batch: Batch) -> torch.Tensor:
-    """t2m(t+24h) forecast for one batch: persistence + the model's predicted tendency."""
-    d = to_torch(batch)  # {label: (B, H, W) tensor}, zero-copy via DLPack
-    x = torch.stack([d["t2m"], d["u10"], d["v10"]], dim=1)  # (B, 3, H, W)
-    return d["t2m"][:, None] + model(x)  # (B, 1, H, W)
+def _forecast(model: AdvectionCNN, batch: Batch, device: torch.device) -> torch.Tensor:
+    """t2m(t+24h) forecast for one batch: persistence + the model's predicted tendency.
+
+    ``to_torch`` is a zero-copy DLPack hand-off on CPU; moving to ``device`` is the H2D
+    copy -- placement is the training loop's job, not the dataset's (it speaks numpy)."""
+    d = to_torch(batch)  # {label: (B, H, W) tensor}, CPU via DLPack
+    x = torch.stack([d["t2m"], d["u10"], d["v10"]], dim=1).to(device)  # (B, 3, H, W)
+    return d["t2m"][:, None].to(device) + model(x)  # (B, 1, H, W)
 
 
-def train(ds: InSituDataset, *, epochs: int) -> tuple[float, float]:
+def train(ds: InSituDataset, *, epochs: int, device: str = "cpu") -> tuple[float, float]:
     """Train the CNN; return ``(model_rmse, persistence_rmse)`` -- 24 h forecast skill on val."""
-    model = AdvectionCNN()
+    dev = torch.device(device)
+    model = AdvectionCNN().to(dev)
     opt = torch.optim.Adam(model.parameters(), lr=1e-3)
     for epoch in range(epochs):
         ds.set_epoch(epoch)
         model.train()
         last = 0.0
         for batch in ds.train:
-            target = to_torch(batch)["target"][:, None]
-            loss = nn.functional.mse_loss(_forecast(model, batch), target)
+            target = to_torch(batch)["target"][:, None].to(dev)
+            loss = nn.functional.mse_loss(_forecast(model, batch, dev), target)
             opt.zero_grad()
             loss.backward()
             opt.step()
@@ -74,13 +77,13 @@ def train(ds: InSituDataset, *, epochs: int) -> tuple[float, float]:
         print(f"epoch {epoch}  train mse {last:.4f}")
     model.eval()
     with torch.no_grad():
-        return evaluate(ds.val, lambda b: _forecast(model, b).detach().numpy())
+        return evaluate(ds.val, lambda b: _forecast(model, b, dev).detach().cpu().numpy())
 
 
 def main() -> None:
     args = cli()
     ds = build_datasets(args)
-    model_rmse, persistence_rmse = train(ds, epochs=args.epochs)
+    model_rmse, persistence_rmse = train(ds, epochs=args.epochs, device=args.device)
     print(
         f"\n24 h forecast RMSE on held-out data: model {model_rmse:.3f}  vs  "
         f"persistence {persistence_rmse:.3f}  ({persistence_rmse / model_rmse:.1f}x better)"

--- a/examples/fit_scaler.py
+++ b/examples/fit_scaler.py
@@ -34,7 +34,6 @@ import zarr
 
 from insitubatch import (
     Batch,
-    SplitName,
     ensure_local_dir,
     open_geometries,
     split_by_chunk,
@@ -73,7 +72,7 @@ def fit_over_loader(ds: InSituDataset) -> tuple[dict[str, StandardScaler], float
     scalers = {v: StandardScaler() for v in ds.variables}
     ds.set_epoch(0)
     n, t = 0, time.perf_counter()
-    for batch in ds:
+    for batch in ds.train:
         for v in ds.variables:
             scalers[v].partial_fit(batch.arrays[v].reshape(-1, 1))
         n += len(batch.sample_indices)
@@ -119,7 +118,6 @@ def run_demo(
         url,
         manifest,
         geometries=geoms,
-        split=SplitName.TRAIN,
         batch_size=16,
         block_chunks=4,
         shuffle=False,
@@ -144,7 +142,7 @@ def run_demo(
     ds.batch_transforms = (make_batch_scaler(scalers),)
     ds.set_epoch(1)
     means, stds, t = [], [], time.perf_counter()
-    for batch in ds:
+    for batch in ds.train:
         for v in ds.variables:
             means.append(float(batch.arrays[v].mean()))
             stds.append(float(batch.arrays[v].std()))

--- a/examples/wb2_arraylake.py
+++ b/examples/wb2_arraylake.py
@@ -149,7 +149,6 @@ def run(
         store,
         manifest,
         geometries={qual: geom},
-        split=SplitName.TRAIN,
         batch_size=batch_size,
         block_chunks=block_chunks,
         prefetch_depth=prefetch_depth,
@@ -168,7 +167,7 @@ def run(
     for epoch in range(num_epochs):
         ds.set_epoch(epoch)
         t_prev = time.perf_counter()
-        for i, batch in enumerate(ds):
+        for i, batch in enumerate(ds.train):
             now = time.perf_counter()
             waits.append(now - t_prev)
             a = batch.arrays[qual]

--- a/examples/wb2_dataloader.py
+++ b/examples/wb2_dataloader.py
@@ -7,15 +7,16 @@ What differs:
 - **Storage is obstore.** Pass any zarr ``--url`` (e.g. an S3 ERA5 store); reads
   go through ``store_from_url`` (so ``--request-payer`` works for Requester-Pays).
 - **Parallelism is in the event loop, not workers.** There is no ``num_workers``
-  knob — insitubatch fans out IO on its async loop and prefetches; that's the
-  point of the comparison.
+  knob — insitubatch fans out IO on its async loop and prefetches; a different
+  parallelism model for the same batches.
 - **A spatial subregion is extracted with a ``batch_transform``** (random crop per
   sample), to echo the demo's patches.
 
-**v1 limitation vs the demo:** the demo samples 48x48 patches over *3 timesteps*.
-insitubatch v1 samples one timestep per sample (the outer axis); a multi-timestep
-window crosses chunk boundaries and is not supported yet. So each sample here is a
-single-timestep field cropped to a spatial subregion.
+**Multi-timestep windows:** the demo samples 48x48 patches over *3 timesteps*. That
+windowed, multi-offset access is now supported — declare each timestep as an offset view
+(``g``, ``g.shift(1)``, …); see ``examples/advection/`` for an input@t / target@t+h
+forecast. This script keeps a single-timestep spatial crop to isolate the storage +
+parallelism comparison.
 
     uv run python -m examples.wb2_dataloader --wb2 --max-batches 100   # public WeatherBench2 GCS
     uv run python -m examples.wb2_dataloader --wb2 --num-epochs 2 --cache-resident  # decode-once
@@ -24,8 +25,8 @@ single-timestep field cropped to a spatial subregion.
         --batch-size 32 --train-step-ms 10 --request-payer
     uv run python -m examples.wb2_dataloader            # tiny synthetic data, no network
 
-Compare the worker-process stack (and how to cut its startup) in
-``examples/wb2_xbatcher.py``.
+The companion ``examples/wb2_xbatcher.py`` runs the same task on Earthmover's xbatcher +
+DataLoader stack (and shows how to cut its startup cost).
 """
 
 from __future__ import annotations

--- a/examples/wb2_dataloader.py
+++ b/examples/wb2_dataloader.py
@@ -136,7 +136,6 @@ def run_demo(
         url,
         manifest,
         geometries={var: geom},
-        split=SplitName.TRAIN,
         batch_size=batch_size,
         block_chunks=block_chunks,
         prefetch_depth=prefetch_depth,
@@ -155,7 +154,7 @@ def run_demo(
     for epoch in range(num_epochs):
         ds.set_epoch(epoch)
         t_prev = time.perf_counter()
-        for i, batch in enumerate(ds):
+        for i, batch in enumerate(ds.train):
             now = time.perf_counter()
             waits.append(now - t_prev)
             a = batch.arrays[var]

--- a/examples/wb2_xbatcher.py
+++ b/examples/wb2_xbatcher.py
@@ -1,11 +1,14 @@
-"""The Earthmover ``dataloader-demo`` stack — xbatcher + torch DataLoader — with a
-focus on **cold-start latency** and how to kill it.
+"""Earthmover's ``dataloader-demo`` stack — xbatcher + torch DataLoader — with a
+focus on **cold-start latency** and how to cut it.
 
-This is the worker-process baseline that insitubatch replaces (see
-``examples/wb2_dataloader.py`` for the single-event-loop version). It loads an
-ERA5-style zarr with ``xarray`` + ``xbatcher`` and feeds a torch ``DataLoader``
-with ``num_workers`` worker processes, exactly as the community demo does:
-https://github.com/earth-mover/dataloader-demo
+xbatcher (from the Earthmover / pangeo community) is the domain-standard way to *define*
+ndim batches; this runs their published demo as-is — ``xarray`` + ``xbatcher`` for the
+batch definition, fed to a torch ``DataLoader`` with ``num_workers`` worker processes
+(https://github.com/earth-mover/dataloader-demo) — and uses it to study where the
+worker-process model spends startup time (useful whichever loader you ship). The
+companion ``examples/wb2_dataloader.py`` runs the *same task* on insitubatch's
+single-event-loop engine; the two are complementary engines for the same problem, and
+pairing them makes the cold-start trade-off concrete.
 
 **Why this script exists: inference startup.** Training amortizes worker spin-up
 over many epochs, so it barely shows. Inference usually does *not* — you make one
@@ -26,8 +29,10 @@ real cost, and the worker start method is the lever:
   attached to a different loop`` (obstore deadlocks instead). ``--mp fork`` still
   lets you reproduce the failure on purpose.
 
-insitubatch pays none of this: one in-process event loop, no fork, nothing to
-relaunch. That contrast is the point.
+insitubatch's single in-process event loop sidesteps this entirely — no fork, nothing
+to relaunch — so it starts fast from cold; this script exists to make the trade-off
+visible (and to show how ``forkserver-preload`` already cuts the worker-stack TTFB a
+lot) so you can pick what fits your workload.
 
     uv run python -m examples.wb2_xbatcher --wb2 --compare --max-batches 100  # teaching table
     uv run python -m examples.wb2_xbatcher --wb2 --max-batches 100  # one run, default regime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,10 @@ torch = [
 ]
 jax = [
     "jax>=0.4.30",
+    # flax + optax are the idiomatic JAX training stack the advection example uses; the
+    # bare `to_jax` DLPack adapter needs only jax itself.
+    "flax>=0.8",
+    "optax>=0.2",
 ]
 tf = [
     "tensorflow>=2.16",

--- a/src/insitubatch/__init__.py
+++ b/src/insitubatch/__init__.py
@@ -21,7 +21,7 @@ from .shuffle import (
     sequential_order,
     shuffle_quality,
 )
-from .split import SplitManifest, split_by_chunk
+from .split import SplitManifest, split_by_chunk, valid_anchor_range
 from .store import StoreLike, as_store, ensure_local_dir, open_geometries, store_from_url
 from .transforms import (
     BatchTransform,
@@ -63,4 +63,5 @@ __all__ = [
     "shuffle_quality",
     "split_by_chunk",
     "store_from_url",
+    "valid_anchor_range",
 ]

--- a/src/insitubatch/frameworks.py
+++ b/src/insitubatch/frameworks.py
@@ -62,12 +62,21 @@ def to_jax(batch: Batch) -> dict[str, Any]:
 
 
 def to_tf(batch: Batch) -> dict[str, Any]:
-    """Convert a numpy ``Batch`` to a dict of ``tf.Tensor`` (DLPack; zero-copy on CPU)."""
+    """Convert a numpy ``Batch`` to a dict of ``tf.Tensor`` (one CPU copy per variable).
+
+    Unlike torch/JAX -- whose array-accepting ``from_dlpack`` manages the exported buffer's
+    lifetime correctly -- TensorFlow only exposes the *experimental* ``from_dlpack(capsule)``,
+    which mishandles ownership of the exported numpy buffer: under the concurrent allocation
+    of the prefetch decode threads it double-frees that buffer and aborts the process
+    (SIGABRT, no message). ``convert_to_tensor`` copies into a TF-owned tensor instead, so TF
+    never touches insitu-managed memory; the batch is already an owned array, so this is a
+    single CPU copy. (torch/JAX stay zero-copy; this is a TF-DLPack limitation, not ours.)
+    """
     try:
         import tensorflow as tf
     except ImportError as exc:  # pragma: no cover - tf-less installs
         raise _missing("TensorFlow", "tf") from exc
-    return {k: tf.experimental.dlpack.from_dlpack(v.__dlpack__()) for k, v in batch.arrays.items()}
+    return {k: tf.convert_to_tensor(v) for k, v in batch.arrays.items()}
 
 
 def as_torch(view: _SplitView) -> IterableDataset:

--- a/src/insitubatch/frameworks.py
+++ b/src/insitubatch/frameworks.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
-from .source import InSituDataset
+from .source import _SplitView
 from .types import Batch
 
 if TYPE_CHECKING:  # annotations only; these are optional at runtime
@@ -70,11 +70,11 @@ def to_tf(batch: Batch) -> dict[str, Any]:
     return {k: tf.experimental.dlpack.from_dlpack(v.__dlpack__()) for k, v in batch.arrays.items()}
 
 
-def as_torch(ds: InSituDataset) -> IterableDataset:
-    """Wrap an :class:`InSituDataset` as a torch ``IterableDataset`` for ``DataLoader``.
+def as_torch(view: _SplitView) -> IterableDataset:
+    """Wrap a split view (e.g. ``ds.train``) as a torch ``IterableDataset`` for ``DataLoader``.
 
     Each yielded item is a ``dict[str, torch.Tensor]`` (via :func:`to_torch`). Use
-    ``DataLoader(as_torch(ds), batch_size=None, num_workers=0)``.
+    ``DataLoader(as_torch(ds.train), batch_size=None, num_workers=0)``.
     """
     try:
         from torch.utils.data import IterableDataset
@@ -82,20 +82,20 @@ def as_torch(ds: InSituDataset) -> IterableDataset:
         raise _missing("PyTorch", "torch") from exc
 
     class _TorchStream(IterableDataset):
-        def __init__(self, stream: InSituDataset) -> None:
+        def __init__(self, stream: _SplitView) -> None:
             self._stream = stream
 
         def __iter__(self) -> Iterator[dict[str, torch.Tensor]]:
             for batch in self._stream:
                 yield to_torch(batch)
 
-    return _TorchStream(ds)
+    return _TorchStream(view)
 
 
-def as_tf_dataset(ds: InSituDataset, *, prefetch: int = 2) -> tf.data.Dataset:
-    """Wrap an :class:`InSituDataset` as a ``tf.data.Dataset`` via ``from_generator``.
+def as_tf_dataset(view: _SplitView, *, prefetch: int = 2) -> tf.data.Dataset:
+    """Wrap a split view (e.g. ``ds.val``) as a ``tf.data.Dataset`` via ``from_generator``.
 
-    ``output_signature`` is inferred from the dataset's geometries: each variable is
+    ``output_signature`` is inferred from the view's geometries: each variable is
     ``(None, *inner)`` (None = the variable last-batch size) with the variable's dtype.
     Note ``from_generator`` *copies* into the TF runtime; for a zero-copy handoff call
     :func:`to_tf` on the raw stream instead.
@@ -107,11 +107,11 @@ def as_tf_dataset(ds: InSituDataset, *, prefetch: int = 2) -> tf.data.Dataset:
 
     signature = {
         name: tf.TensorSpec(shape=(None, *geom.inner_shape), dtype=geom.dtype)
-        for name, geom in ds.geometries.items()
+        for name, geom in view.geometries.items()
     }
 
     def gen() -> Iterator[dict[str, Any]]:
-        for batch in ds:
+        for batch in view:
             yield batch.arrays
 
     tfds = tf.data.Dataset.from_generator(gen, output_signature=signature)

--- a/src/insitubatch/plan.py
+++ b/src/insitubatch/plan.py
@@ -35,16 +35,17 @@ def build_stored_chunk_reads(
     first. Each outer chunk expands to its inner grid; every variable contributes
     its own grid (variables may chunk the inner dims differently). Order is
     ``chunk -> variable -> inner`` so a whole outer chunk's tiles are scheduled
-    together (it can be assembled and drained promptly). Dedup is
-    belt-and-suspenders -- a draw order visits each outer chunk once -- but makes
-    the function safe to call with repeated ids.
+    together (it can be assembled and drained promptly). Reads are keyed by the
+    array *path* (not the dict label), so several windowed views of one array
+    (same path, different ``offset``) collapse to a single fetch -- decode-once.
+    Dedup also makes the function safe to call with repeated ids.
     """
     reads: list[StoredChunkRead] = []
     seen: set[StoredChunkRead] = set()
     for cid in chunk_ids:
-        for name, geom in geometries.items():
+        for geom in geometries.values():
             for inner in geom.inner_coords():
-                read = StoredChunkRead(array=name, chunk_index=int(cid), inner_coord=inner)
+                read = StoredChunkRead(array=geom.path, chunk_index=int(cid), inner_coord=inner)
                 if read not in seen:
                     seen.add(read)
                     reads.append(read)

--- a/src/insitubatch/plan.py
+++ b/src/insitubatch/plan.py
@@ -39,14 +39,37 @@ def build_stored_chunk_reads(
     array *path* (not the dict label), so several windowed views of one array
     (same path, different ``offset``) collapse to a single fetch -- decode-once.
     Dedup also makes the function safe to call with repeated ids.
+
+    ``chunk_ids`` are *anchor* chunks. A windowed variable reads ``array[anchor +
+    offset]``, so its anchor chunk's samples map to one or two offset-shifted *read*
+    chunks; each is expanded here (clamped to the array, since edge anchors that would
+    read off the array are dropped from the draw upstream). With every ``offset == 0``
+    this is exactly ``anchor chunk -> itself``.
     """
     reads: list[StoredChunkRead] = []
     seen: set[StoredChunkRead] = set()
     for cid in chunk_ids:
         for geom in geometries.values():
-            for inner in geom.inner_coords():
-                read = StoredChunkRead(array=geom.path, chunk_index=int(cid), inner_coord=inner)
-                if read not in seen:
-                    seen.add(read)
-                    reads.append(read)
+            for read_cid in _read_chunks(geom, int(cid)):
+                for inner in geom.inner_coords():
+                    read = StoredChunkRead(geom.path, read_cid, inner)
+                    if read not in seen:
+                        seen.add(read)
+                        reads.append(read)
     return reads
+
+
+def _read_chunks(geom: ArrayGeometry, anchor_chunk: int) -> range:
+    """Offset-shifted read chunks an anchor chunk needs for ``geom`` (1-2, clamped).
+
+    The anchor samples ``[start, stop)`` of ``anchor_chunk`` read array samples
+    ``[start+offset, stop-1+offset]``; clamp to ``[0, n_samples)`` (edge anchors are
+    dropped from the draw) and return the half-open range of chunks they span.
+    """
+    spc = geom.sample_chunk_size
+    anchors = geom.samples_in_chunk(anchor_chunk)
+    lo = max(0, anchors.start + geom.offset)
+    hi = min(geom.n_samples - 1, anchors.stop - 1 + geom.offset)
+    if lo > hi:  # the whole anchor chunk reads off the array (edge); nothing to fetch
+        return range(0)
+    return range(lo // spc, hi // spc + 1)

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -71,6 +71,7 @@ class _Slot:
     nbytes: int  # slot size, charged to the budget (fixed at admit)
     ready: bool = False
     error: BaseException | None = None
+    claimed: bool = False  # the driver has referenced it *this epoch* (see wait_ready)
 
 
 class ChunkPool:
@@ -116,10 +117,12 @@ class ChunkPool:
             self._dir.mkdir(parents=True, exist_ok=True)
         self._budget = budget_bytes  # None => unbounded (never self-evicts)
         self._bytes = 0
-        # OrderedDict in recency order (LRU front -> MRU back); pinned keys are
-        # exempt from eviction.
+        # OrderedDict in recency order (LRU front -> MRU back). Eviction targets only
+        # a *ready, unreferenced* slot: a not-ready slot is an in-flight fetch, and a
+        # refcounted slot is held by a live block (windows let one chunk be read by
+        # several blocks at once, so pins are reference-counted, not a boolean).
         self._slots: OrderedDict[tuple[str, int], _Slot] = OrderedDict()
-        self._pinned: set[tuple[str, int]] = set()
+        self._pinned: dict[tuple[str, int], int] = {}  # key -> refcount (>0 == pinned)
         self._cv = threading.Condition(threading.Lock())
         self._error: BaseException | None = None  # global poison (driver death)
         self.max_resident = 0  # peak distinct outer chunk positions held at once
@@ -143,28 +146,34 @@ class ChunkPool:
     # -- admission / pinning / eviction -------------------------------------
 
     def try_admit(self, array: str, chunk_index: int) -> bool:
-        """Reserve + allocate + pin one outer chunk, evicting unpinned-LRU for room.
+        """Reserve + allocate + reference one outer-chunk slot, evicting ready-LRU for room.
 
-        Returns ``True`` once the slot exists and is pinned (idempotent if already
-        resident -- e.g. another variable's tile admitted this position). Returns
-        ``False`` only when the budget is full of *pinned* slots: the working set
-        exceeds the budget, so the caller must wait for the consumer to unpin one.
+        Admission takes one reference (incref) and *claims* the slot for this epoch (so
+        the consumer's :meth:`wait_ready` won't gather it until the driver has referenced
+        it -- see there), so the slot stays resident from its in-flight fetch through to
+        the consumer's release. The driver fetches each chunk once per epoch, so an
+        eviction before consume could not be re-fetched and would deadlock the waiter.
+        The consumer releases each chunk at its *last* use (:meth:`unpin_keys`); windowed
+        reads let one chunk be referenced by several blocks, hence reference counts, not a
+        boolean. Idempotent if already resident (incref only). Returns ``False`` only when
+        the budget is full of in-flight or referenced slots -- the caller awaits a release.
         """
         key = (array, chunk_index)
         geom = self._by_path[array]
         nbytes = int(np.prod(geom.slot_shape(chunk_index), dtype=np.int64)) * geom.dtype.itemsize
         with self._cv:
             if key in self._slots:
-                # Only reached on a miss (a ready chunk is taken by pin_if_ready), so
-                # any resident slot here is a stale partial left by a cancelled epoch
-                # -- drop it and rebuild fresh rather than reuse a half-filled buffer.
-                self._drop(key)
+                self._pin(key)  # already resident (in-flight or ready hit) -> incref, reuse
+                self._slots[key].claimed = True
+                self._cv.notify_all()  # a ready hit may now satisfy a waiter
+                return True
             if not self._make_room(nbytes):
                 return False
             self._slots[key] = _Slot(
                 data=self._alloc(array, chunk_index, geom.slot_shape(chunk_index), geom.dtype),
                 remaining=geom.n_inner_chunks(chunk_index),
                 nbytes=nbytes,
+                claimed=True,
             )
             self._bytes += nbytes
             self._pin(key)
@@ -178,62 +187,99 @@ class ChunkPool:
             return slot is not None and slot.ready and slot.error is None
 
     def pin_if_ready(self, array: str, chunk_index: int) -> bool:
-        """Atomically pin a resident, ready chunk (a cache hit) and touch its LRU.
+        """Incref + return ``True`` iff the chunk is resident, ready, and not failed.
 
-        Returns ``True`` on a hit (caller skips fetch+decode+transform), ``False``
-        if the chunk is absent or still assembling (a miss -> ``try_admit``). One
-        lock so the check and the pin can't race an eviction in between.
+        A cross-epoch cache hit the driver can skip fetching -- but it must still be
+        referenced so it stays resident through the consumer's use (released at last
+        use like an admitted chunk), else it could be evicted before the waiter gathers
+        it and, since the driver fetches each chunk once, deadlock. One lock so the
+        check and the incref cannot race an eviction in between.
         """
         with self._cv:
-            slot = self._slots.get((array, chunk_index))
+            key = (array, chunk_index)
+            slot = self._slots.get(key)
             if slot is not None and slot.ready and slot.error is None:
-                self._pin((array, chunk_index))
+                self._pin(key)
+                slot.claimed = True  # publish the claim so a waiter may now proceed
+                self._cv.notify_all()
                 return True
             return False
 
-    def unpin(self, chunk_ids: set[int]) -> None:
-        """Release the given drained outer chunks: now LRU-evictable, not yet dropped.
+    def pin_keys(self, keys: set[tuple[str, int]]) -> None:
+        """Reference (incref) a set of ``(path, chunk_index)`` slots for a live block.
 
-        Replaces eviction -- the pool decides *when* to drop (lazily, under budget
-        pressure), so unpinned chunks linger for cross-epoch reuse. Wakes any admit
-        parked on a full budget.
+        Windows make one chunk readable by several concurrent blocks, so pins are
+        reference-counted: each block that needs a slot increfs it on entry and
+        decrefs it on drain (:meth:`unpin_keys`). A slot with refcount > 0 is never
+        evicted. Pinning a not-yet-allocated key is fine -- the count is recorded and
+        the slot, once admitted, inherits it.
         """
         with self._cv:
-            for key in [k for k in self._slots if k[1] in chunk_ids]:
-                self._pinned.discard(key)
+            for key in keys:
+                self._pin(key)
+
+    def unpin_keys(self, keys: set[tuple[str, int]]) -> None:
+        """Release (decref) a block's ``(path, chunk_index)`` references.
+
+        A slot dropping to refcount 0 becomes LRU-evictable (retained for cross-epoch
+        reuse until budget pressure drops it), not dropped now. Wakes any admit parked
+        on a full budget.
+        """
+        with self._cv:
+            for key in keys:
+                self._unpin_one(key)
             self._cv.notify_all()
 
     def unpin_all(self) -> None:
-        """Release every pin (epoch boundary): all resident chunks become evictable.
+        """Epoch boundary reset: clear every pin and drop abandoned partials.
 
         A pin is per-epoch working state, not cache membership -- ready chunks stay
-        resident (unpinned) for cross-epoch reuse. No pin should survive an epoch: an
+        resident (unpinned) for cross-epoch reuse. No pin may survive an epoch: an
         aborted epoch (early ``break``) leaves its read-ahead and un-drained current
-        block pinned, which would shrink the next epoch's budget until ``try_admit``
-        can free no room and the driver deadlocks. Called at the next epoch's start,
-        when the prior scheduler is fully closed (no pin/unpin can race this).
+        block referenced, which would shrink the next epoch's budget until admission
+        can free no room and the driver deadlocks. A *not-ready* slot at this boundary
+        is an abandoned partial (its fetch was cancelled mid-flight) -- it can never be
+        a valid cache entry, so drop it; that also restores the in-epoch invariant
+        "not ready => in flight" that protects fetches from eviction. Called at the
+        next epoch's start, when the prior scheduler is fully closed (no race).
         """
         with self._cv:
             self._pinned.clear()
+            for key in [k for k, slot in self._slots.items() if not slot.ready]:
+                self._drop(key)
+            for slot in self._slots.values():
+                slot.claimed = False  # a retained chunk must be re-claimed next epoch
             self._cv.notify_all()
 
     def _pin(self, key: tuple[str, int]) -> None:  # call under the lock
-        self._pinned.add(key)
-        self._slots.move_to_end(key)  # MRU
+        self._pinned[key] = self._pinned.get(key, 0) + 1
+        if key in self._slots:
+            self._slots.move_to_end(key)  # MRU (the slot may not be allocated yet)
+
+    def _unpin_one(self, key: tuple[str, int]) -> None:  # call under the lock
+        n = self._pinned.get(key, 0)
+        if n <= 1:
+            self._pinned.pop(key, None)
+        else:
+            self._pinned[key] = n - 1
 
     def _make_room(self, nbytes: int) -> bool:  # call under the lock
         if self._budget is None:
             return True
         while self._bytes + nbytes > self._budget:
-            victim = next((k for k in self._slots if k not in self._pinned), None)
-            if victim is None:  # everything resident is pinned -> no room
+            # Evict the LRU slot that is ready *and* unreferenced; a not-ready slot is
+            # an in-flight fetch and a refcounted slot is held by a live block.
+            victim = next(
+                (k for k, s in self._slots.items() if k not in self._pinned and s.ready), None
+            )
+            if victim is None:  # everything resident is in-flight or pinned -> no room
                 return False
             self._drop(victim)
         return True
 
     def _drop(self, key: tuple[str, int]) -> None:  # call under the lock
         slot = self._slots.pop(key)
-        self._pinned.discard(key)  # no stale pin if dropping a (rare) pinned partial
+        self._pinned.pop(key, None)  # no stale refcount if dropping a (rare) pinned partial
         self._bytes -= slot.nbytes
         self._free(slot)
 
@@ -328,17 +374,24 @@ class ChunkPool:
     # -- consume: wait / gather ---------------------------------------------
 
     def wait_ready(self, array: str, chunk_index: int) -> None:
-        """Block until the outer chunk is fully assembled (or raise its error).
+        """Block until the outer chunk is assembled *and claimed this epoch* (or raise).
 
-        Wakes on three conditions: the chunk is ready, the chunk failed
-        (:meth:`fail`), or the whole pool was poisoned (:meth:`set_error`) -- the
-        last covers a driver death before this chunk was even allocated, so a
-        consumer never waits forever on a chunk that will never arrive.
+        Waiting on ``claimed`` (set by the driver's admit / pin_if_ready) closes a
+        cross-epoch race: a chunk still resident-and-ready from the prior epoch would
+        otherwise be gathered before the driver references it, letting the consumer's
+        last-use release land before the driver's pin -- a lost release that leaks a
+        reference (and, worse, lets the driver evict a chunk mid-gather). Requiring the
+        claim orders pin-before-consume-before-release. Wakes on: ready+claimed, the
+        chunk failed (:meth:`fail`), or the pool was poisoned (:meth:`set_error`, covering
+        a driver death before this chunk was allocated).
         """
         key = (array, chunk_index)
         with self._cv:
             self._cv.wait_for(
-                lambda: self._error is not None or (key in self._slots and self._slots[key].ready)
+                lambda: (
+                    self._error is not None
+                    or (key in self._slots and self._slots[key].ready and self._slots[key].claimed)
+                )
             )
             if self._error is not None:
                 raise self._error
@@ -347,29 +400,32 @@ class ChunkPool:
             raise error
 
     def gather(self, rows: np.ndarray, variables: list[str], sample_chunk_size: int) -> Batch:
-        """Assemble one batch from ``[chunk_id, within]`` draw rows.
+        """Assemble one batch from ``[chunk_id, within]`` *anchor* draw rows.
 
-        Caller must have waited for every referenced outer chunk to be ready.
-        Draws are grouped by chunk so each slot is touched once (one coalesced
-        fancy-index, never a Python per-sample loop); ``data`` and ``sample_indices``
-        come out in the same grouped order, so row ``i`` of every variable refers to
-        the same sample.
+        Each row is one sample anchor ``t = chunk_id*spc + within``; each variable
+        reads its array at ``t + offset`` (offset 0 is the plain non-windowed case).
+        Output is in anchor-row order: row ``i`` of every variable is the same anchor,
+        ``sample_indices[i] == t_i``. Per variable the reads are grouped by the
+        variable's *own* (offset-shifted) chunk -- one coalesced fancy-index per chunk,
+        never a Python per-sample loop. The caller must have waited every referenced
+        ``(path, offset-shifted chunk)`` ready.
         """
-        chunk_ids = rows[:, 0]
-        within = rows[:, 1]
-        uniq = np.unique(chunk_ids)
+        spc = sample_chunk_size
+        anchor = rows[:, 0].astype(np.int64) * spc + rows[:, 1].astype(np.int64)  # (N,)
+        n = anchor.shape[0]
 
-        out: dict[str, list[np.ndarray]] = {v: [] for v in variables}
-        names = {v: self._geom[v].path for v in variables}  # label -> underlying array
-        idx_pieces: list[np.ndarray] = []
-        for cid in uniq:
-            w = within[chunk_ids == cid]
-            idx_pieces.append(cid * sample_chunk_size + w)
-            for var in variables:
-                out[var].append(self._slots[(names[var], int(cid))].data[w])
-
-        arrays = {var: np.concatenate(pieces, axis=0) for var, pieces in out.items()}
-        return Batch(arrays=arrays, sample_indices=np.concatenate(idx_pieces))
+        arrays: dict[str, np.ndarray] = {}
+        for var in variables:
+            geom = self._geom[var]
+            sample = anchor + geom.offset  # this view reads array[anchor + offset]
+            read_cid = sample // spc
+            within = sample % spc
+            out = np.empty((n, *geom.inner_shape), dtype=geom.dtype)
+            for cid in np.unique(read_cid):
+                mask = read_cid == cid  # rows that read this chunk -> one coalesced index
+                out[mask] = self._slots[(geom.path, int(cid))].data[within[mask]]
+            arrays[var] = out
+        return Batch(arrays=arrays, sample_indices=anchor)
 
     def _free(self, slot: _Slot) -> None:
         """Release a slot's backing: a no-op for heap, flush+close+unlink for mmap.

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -101,10 +101,10 @@ class ChunkPool:
         budget_bytes: int | None = None,
     ) -> None:
         self._geom = geometries  # label -> geometry (a label is one (array, offset) view)
-        # Slots are keyed by the underlying array *name*, not the variable label, so two
+        # Slots are keyed by the underlying array *path*, not the variable label, so two
         # views of one array (e.g. t2m_now / t2m_next) share a single decode. One
-        # representative geometry per name suffices for slot sizing (aliases share shape).
-        self._by_name = {g.name: g for g in geometries.values()}
+        # representative geometry per path suffices for slot sizing (aliases share shape).
+        self._by_path = {g.path: g for g in geometries.values()}
         self._chunk_transforms = tuple(chunk_transforms)
         # backing: heap (np.empty) or mmap'd .npy under backing_dir (point at NVMe).
         # The scatter writes straight into the slot either way; mmap keeps the working
@@ -151,7 +151,7 @@ class ChunkPool:
         exceeds the budget, so the caller must wait for the consumer to unpin one.
         """
         key = (array, chunk_index)
-        geom = self._by_name[array]
+        geom = self._by_path[array]
         nbytes = int(np.prod(geom.slot_shape(chunk_index), dtype=np.int64)) * geom.dtype.itemsize
         with self._cv:
             if key in self._slots:
@@ -257,7 +257,7 @@ class ChunkPool:
         """
         key = (array, chunk_index)
         slot = self._slots[key]  # allocated by the scheduler before any scatter
-        dst, src = self._by_name[array].tile_placement(chunk_index, inner_coord)
+        dst, src = self._by_path[array].tile_placement(chunk_index, inner_coord)
         slot.data[dst] = tile[src]  # disjoint, fixed-shape: lock-free (rule 1)
 
         with self._cv:
@@ -319,7 +319,7 @@ class ChunkPool:
     def _apply_transforms(self, array: str, chunk_index: int, data: np.ndarray) -> np.ndarray:
         if not self._chunk_transforms:
             return data
-        offset = chunk_index * self._by_name[array].sample_chunk_size
+        offset = chunk_index * self._by_path[array].sample_chunk_size
         chunk = DecodedChunk(read=ChunkRead(array, chunk_index), data=data, sample_offset=offset)
         for transform in self._chunk_transforms:  # vectorized numpy -> GIL released
             chunk = transform(chunk)
@@ -360,7 +360,7 @@ class ChunkPool:
         uniq = np.unique(chunk_ids)
 
         out: dict[str, list[np.ndarray]] = {v: [] for v in variables}
-        names = {v: self._geom[v].name for v in variables}  # label -> underlying array
+        names = {v: self._geom[v].path for v in variables}  # label -> underlying array
         idx_pieces: list[np.ndarray] = []
         for cid in uniq:
             w = within[chunk_ids == cid]

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -100,7 +100,11 @@ class ChunkPool:
         backing_dir: str | Path | None = None,
         budget_bytes: int | None = None,
     ) -> None:
-        self._geom = geometries
+        self._geom = geometries  # label -> geometry (a label is one (array, offset) view)
+        # Slots are keyed by the underlying array *name*, not the variable label, so two
+        # views of one array (e.g. t2m_now / t2m_next) share a single decode. One
+        # representative geometry per name suffices for slot sizing (aliases share shape).
+        self._by_name = {g.name: g for g in geometries.values()}
         self._chunk_transforms = tuple(chunk_transforms)
         # backing: heap (np.empty) or mmap'd .npy under backing_dir (point at NVMe).
         # The scatter writes straight into the slot either way; mmap keeps the working
@@ -147,7 +151,7 @@ class ChunkPool:
         exceeds the budget, so the caller must wait for the consumer to unpin one.
         """
         key = (array, chunk_index)
-        geom = self._geom[array]
+        geom = self._by_name[array]
         nbytes = int(np.prod(geom.slot_shape(chunk_index), dtype=np.int64)) * geom.dtype.itemsize
         with self._cv:
             if key in self._slots:
@@ -253,7 +257,7 @@ class ChunkPool:
         """
         key = (array, chunk_index)
         slot = self._slots[key]  # allocated by the scheduler before any scatter
-        dst, src = self._geom[array].tile_placement(chunk_index, inner_coord)
+        dst, src = self._by_name[array].tile_placement(chunk_index, inner_coord)
         slot.data[dst] = tile[src]  # disjoint, fixed-shape: lock-free (rule 1)
 
         with self._cv:
@@ -315,7 +319,7 @@ class ChunkPool:
     def _apply_transforms(self, array: str, chunk_index: int, data: np.ndarray) -> np.ndarray:
         if not self._chunk_transforms:
             return data
-        offset = chunk_index * self._geom[array].sample_chunk_size
+        offset = chunk_index * self._by_name[array].sample_chunk_size
         chunk = DecodedChunk(read=ChunkRead(array, chunk_index), data=data, sample_offset=offset)
         for transform in self._chunk_transforms:  # vectorized numpy -> GIL released
             chunk = transform(chunk)
@@ -356,12 +360,13 @@ class ChunkPool:
         uniq = np.unique(chunk_ids)
 
         out: dict[str, list[np.ndarray]] = {v: [] for v in variables}
+        names = {v: self._geom[v].name for v in variables}  # label -> underlying array
         idx_pieces: list[np.ndarray] = []
         for cid in uniq:
             w = within[chunk_ids == cid]
             idx_pieces.append(cid * sample_chunk_size + w)
             for var in variables:
-                out[var].append(self._slots[(var, int(cid))].data[w])
+                out[var].append(self._slots[(names[var], int(cid))].data[w])
 
         arrays = {var: np.concatenate(pieces, axis=0) for var, pieces in out.items()}
         return Batch(arrays=arrays, sample_indices=np.concatenate(idx_pieces))

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -425,7 +425,8 @@ class ChunkPool:
                 mask = read_cid == cid  # rows that read this chunk -> one coalesced index
                 out[mask] = self._slots[(geom.path, int(cid))].data[within[mask]]
             arrays[var] = out
-        return Batch(arrays=arrays, sample_indices=anchor)
+        offsets = {var: self._geom[var].offset for var in variables}
+        return Batch(arrays=arrays, sample_indices=anchor, offsets=offsets)
 
     def _free(self, slot: _Slot) -> None:
         """Release a slot's backing: a no-op for heap, flush+close+unlink for mmap.

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -276,8 +276,12 @@ class Scheduler:
             if self._arrays:
                 return
             store = as_store(self._store, **self._store_kwargs)  # type: ignore[arg-type]
-            for name, geom in self._geometries.items():
-                aa = await za.open_array(store=store, path=name, mode="r")
+            # Open each distinct array once, keyed by its zarr path: several windowed
+            # views (same path, different offset) share one open + one decode path.
+            for geom in self._geometries.values():
+                if geom.path in self._arrays:
+                    continue
+                aa = await za.open_array(store=store, path=geom.path, mode="r")
                 # Format-agnostic: zarr-v2 metadata exposes `dtype`/`encode_chunk_key`
                 # where v3 has `data_type`/`chunk_key_encoding.encode_chunk_key` -- so the
                 # engine reads public v2 stores (WeatherBench2 ARCO) as well as v3.
@@ -290,7 +294,7 @@ class Scheduler:
                     config=aa.config,
                     prototype=self._proto,
                 )
-                self._arrays[name] = _ArrayCtx(
+                self._arrays[geom.path] = _ArrayCtx(
                     path=aa.store_path.path,
                     store=aa.store_path.store,
                     encode=meta.encode_chunk_key,

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -16,16 +16,18 @@ Two bounded resources, deliberately distinct:
 * **in-flight** (``max_inflight``, an ``asyncio.Semaphore``) -- tiles in flight; a
   slot is held from fetch-start to scatter-done, spanning fetch + decode + scatter.
 * **residency** (the pool's byte budget) -- admission (``pool.try_admit``) evicts
-  unpinned-LRU to make room and *pins* the chunk; when the working set fills the
-  budget (everything resident is pinned) the loop awaits a consumer ``unpin``. So
-  the number of outstanding fetch tasks is bounded by the resident window, not by
-  the epoch length.
+  ready-and-unreferenced LRU to make room and *references* (refcounted pin) the chunk,
+  so it stays resident from in-flight fetch through to the consumer's release; when the
+  budget is full of referenced slots the loop awaits a consumer release. So the number
+  of outstanding fetch tasks is bounded by the resident window, not by the epoch length.
 
-Per chunk the scheduler first asks the pool whether it already holds it
+Per chunk the scheduler first asks the pool whether it already holds it ready
 (``pin_if_ready``): a still-resident prepped chunk is a hit and costs no fetch
 (cross-epoch reuse, since the pool persists across epochs). Misses are admitted and
-their tiles fetched. The consumer waits on slot readiness, gathers, and
-:meth:`unpin`\\s drained chunks. Errors propagate two ways -- a per-tile
+their tiles fetched. The consumer waits on slot readiness, gathers, and releases each
+chunk at its *last* use (:meth:`unpin_block`) -- windowed reads let one chunk feed
+several blocks, so it is released only when no later block needs it. Errors propagate
+two ways -- a per-tile
 fetch/decode failure poisons just that chunk (``pool.fail``); a driver failure
 poisons the whole pool (``pool.set_error``) so any waiter re-raises instead of
 hanging.
@@ -209,10 +211,11 @@ class Scheduler:
         fut.add_done_callback(self._on_drive_done)
         return fut
 
-    def unpin(self, chunk_ids: set[int]) -> None:
-        """Release drained outer chunks (thread-safe): now LRU-evictable, and wake
-        any admit parked on a full budget so it can evict them and proceed."""
-        self.pool.unpin(chunk_ids)
+    def unpin_block(self, keys: set[tuple[str, int]]) -> None:
+        """Release references on a set of drained ``(path, chunk_index)`` slots
+        (thread-safe): the slots that hit refcount 0 become LRU-evictable; wake any
+        admit parked on a full budget so it can evict them and proceed."""
+        self.pool.unpin_keys(keys)
         if self._capacity is not None:
             self._loop.call_soon_threadsafe(self._capacity.set)
 
@@ -230,9 +233,11 @@ class Scheduler:
 
     async def _drive(self, reads: list[StoredChunkRead]) -> None:
         await self._ensure_arrays()
-        # Per (var, chunk): decided[k] = True if it was a cache hit (skip its tiles),
+        # Per (path, chunk): decided[k] = True if it was a cache hit (skip its tiles),
         # False if a miss we admitted (fetch its tiles). reads are chunk-major so a
-        # (var, chunk) is first-seen on its first tile.
+        # (path, chunk) is first-seen on its first tile. Residency is held by the
+        # consumer's per-block pins, not here -- admission only allocates the slot, and
+        # a not-ready (in-flight) slot is eviction-protected until its fetch completes.
         decided: dict[tuple[str, int], bool] = {}
         tasks: list[asyncio.Task] = []
         try:

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -37,7 +37,7 @@ import numpy as np
 from .pool import ChunkPool
 from .scheduler import Scheduler, SchedulerConfig
 from .shuffle import block_shuffled_order, sequential_order
-from .split import SplitManifest
+from .split import SplitManifest, valid_anchor_range
 from .store import StoreLike, open_geometries
 from .types import ArrayGeometry, Batch, DecodedChunk, SplitName, StoredChunkRead
 
@@ -142,11 +142,32 @@ class InSituDataset:
         # variables, must be co-resident (a batch draws across a whole block) -- and
         # a larger budget (cache_budget_bytes) retains drained chunks for cross-epoch
         # decode-once reuse. cache_dir spills slots to NVMe (mmap) instead of heap.
-        per_chunk_all_vars = sum(
-            g.sample_chunk_size * int(np.prod(g.inner_shape)) * g.dtype.itemsize
-            for g in self.geometries.values()
+        #
+        # Windows widen the floor. A windowed read (any nonzero offset) crosses a chunk
+        # boundary, so an anchor chunk's read-union spans up to 2 + ceil(span/spc)
+        # chunks per variable (span = max offset - min offset); with every offset 0 the
+        # factor is 1 -- the plain 2 * block_chunks working set.
+        spc0 = next(iter(self.geometries.values())).sample_chunk_size
+        offsets = [g.offset for g in self.geometries.values()]
+        span = max(offsets) - min(offsets)
+        windowed = any(o != 0 for o in offsets)
+        window_factor = 2 + (-(-span // spc0)) if windowed else 1  # 2 + ceil(span/spc)
+        per_chunk_all_vars = int(
+            sum(
+                g.sample_chunk_size * int(np.prod(g.inner_shape)) * g.dtype.itemsize
+                for g in self.geometries.values()
+            )
         )
-        working_set = 2 * block_chunks * int(per_chunk_all_vars)
+        working_set = 2 * block_chunks * window_factor * per_chunk_all_vars
+        if windowed and self.shuffle:
+            # Shuffle permutes chunk order, so a windowed read can spill into chunks
+            # owned by any other block: a chunk admitted early may be needed late. Until
+            # bounded residency (re-fetch the spill) lands, hold the whole split resident
+            # -- decode-once, the accepted memory cost of windows (spill to NVMe via
+            # cache_dir on large splits). Sequential (eval) windows spill only locally
+            # and keep the tight working set above.
+            n_split_chunks = len(self.manifest.chunks[self.split.value])
+            working_set = max(working_set, n_split_chunks * per_chunk_all_vars)
         self.cache_budget_bytes = max(int(cache_budget_bytes or 0), working_set)
         self._pool = ChunkPool(
             self.geometries,
@@ -173,7 +194,7 @@ class InSituDataset:
         chunk_ids = np.asarray(self.manifest.chunks[self.split.value], dtype=np.int64)
         spc = geom.sample_chunk_size
         if self.shuffle:
-            return block_shuffled_order(
+            order = block_shuffled_order(
                 chunk_ids,
                 spc,
                 geom.n_samples,
@@ -181,7 +202,32 @@ class InSituDataset:
                 seed=self.seed,
                 epoch=self._epoch,
             )
-        return sequential_order(chunk_ids, spc, geom.n_samples)
+        else:
+            order = sequential_order(chunk_ids, spc, geom.n_samples)
+        return self._drop_edge_anchors(order, spc, geom.n_samples)
+
+    def _drop_edge_anchors(self, order: np.ndarray, spc: int, n_samples: int) -> np.ndarray:
+        """Keep only anchors whose every windowed read ``anchor + offset`` is on the
+        array. Offset 0 (no window) keeps the whole order. Anchors are dropped, not
+        their chunks, so an edge chunk still contributes its interior anchors."""
+        offsets = [g.offset for g in self.geometries.values()]
+        lo, hi = valid_anchor_range(offsets, n_samples)
+        if lo == 0 and hi == n_samples:
+            return order
+        anchor = order[:, 0] * spc + order[:, 1]
+        return order[(anchor >= lo) & (anchor < hi)]
+
+    def _block_read_keys(self, block_rows: np.ndarray, spc: int) -> set[tuple[str, int]]:
+        """The ``(path, chunk)`` slots a block's anchors read across all variables --
+        the residency set to pin while draining it. A windowed variable reads
+        ``anchor + offset``, so its read chunks may spill into neighbouring blocks'
+        chunks; the refcounted pins let those shared chunks be held by both blocks."""
+        anchor = block_rows[:, 0].astype(np.int64) * spc + block_rows[:, 1].astype(np.int64)
+        keys: set[tuple[str, int]] = set()
+        for geom in self.geometries.values():
+            read_cid = (anchor + geom.offset) // spc
+            keys.update((geom.path, int(c)) for c in np.unique(read_cid))
+        return keys
 
     def __iter__(self) -> Iterator[Batch]:
         """Drain assembled batches from a background producer (prefetch).
@@ -211,17 +257,30 @@ class InSituDataset:
         out_q: queue.Queue = queue.Queue(maxsize=self.prefetch_depth)
         stop = threading.Event()
 
+        # Per-block read-union keys (path, chunk) -- what each block reads across all
+        # variables' offsets. A windowed read can spill into chunks owned by any other
+        # block (shuffle permutes chunk order), and the driver fetches each chunk only
+        # once, so a chunk must stay resident from admit until its *last* referencing
+        # block drains. Release each chunk exactly there (last_use).
+        block_keys = [self._block_read_keys(order[rs:re], spc) for rs, re, _ in blocks]
+        release: list[set[tuple[str, int]]] = [set() for _ in blocks]
+        last_use: dict[tuple[str, int], int] = {}
+        for bi, keys in enumerate(block_keys):
+            for key in keys:
+                last_use[key] = bi  # later block overwrites -> ends on the max index
+        for key, bi in last_use.items():
+            release[bi].add(key)
+
         def produce(sched: Scheduler) -> None:
             bs = self.batch_size
             try:
                 sched.start(ordered_chunks)
-                for rstart, rstop, block_cids in blocks:
-                    block = [int(c) for c in block_cids]
-                    # A block's batches draw across all its chunks, so wait the whole
-                    # block assembled before gathering (each wait is cheap once ready).
-                    for cid in block:
-                        for var in self.variables:
-                            sched.pool.wait_ready(var, cid)
+                for bi, (rstart, rstop, _cids) in enumerate(blocks):
+                    # A block's batches draw across its whole read-union, so wait it all
+                    # assembled (and claimed by the driver -- see ChunkPool.wait_ready)
+                    # before gathering; each wait is cheap once ready.
+                    for path, cid in block_keys[bi]:
+                        sched.pool.wait_ready(path, cid)
                     for start in range(rstart, rstop, bs):
                         if stop.is_set():
                             return
@@ -230,9 +289,11 @@ class InSituDataset:
                         for transform in self.batch_transforms:
                             batch = transform(batch)
                         out_q.put(batch)  # blocks when full -> backpressure
-                    # Release the block: now LRU-evictable (retained for reuse if the
-                    # budget allows), and unblocks admission of the next read-ahead.
-                    sched.unpin(set(block))
+                    # Release the driver's reference on chunks whose *last* use is this
+                    # block: now LRU-evictable (retained for reuse if budget allows),
+                    # unblocking the read-ahead. Chunks read again later keep their
+                    # reference until then.
+                    sched.unpin_block(release[bi])
             except Exception as exc:  # noqa: BLE001 - forwarded to the consumer
                 out_q.put(exc)
             finally:

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -72,13 +72,22 @@ def _partition_blocks(order: np.ndarray, block_chunks: int) -> list[tuple[int, i
 
 
 class InSituDataset:
-    """A framework-neutral iterable that streams shuffled numpy batches from Zarr.
+    """A framework-neutral source of shuffled numpy batches from Zarr, split-aware.
 
-    One epoch = permute the split's chunks -> walk shuffle-blocks -> for each
-    block, stream-fetch its stored chunks into the pool, gather coalesced batches,
-    evict the block. Iterating yields numpy :class:`Batch` objects; convert to a
-    framework with :mod:`insitubatch.frameworks` (``as_torch`` / ``to_jax`` /
-    ``as_tf_dataset``).
+    The dataset is *not* itself iterated -- you iterate one of its split views:
+    :attr:`train` (shuffled), :attr:`val`, :attr:`test`, :attr:`all` (deterministic).
+    All four share **one** :class:`ChunkPool`, so a chunk that two splits both read --
+    e.g. a windowed read spilling across a split boundary -- is decoded once::
+
+        ds = InSituDataset(store, manifest, geometries=geoms, batch_size=32)
+        for batch in ds.train: ...   # one epoch; ds.set_epoch(e) reshuffles
+        for batch in ds.val: ...
+
+    One epoch over a view = permute the split's chunks -> walk shuffle-blocks -> per
+    block, stream-fetch its stored chunks into the pool, gather coalesced batches, evict.
+    Batches are numpy :class:`Batch`; convert to a framework with
+    :mod:`insitubatch.frameworks` (``as_torch`` / ``to_jax`` / ``as_tf_dataset``). A
+    different per-split configuration (e.g. train-only augmentation) is a separate dataset.
     """
 
     def __init__(
@@ -86,7 +95,6 @@ class InSituDataset:
         store: StoreLike,
         manifest: SplitManifest,
         geometries: dict[str, ArrayGeometry] | None = None,
-        split: SplitName = SplitName.TRAIN,
         *,
         batch_size: int = 32,
         block_chunks: int = 16,
@@ -107,7 +115,6 @@ class InSituDataset:
             geometries if geometries is not None else open_geometries(store, **store_kwargs)
         )
         self.manifest = manifest
-        self.split = split
         self.variables = list(self.geometries)
 
         # Variables must share the sample axis (length + chunk size): the draw order
@@ -164,10 +171,10 @@ class InSituDataset:
             # owned by any other block: a chunk admitted early may be needed late. Until
             # bounded residency (re-fetch the spill) lands, hold the whole split resident
             # -- decode-once, the accepted memory cost of windows (spill to NVMe via
-            # cache_dir on large splits). Sequential (eval) windows spill only locally
-            # and keep the tight working set above.
-            n_split_chunks = len(self.manifest.chunks[self.split.value])
-            working_set = max(working_set, n_split_chunks * per_chunk_all_vars)
+            # cache_dir on large splits). Only `.train` shuffles (eval views are
+            # sequential and spill only locally), so size to the train split.
+            n_train_chunks = len(self.manifest.chunks[SplitName.TRAIN.value])
+            working_set = max(working_set, n_train_chunks * per_chunk_all_vars)
         self.cache_budget_bytes = max(int(cache_budget_bytes or 0), working_set)
         self._pool = ChunkPool(
             self.geometries,
@@ -187,13 +194,43 @@ class InSituDataset:
         """Call from the training loop so each epoch reshuffles deterministically."""
         self._epoch = epoch
 
+    # -- the splits, as iterables (one dataset, one shared pool) -------------
+
+    @property
+    def train(self) -> _SplitView:
+        """Iterable over the train split, shuffled per the dataset's ``shuffle`` flag."""
+        return _SplitView(self, SplitName.TRAIN, self.shuffle)
+
+    @property
+    def val(self) -> _SplitView:
+        """Iterable over the val split, in deterministic (sequential) order."""
+        return _SplitView(self, SplitName.VAL, False)
+
+    @property
+    def test(self) -> _SplitView:
+        """Iterable over the test split, in deterministic (sequential) order."""
+        return _SplitView(self, SplitName.TEST, False)
+
+    @property
+    def all(self) -> _SplitView:
+        """Iterable over every split's chunks (deterministic) -- e.g. full-archive inference."""
+        return _SplitView(self, None, False)
+
     _SENTINEL = object()
 
-    def _draw_order(self) -> np.ndarray:
+    def _chunk_ids(self, split: SplitName | None) -> np.ndarray:
+        """Sample-axis chunk indices for a split (``None`` = every split's chunks)."""
+        if split is None:
+            ids = sorted(set().union(*(set(self.manifest.chunks[s.value]) for s in SplitName)))
+        else:
+            ids = self.manifest.chunks[split.value]
+        return np.asarray(ids, dtype=np.int64)
+
+    def _draw_order(self, split: SplitName | None, shuffle: bool) -> np.ndarray:
         geom = self.geometries[self.variables[0]]
-        chunk_ids = np.asarray(self.manifest.chunks[self.split.value], dtype=np.int64)
+        chunk_ids = self._chunk_ids(split)
         spc = geom.sample_chunk_size
-        if self.shuffle:
+        if shuffle:
             order = block_shuffled_order(
                 chunk_ids,
                 spc,
@@ -229,22 +266,24 @@ class InSituDataset:
             keys.update((geom.path, int(c)) for c in np.unique(read_cid))
         return keys
 
-    def __iter__(self) -> Iterator[Batch]:
-        """Drain assembled batches from a background producer (prefetch).
+    def _iterate(self, split: SplitName | None, shuffle: bool) -> Iterator[Batch]:
+        """Drain assembled batches for one split from a background producer (prefetch).
 
-        A producer thread starts the scheduler over the epoch's chunks (in draw
-        order), then for each shuffle-block waits the block assembled, gathers its
-        batches, and unpins it; this consumer pops from a bounded queue (depth
-        ``prefetch_depth``) that provides backpressure and inter-batch overlap.
+        Called by the ``.train`` / ``.val`` / ``.test`` / ``.all`` views, all sharing the
+        one :class:`ChunkPool` -- so a chunk a windowed read pulls across a split boundary
+        is decoded once and reused by both splits.
 
-        The scheduler keeps ``max_inflight`` tiles continuously in flight and, while
-        the cache budget has room, fetches one block ahead, so block-boundary IO
-        overlaps the current block's per-batch compute instead of stalling. Chunks
-        skipped because the pool already holds them (cross-epoch hits) cost no fetch.
+        A producer thread starts the scheduler over the split's chunks (in draw order),
+        then for each shuffle-block waits the block assembled, gathers its batches, and
+        unpins it; this consumer pops from a bounded queue (depth ``prefetch_depth``) that
+        provides backpressure and inter-batch overlap. The scheduler keeps ``max_inflight``
+        tiles continuously in flight and fetches one block ahead, so block-boundary IO
+        overlaps the per-batch compute. Chunks the pool already holds (cross-epoch or
+        cross-split hits) cost no fetch.
         """
         geom = self.geometries[self.variables[0]]
         spc = geom.sample_chunk_size
-        order = self._draw_order()
+        order = self._draw_order(split, shuffle)
         blocks = _partition_blocks(order, self.block_chunks)
         ordered_chunks = [int(c) for _rstart, _rstop, cids in blocks for c in cids]
 
@@ -340,3 +379,24 @@ class InSituDataset:
     def __del__(self) -> None:
         with contextlib.suppress(Exception):  # best-effort on GC
             self._pool.close()
+
+
+class _SplitView:
+    """A lazy, re-iterable view of one split, returned by ``InSituDataset.train`` /
+    ``.val`` / ``.test`` / ``.all``. Iterating it streams that split's batches through the
+    dataset's *shared* pool, so a chunk two splits both read (a windowed read spilling
+    across a split boundary) is decoded once. Re-iterable: a fresh pass each ``iter()``.
+    ``geometries`` is exposed so the framework adapters can infer tensor shapes.
+    """
+
+    def __init__(self, dataset: InSituDataset, split: SplitName | None, shuffle: bool) -> None:
+        self._dataset = dataset
+        self._split = split
+        self._shuffle = shuffle
+
+    @property
+    def geometries(self) -> dict[str, ArrayGeometry]:
+        return self._dataset.geometries
+
+    def __iter__(self) -> Iterator[Batch]:
+        return self._dataset._iterate(self._split, self._shuffle)

--- a/src/insitubatch/split.py
+++ b/src/insitubatch/split.py
@@ -17,12 +17,31 @@ which split, so a run is reproducible and shareable.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import numpy as np
 
 from .types import ArrayGeometry, SplitName
+
+
+def valid_anchor_range(offsets: Iterable[int], n_samples: int) -> tuple[int, int]:
+    """Half-open ``[lo, hi)`` of anchor sample-indices whose *every* windowed read
+    ``anchor + offset`` stays in ``[0, n_samples)`` -- the anchors a windowed dataset
+    may draw, with array-edge anchors dropped.
+
+    Offsets ``{-1, 0, 1}`` over ``T`` samples -> anchors ``[1, T-1)``. Range is the
+    *only* validity the engine enforces; whether the user's offset choices define a
+    meaningful (non-leaky) task is theirs to decide (DESIGN, M-W). Empty/too-wide
+    windows return an empty range ``(lo, lo)``.
+    """
+    offs = list(offsets)
+    if not offs:
+        return (0, n_samples)
+    lo = max(0, -min(offs))
+    hi = n_samples - max(0, max(offs))
+    return (lo, max(lo, hi))
 
 
 @dataclass(slots=True)

--- a/src/insitubatch/store.py
+++ b/src/insitubatch/store.py
@@ -101,7 +101,7 @@ def open_geometries(
                 "open_geometries handles arrays (variables), not subgroups."
             )
         out[name] = ArrayGeometry(
-            name=name,
+            path=name,
             shape=tuple(arr.shape),
             chunks=tuple(arr.chunks),
             dtype=np.dtype(arr.dtype),

--- a/src/insitubatch/types.py
+++ b/src/insitubatch/types.py
@@ -34,7 +34,7 @@ class ArrayGeometry:
     and are kept contiguous to preserve partial zero-copy.
     """
 
-    name: str
+    path: str  # the array's zarr path within the store, e.g. "t2m" or "surface/hourly/t2m"
     shape: tuple[int, ...]
     chunks: tuple[int, ...]
     dtype: np.dtype

--- a/src/insitubatch/types.py
+++ b/src/insitubatch/types.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import itertools
 from collections.abc import Iterator
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import StrEnum
 
 import numpy as np
@@ -32,12 +32,23 @@ class ArrayGeometry:
     time for ERA5/HRRR) explicitly, because that is the axis we split, shuffle,
     and batch along. The trailing dims are carried opaquely as ``inner_shape``
     and are kept contiguous to preserve partial zero-copy.
+
+    ``offset`` makes a variable a *windowed view*: it reads ``array[anchor + offset]``
+    around a shared sample anchor. Two geometries with the same ``path`` and different
+    ``offset`` (e.g. ``g`` and ``g.shift(1)``) are two views of one array -- they decode
+    once and share slots. Offset 0 is not special; everything is relative to the anchor.
     """
 
     path: str  # the array's zarr path within the store, e.g. "t2m" or "surface/hourly/t2m"
     shape: tuple[int, ...]
     chunks: tuple[int, ...]
     dtype: np.dtype
+    offset: int = 0  # sample-axis read shift: this view reads array[anchor + offset]
+
+    def shift(self, k: int) -> ArrayGeometry:
+        """A view of the same array read ``k`` samples later (composes: ``shift(1).shift(1)``
+        is ``offset += 2``). Declare a forecast target as ``g.shift(horizon)``."""
+        return replace(self, offset=self.offset + k)
 
     @property
     def n_samples(self) -> int:

--- a/src/insitubatch/types.py
+++ b/src/insitubatch/types.py
@@ -11,7 +11,7 @@ chunk, async fan-out is everything).
 from __future__ import annotations
 
 import itertools
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field, replace
 from enum import StrEnum
 
@@ -196,10 +196,37 @@ class DecodedChunk:
 class Batch:
     """A model-ready batch.
 
-    ``arrays`` maps variable name -> stacked array of shape ``(batch, *inner)``.
-    ``sample_indices`` records provenance (which global samples, in order) for
-    determinism checks and resumption.
+    ``arrays`` maps variable *label* -> stacked array of shape ``(batch, *inner)``.
+    ``sample_indices`` is the per-row *anchor* sample index ``t`` (provenance for
+    determinism / resumption). ``offsets`` maps each label to its sample-axis read
+    offset, so label ``v`` of row ``i`` was read from global sample ``sample_indices[i]
+    + offsets[v]``. A plain (non-windowed) batch has every offset 0; a forecast batch
+    pairs e.g. an input at offset 0 with a target at offset ``horizon``.
+
+    The batch stays a flat ``{label: array}`` dict -- there is no lead/role axis in the
+    engine. Use :meth:`stack` to assemble a multi-step window into one array and
+    :meth:`read_indices` for a label's true provenance.
     """
 
     arrays: dict[str, np.ndarray]
     sample_indices: np.ndarray = field(default_factory=lambda: np.empty(0, dtype=np.int64))
+    offsets: dict[str, int] = field(default_factory=dict)  # label -> sample-axis read offset
+
+    def read_indices(self, label: str) -> np.ndarray:
+        """Global sample index each row of ``label`` was read from: ``anchor + offset``.
+
+        Provenance for a windowed view (e.g. to confirm a target leads its input by the
+        intended horizon). Defaults the offset to 0 for a label without one recorded.
+        """
+        return self.sample_indices + self.offsets.get(label, 0)
+
+    def stack(self, labels: Sequence[str], axis: int = 1) -> np.ndarray:
+        """Stack several labels into one array along a new ``axis`` (default 1).
+
+        The obvious way to build a multi-step input window from a set of time-shifted
+        views, e.g. ``batch.stack(["t_m2", "t_m1", "t_0"])`` -> ``(batch, 3, *inner)``.
+        Order follows ``labels``; row ``i`` of every label shares anchor
+        ``sample_indices[i]``, so the stacked steps stay aligned. The caller chooses the
+        labels and their order -- the engine does not impose a window layout.
+        """
+        return np.stack([self.arrays[label] for label in labels], axis=axis)

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -1,0 +1,77 @@
+"""Advected-field forecast example: windowed-data correctness + each framework learns.
+
+The data layer is framework-neutral, so one fixture builds the store and three tests --
+torch (run in CI), JAX, TF (each ``importorskip``) -- train the *same* tiny model on the
+*same* dataset and assert it beats the persistence baseline (i.e. it learned the wind-
+driven advection that windowed, multi-variable, no-reshard sampling makes available).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from examples.advection.data import (
+    SYNTH_HORIZON,
+    forecast_dataset,
+    inputs_and_targets,
+    make_advection_store,
+    rmse,
+)
+from insitubatch import SplitName
+
+
+@pytest.fixture
+def synth_store(tmp_path) -> str:
+    """A small advected-field store (fast: short trajectory, small grid)."""
+    url = f"file://{tmp_path}/adv.zarr"
+    make_advection_store(url, n_steps=288, size=24, seed=0)
+    return url
+
+
+def _datasets(url: str):
+    train = forecast_dataset(url, split=SplitName.TRAIN, batch_size=32)
+    val = forecast_dataset(url, split=SplitName.VAL, batch_size=32, shuffle=False)
+    return train, val
+
+
+def test_forecast_dataset_is_windowed_and_multivariable(synth_store) -> None:
+    ds = forecast_dataset(synth_store, split=SplitName.TRAIN, batch_size=32, shuffle=False)
+    ds.set_epoch(0)
+    batch = next(iter(ds))
+
+    assert set(batch.arrays) == {"t2m", "u10", "v10", "target"}
+    # target is t2m read `horizon` steps ahead -- two views of one in-place array, no reshard
+    assert batch.offsets == {"t2m": 0, "u10": 0, "v10": 0, "target": SYNTH_HORIZON}
+    np.testing.assert_array_equal(
+        batch.read_indices("target"), batch.sample_indices + SYNTH_HORIZON
+    )
+    x, persistence, target = inputs_and_targets(batch)
+    assert x.shape[1] == 3  # three input channels stacked (Batch.stack)
+    assert persistence.shape == target.shape
+    # the field advects over 24 h, so persistence has real error a model can beat
+    assert rmse(persistence, target) > 0.3
+
+
+def test_torch_beats_persistence(synth_store) -> None:
+    pytest.importorskip("torch")
+    from examples.advection.train_torch import train
+
+    model_rmse, persistence_rmse = train(*_datasets(synth_store), epochs=8)
+    assert model_rmse < persistence_rmse
+
+
+def test_jax_beats_persistence(synth_store) -> None:
+    pytest.importorskip("flax")
+    from examples.advection.train_jax import train
+
+    model_rmse, persistence_rmse = train(*_datasets(synth_store), epochs=8)
+    assert model_rmse < persistence_rmse
+
+
+def test_tf_beats_persistence(synth_store) -> None:
+    pytest.importorskip("tensorflow")
+    from examples.advection.train_tf import train
+
+    model_rmse, persistence_rmse = train(*_datasets(synth_store), epochs=8)
+    assert model_rmse < persistence_rmse

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -18,7 +18,6 @@ from examples.advection.data import (
     make_advection_store,
     rmse,
 )
-from insitubatch import SplitName
 
 
 @pytest.fixture
@@ -29,16 +28,14 @@ def synth_store(tmp_path) -> str:
     return url
 
 
-def _datasets(url: str):
-    train = forecast_dataset(url, split=SplitName.TRAIN, batch_size=32)
-    val = forecast_dataset(url, split=SplitName.VAL, batch_size=32, shuffle=False)
-    return train, val
+def _dataset(url: str):
+    return forecast_dataset(url, batch_size=32)
 
 
 def test_forecast_dataset_is_windowed_and_multivariable(synth_store) -> None:
-    ds = forecast_dataset(synth_store, split=SplitName.TRAIN, batch_size=32, shuffle=False)
+    ds = forecast_dataset(synth_store, batch_size=32, shuffle=False)
     ds.set_epoch(0)
-    batch = next(iter(ds))
+    batch = next(iter(ds.train))
 
     assert set(batch.arrays) == {"t2m", "u10", "v10", "target"}
     # target is t2m read `horizon` steps ahead -- two views of one in-place array, no reshard
@@ -57,7 +54,7 @@ def test_torch_beats_persistence(synth_store) -> None:
     pytest.importorskip("torch")
     from examples.advection.train_torch import train
 
-    model_rmse, persistence_rmse = train(*_datasets(synth_store), epochs=8)
+    model_rmse, persistence_rmse = train(_dataset(synth_store), epochs=8)
     assert model_rmse < persistence_rmse
 
 
@@ -65,7 +62,7 @@ def test_jax_beats_persistence(synth_store) -> None:
     pytest.importorskip("flax")
     from examples.advection.train_jax import train
 
-    model_rmse, persistence_rmse = train(*_datasets(synth_store), epochs=8)
+    model_rmse, persistence_rmse = train(_dataset(synth_store), epochs=8)
     assert model_rmse < persistence_rmse
 
 
@@ -73,5 +70,5 @@ def test_tf_beats_persistence(synth_store) -> None:
     pytest.importorskip("tensorflow")
     from examples.advection.train_tf import train
 
-    model_rmse, persistence_rmse = train(*_datasets(synth_store), epochs=8)
+    model_rmse, persistence_rmse = train(_dataset(synth_store), epochs=8)
     assert model_rmse < persistence_rmse

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -29,7 +29,7 @@ def test_error_propagates_through_prefetch(write_zarr) -> None:
     ds = InSituDataset(url, manifest, chunk_transforms=[_boom])
     ds.set_epoch(0)
     with pytest.raises(ValueError, match="boom"):
-        list(ds)
+        list(ds.train)
 
 
 def test_bad_chunk_raises_by_default_then_nan_fills(write_zarr) -> None:
@@ -48,11 +48,11 @@ def test_bad_chunk_raises_by_default_then_nan_fills(write_zarr) -> None:
     ds = InSituDataset(url, manifest, shuffle=False, batch_size=8)
     ds.set_epoch(0)
     with pytest.raises(Exception):  # noqa: B017 - decode raises a codec-specific type
-        list(ds)
+        list(ds.train)
 
     ds = InSituDataset(url, manifest, shuffle=False, batch_size=8, on_bad_chunk="nan")
     ds.set_epoch(0)
-    batches = list(ds)
+    batches = list(ds.train)
     idx = np.concatenate([b.sample_indices for b in batches])
     out = np.concatenate([b.arrays["t2m"] for b in batches])[np.argsort(idx)]
 

--- a/tests/test_icechunk.py
+++ b/tests/test_icechunk.py
@@ -14,7 +14,6 @@ import pytest
 import zarr
 
 from insitubatch import (
-    SplitName,
     as_store,
     open_geometries,
     split_by_chunk,
@@ -67,17 +66,16 @@ def test_dataset_streams_from_icechunk_store(icechunk_store) -> None:
     ds = InSituDataset(
         store,
         manifest,
-        split=SplitName.TRAIN,
         shuffle=False,
         batch_size=5,
         block_chunks=2,
     )
     ds.set_epoch(0)
-    idx = np.concatenate([b.sample_indices for b in ds])
+    idx = np.concatenate([b.sample_indices for b in ds.train])
     assert idx.tolist() == list(range(40))  # strictly in order
 
     ds.set_epoch(0)
-    out = np.concatenate([b.arrays["t2m"] for b in ds], axis=0)
+    out = np.concatenate([b.arrays["t2m"] for b in ds.train], axis=0)
     np.testing.assert_array_equal(out, src)
 
 
@@ -95,7 +93,7 @@ def test_icechunk_matches_url_path(icechunk_store, write_zarr) -> None:
     def collect(spec):
         ds = InSituDataset(spec, manifest, shuffle=False, batch_size=5, block_chunks=2)
         ds.set_epoch(0)
-        return np.concatenate([b.arrays["t2m"] for b in ds], axis=0)
+        return np.concatenate([b.arrays["t2m"] for b in ds.train], axis=0)
 
     np.testing.assert_array_equal(collect(store), src)
     np.testing.assert_array_equal(collect(url), src)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import numpy as np
 
 from insitubatch import (
-    SplitName,
     StandardScaler,
     open_geometries,
     split_by_chunk,
@@ -30,7 +29,6 @@ def test_transforms_prefetch_reconstruct(write_zarr) -> None:
     ds = InSituDataset(
         url,
         manifest,
-        split=SplitName.TRAIN,
         shuffle=False,
         batch_size=6,
         block_chunks=3,
@@ -40,6 +38,6 @@ def test_transforms_prefetch_reconstruct(write_zarr) -> None:
 
     for _epoch in range(2):
         ds.set_epoch(_epoch)
-        normalized = np.concatenate([b.arrays["t2m"] for b in ds], axis=0)
+        normalized = np.concatenate([b.arrays["t2m"] for b in ds.train], axis=0)
         reconstructed = normalized * (std + 1e-8) + mean  # invert the scaler
         np.testing.assert_allclose(reconstructed, src, rtol=1e-4, atol=1e-4)

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -11,7 +11,7 @@ import pytest
 
 jax = pytest.importorskip("jax")
 
-from insitubatch import SplitName, open_geometries, split_by_chunk  # noqa: E402
+from insitubatch import open_geometries, split_by_chunk  # noqa: E402
 from insitubatch.frameworks import to_jax  # noqa: E402
 from insitubatch.source import InSituDataset  # noqa: E402
 
@@ -20,13 +20,11 @@ def test_to_jax_roundtrip(write_zarr) -> None:
     url, srcs = write_zarr(n=40, spc=8)
     geom = open_geometries(url)["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
-    ds = InSituDataset(
-        url, manifest, split=SplitName.TRAIN, shuffle=False, batch_size=8, block_chunks=2
-    )
+    ds = InSituDataset(url, manifest, shuffle=False, batch_size=8, block_chunks=2)
     ds.set_epoch(0)
 
     seen = []
-    for batch in ds:
+    for batch in ds.train:
         arrays = to_jax(batch)
         assert isinstance(arrays["t2m"], jax.Array)
         assert arrays["t2m"].shape[1:] == (2, 2)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -261,9 +261,9 @@ def test_pool_lru_evicts_unpinned_under_budget(tiled_store):
     fill(0)
     fill(1)
     assert pool.resident_chunks == 2
-    # Budget full of *pinned* slots -> a third miss can't be admitted yet.
+    # Budget full of *referenced* slots -> a third miss can't be admitted yet.
     assert not pool.try_admit("single_inner", 2)
-    pool.unpin({0, 1})  # release -> now LRU-evictable (0 is LRU)
+    pool.unpin_keys({("single_inner", 0), ("single_inner", 1)})  # release -> LRU-evictable
     assert pool.try_admit("single_inner", 2)  # evicts chunk 0
     for inner in geom.inner_coords():
         pool.scatter("single_inner", 2, inner, tiles[(2, *inner)])
@@ -274,3 +274,61 @@ def test_pool_lru_evicts_unpinned_under_budget(tiled_store):
     rows = np.array([[1, w] for w in range(spc)], dtype=np.int64)
     kept = pool.gather(rows, ["single_inner"], spc).arrays["single_inner"]
     np.testing.assert_array_equal(kept, srcs["single_inner"][spc : 2 * spc])
+
+
+def test_pool_pin_is_reference_counted_not_boolean(tiled_store):
+    """A chunk read by several windowed blocks is pinned several times and must stay
+    resident until the *last* release -- a single unpin after a double-pin must not free
+    it (the boolean-set bug). Pins are counts: N pins need N unpins."""
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    full = geom.sample_chunk_size * int(np.prod(geom.inner_shape)) * geom.dtype.itemsize
+    pool = ChunkPool(geoms, budget_bytes=full)  # holds exactly one chunk
+
+    pool.try_admit("single_inner", 0)  # admission references it -> refcount 1
+    for inner in geom.inner_coords():
+        pool.scatter("single_inner", 0, inner, tiles[(0, *inner)])
+    pool.wait_ready("single_inner", 0)
+
+    pool.pin_keys({("single_inner", 0)})  # a second block references it -> 2
+    assert pool._pinned[("single_inner", 0)] == 2
+    pool.unpin_keys({("single_inner", 0)})  # one block done -> 1, still pinned
+    assert not pool.try_admit("single_inner", 1)  # budget full, chunk 0 not evictable
+    pool.unpin_keys({("single_inner", 0)})  # last block done -> 0, now evictable
+    assert ("single_inner", 0) not in pool._pinned
+    assert pool.try_admit("single_inner", 1)  # evicts chunk 0
+    assert ("single_inner", 0) not in pool._slots
+
+
+def test_pool_unpin_all_drops_abandoned_partial_keeps_ready(tiled_store):
+    """Epoch-boundary reset (unpin_all): clear every refcount, drop a not-ready
+    (abandoned) partial -- a half-scattered chunk a cancelled epoch left behind can
+    never be a valid cache entry -- but retain a fully ready chunk for cross-epoch
+    reuse, with the byte accounting reclaimed."""
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["spatial"])
+    geom = geoms["spatial"]
+    tiles = asyncio.run(_decode_tiles(url, "spatial"))
+    inner = list(geom.inner_coords())
+    assert len(inner) > 1  # need a multi-tile chunk to leave a real partial
+
+    pool = ChunkPool(geoms)
+    # chunk 0: only the first tile scattered -> not ready (abandoned partial)
+    pool.try_admit("spatial", 0)
+    pool.scatter("spatial", 0, inner[0], tiles[(0, *inner[0])])
+    assert not pool.is_ready("spatial", 0)
+    # chunk 1: fully scattered -> ready (a valid cache entry)
+    pool.try_admit("spatial", 1)
+    for ic in inner:
+        pool.scatter("spatial", 1, ic, tiles[(1, *ic)])
+    pool.wait_ready("spatial", 1)
+    bytes_ready = pool._slots[("spatial", 1)].nbytes
+
+    pool.unpin_all()
+
+    assert pool._pinned == {}  # every refcount cleared
+    assert ("spatial", 0) not in pool._slots  # abandoned partial dropped
+    assert pool.is_ready("spatial", 1)  # ready chunk retained (cross-epoch reuse)
+    assert pool._bytes == bytes_ready  # the partial's bytes were reclaimed

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -81,6 +81,39 @@ def test_build_stored_chunk_reads_expands_and_dedups(tiled_store):
     assert all(r.chunk_index == 0 for r in reads[:first_c1])
 
 
+def test_pool_aliased_labels_decode_once(tiled_store):
+    """Two variable *labels* backed by one underlying array (``geom.name``) share a single
+    decoded slot per chunk -- decode-once across offsets (the M-W pool path-keying).
+
+    The pool must key slots on the array name, not the dict label, and ``gather`` must map
+    each label back to its array. Today the label *is* the name, so the engine can't
+    express two views (e.g. ``t2m_now`` / ``t2m_next``) of one array sharing a decode.
+    """
+    url, srcs = tiled_store
+    array = "single_inner"
+    base = open_geometries(url, variables=[array])[array]  # base.name == array
+    geoms = {"now": base, "next": base}  # two labels, one underlying array
+    tiles = asyncio.run(_decode_tiles(url, array))
+    reads = build_stored_chunk_reads(range(base.n_chunks), {array: base})
+
+    pool = ChunkPool(geoms)
+    for cid in range(base.n_chunks):
+        pool.try_admit(array, cid)  # admit by array name
+    for read in reads:
+        pool.scatter(read.array, read.chunk_index, read.inner_coord, tiles[read.coords])
+
+    spc = base.sample_chunk_size
+    for cid in range(base.n_chunks):
+        pool.wait_ready(array, cid)
+    n0 = len(base.samples_in_chunk(0))
+    rows = np.array([[0, w] for w in range(n0)], dtype=np.int64)
+    batch = pool.gather(rows, ["now", "next"], spc)
+
+    assert len(pool._slots) == base.n_chunks  # one slot per chunk, not one per (label, chunk)
+    np.testing.assert_array_equal(batch.arrays["now"], batch.arrays["next"])
+    np.testing.assert_array_equal(batch.arrays["now"], srcs[array][:n0])
+
+
 @pytest.mark.parametrize("var", list(LAYOUTS))
 def test_pool_scatter_reconstructs_array(tiled_store, var):
     """Concurrent tile scatter assembles each outer chunk == arr[:] (FT stress)."""

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -46,7 +46,6 @@ def test_producer_runs_ahead_of_consumer(tmp_path) -> None:
     ds = InSituDataset(
         url,
         manifest,
-        split=SplitName.TRAIN,
         batch_size=4,
         block_chunks=2,
         prefetch_depth=2,
@@ -54,7 +53,7 @@ def test_producer_runs_ahead_of_consumer(tmp_path) -> None:
     )
     ds.set_epoch(0)
 
-    it = iter(ds)
+    it = iter(ds.train)
     first = next(it)  # pulling one batch starts the producer, which runs ahead
     time.sleep(0.2)  # let the background producer fill the bounded queue
 
@@ -77,7 +76,6 @@ def test_prefetch_preserves_values_and_coverage(tmp_path) -> None:
     ds = InSituDataset(
         url,
         manifest,
-        split=SplitName.TRAIN,
         batch_size=4,
         block_chunks=2,
         prefetch_depth=3,
@@ -85,7 +83,7 @@ def test_prefetch_preserves_values_and_coverage(tmp_path) -> None:
     ds.set_epoch(0)
 
     seen: list[np.ndarray] = []
-    for batch in ds:
+    for batch in ds.train:
         idx = batch.sample_indices
         np.testing.assert_array_equal(batch.arrays["t2m"], src[idx])
         seen.append(idx)
@@ -111,14 +109,13 @@ def test_partial_iteration_reaps_producer(tmp_path) -> None:
     ds = InSituDataset(
         url,
         manifest,
-        split=SplitName.TRAIN,
         batch_size=4,
         block_chunks=2,
         prefetch_depth=2,
     )
 
     ds.set_epoch(0)
-    it = iter(ds)
+    it = iter(ds.train)
     for i, _ in enumerate(it):  # consume a couple, then stop short
         if i == 1:
             break
@@ -153,7 +150,6 @@ def test_early_break_then_next_epoch_does_not_deadlock(tmp_path) -> None:
     ds = InSituDataset(
         url,
         manifest,
-        split=SplitName.TRAIN,
         batch_size=4,
         block_chunks=2,
         prefetch_depth=2,
@@ -161,7 +157,7 @@ def test_early_break_then_next_epoch_does_not_deadlock(tmp_path) -> None:
 
     # epoch 0: pull one batch, let the producer read ahead (pinning), then abort.
     ds.set_epoch(0)
-    it = iter(ds)
+    it = iter(ds.train)
     next(it)
     time.sleep(0.3)  # let read-ahead pin a block or two before we tear down
     it.close()  # deterministic generator teardown (GeneratorExit -> __iter__ finally)
@@ -171,7 +167,7 @@ def test_early_break_then_next_epoch_does_not_deadlock(tmp_path) -> None:
     seen: list[np.ndarray] = []
 
     def drain() -> None:
-        for batch in ds:
+        for batch in ds.train:
             seen.append(batch.sample_indices)
         done.set()
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -108,7 +108,7 @@ def test_scheduler_close_closes_the_loop(tiled_store):
 def test_scheduler_poisons_pool_on_driver_failure(tiled_store):
     """A variable absent from the store fails array-open; the pool poison unblocks waiters."""
     url, _ = tiled_store
-    ghost = ArrayGeometry(name="ghost", shape=(4, 2, 2), chunks=(2, 2, 2), dtype=np.dtype("f4"))
+    ghost = ArrayGeometry(path="ghost", shape=(4, 2, 2), chunks=(2, 2, 2), dtype=np.dtype("f4"))
     with _make(url, {"ghost": ghost}) as sched:
         fut = sched.start([0, 1])
         with pytest.raises(Exception):  # noqa: B017 - zarr surfaces a store-specific error type

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -14,7 +14,7 @@ import numpy as np
 import pytest
 import zarr
 
-from insitubatch import ensure_local_dir, open_geometries, store_from_url
+from insitubatch import ensure_local_dir, open_geometries, store_from_url, valid_anchor_range
 from insitubatch.pool import ChunkPool
 from insitubatch.scheduler import Scheduler, SchedulerConfig
 from insitubatch.types import ArrayGeometry
@@ -52,7 +52,7 @@ def _drain_in_order(sched: Scheduler, geom: ArrayGeometry, var: str, *, unpin: b
         rows = np.array([[cid, w] for w in range(n0)], dtype=np.int64)
         out.append(sched.pool.gather(rows, [var], spc).arrays[var])
         if unpin:
-            sched.unpin({cid})
+            sched.unpin_block({(geom.path, cid)})
     return np.concatenate(out, axis=0)
 
 
@@ -105,32 +105,35 @@ def test_scheduler_close_closes_the_loop(tiled_store):
     assert sched._loop.is_closed()
 
 
-def test_scheduler_aliased_labels_open_and_decode_once(tiled_store):
+def test_scheduler_windowed_views_decode_once_and_lead(tiled_store):
     """Two windowed views of one array (same path, different offset) open the array
-    once and share one set of decoded slots -- the decode-once invariant end-to-end.
+    once and share one set of decoded slots (decode-once), and ``next = now.shift(1)``
+    reads one sample ahead of ``now`` at each anchor.
 
-    Offset is not yet applied to the draw/gather, so both labels currently read the
-    same samples; phase 2b makes ``next`` lead by one. What 2a proves is purely that
-    aliasing by ``path`` collapses the fetch: one open, one array's worth of slots.
+    Anchors are restricted to ``valid_anchor_range`` so every ``anchor + offset`` stays
+    on the array (the producer drops edge anchors; here we do it explicitly).
     """
     url, srcs = tiled_store
     base = open_geometries(url, variables=["single_inner"])["single_inner"]
     geoms = {"now": base, "next": base.shift(1)}  # one array, two views
     spc = base.sample_chunk_size
+    src = srcs["single_inner"]
+    lo, hi = valid_anchor_range([0, 1], base.n_samples)  # (0, T-1): drop the last anchor
+    anchors = np.arange(lo, hi)
+    rows = np.stack([anchors // spc, anchors % spc], axis=1).astype(np.int64)
+
     with _make(url, geoms) as sched:
         fut = sched.start(range(base.n_chunks))
-        now, nxt = [], []
         for cid in range(base.n_chunks):
             sched.pool.wait_ready(base.path, cid)  # slots are keyed by path
-            rows = np.array([[cid, w] for w in range(len(base.samples_in_chunk(cid)))], np.int64)
-            now.append(sched.pool.gather(rows, ["now"], spc).arrays["now"])
-            nxt.append(sched.pool.gather(rows, ["next"], spc).arrays["next"])
+        batch = sched.pool.gather(rows, ["now", "next"], spc)
         fut.result(timeout=30)  # surface any driver error
         assert len(sched._arrays) == 1  # opened once: deduped by path
         assert len(sched.pool._slots) == base.n_chunks  # one array's slots, not two
 
-    assert np.array_equal(np.concatenate(now), srcs["single_inner"])
-    assert np.array_equal(np.concatenate(nxt), srcs["single_inner"])  # 2b: nxt leads by 1
+    assert np.array_equal(batch.sample_indices, anchors)  # provenance is the anchor
+    assert np.array_equal(batch.arrays["now"], src[anchors])  # now reads array[anchor]
+    assert np.array_equal(batch.arrays["next"], src[anchors + 1])  # next leads by one
 
 
 def test_scheduler_poisons_pool_on_driver_failure(tiled_store):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -105,6 +105,34 @@ def test_scheduler_close_closes_the_loop(tiled_store):
     assert sched._loop.is_closed()
 
 
+def test_scheduler_aliased_labels_open_and_decode_once(tiled_store):
+    """Two windowed views of one array (same path, different offset) open the array
+    once and share one set of decoded slots -- the decode-once invariant end-to-end.
+
+    Offset is not yet applied to the draw/gather, so both labels currently read the
+    same samples; phase 2b makes ``next`` lead by one. What 2a proves is purely that
+    aliasing by ``path`` collapses the fetch: one open, one array's worth of slots.
+    """
+    url, srcs = tiled_store
+    base = open_geometries(url, variables=["single_inner"])["single_inner"]
+    geoms = {"now": base, "next": base.shift(1)}  # one array, two views
+    spc = base.sample_chunk_size
+    with _make(url, geoms) as sched:
+        fut = sched.start(range(base.n_chunks))
+        now, nxt = [], []
+        for cid in range(base.n_chunks):
+            sched.pool.wait_ready(base.path, cid)  # slots are keyed by path
+            rows = np.array([[cid, w] for w in range(len(base.samples_in_chunk(cid)))], np.int64)
+            now.append(sched.pool.gather(rows, ["now"], spc).arrays["now"])
+            nxt.append(sched.pool.gather(rows, ["next"], spc).arrays["next"])
+        fut.result(timeout=30)  # surface any driver error
+        assert len(sched._arrays) == 1  # opened once: deduped by path
+        assert len(sched.pool._slots) == base.n_chunks  # one array's slots, not two
+
+    assert np.array_equal(np.concatenate(now), srcs["single_inner"])
+    assert np.array_equal(np.concatenate(nxt), srcs["single_inner"])  # 2b: nxt leads by 1
+
+
 def test_scheduler_poisons_pool_on_driver_failure(tiled_store):
     """A variable absent from the store fails array-open; the pool poison unblocks waiters."""
     url, _ = tiled_store

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -65,13 +65,12 @@ def test_shuffle_false_is_in_order(write_zarr) -> None:
     ds = InSituDataset(
         url,
         manifest,
-        split=SplitName.TRAIN,
         shuffle=False,
         batch_size=5,
         block_chunks=2,
     )
     ds.set_epoch(0)
-    idx = np.concatenate([b.sample_indices for b in ds])
+    idx = np.concatenate([b.sample_indices for b in ds.train])
     assert idx.tolist() == list(range(40))  # strictly in order
 
 
@@ -88,7 +87,7 @@ def test_shuffle_true_covers_but_reorders(write_zarr) -> None:
         block_chunks=4,
     )
     ds.set_epoch(0)
-    idx = np.concatenate([b.sample_indices for b in ds])
+    idx = np.concatenate([b.sample_indices for b in ds.train])
     assert sorted(idx.tolist()) == list(range(40))  # full coverage
     assert idx.tolist() != list(range(40))  # but not in order
 
@@ -110,7 +109,6 @@ def test_chunk_decoded_once_per_epoch_without_cache(write_zarr) -> None:
     ds = InSituDataset(
         url,
         manifest,
-        split=SplitName.TRAIN,
         batch_size=1,
         block_chunks=20,
         shuffle=True,
@@ -118,7 +116,7 @@ def test_chunk_decoded_once_per_epoch_without_cache(write_zarr) -> None:
         chunk_transforms=[count],
     )
     ds.set_epoch(0)
-    for _ in ds:
+    for _ in ds.train:
         pass
 
     assert set(decoded) == set(manifest.chunks[SplitName.TRAIN.value])
@@ -143,7 +141,7 @@ def test_residency_is_bounded_by_block(write_zarr) -> None:
         seed=0,
     )
     ds.set_epoch(0)
-    for _ in ds:
+    for _ in ds.train:
         pass
     assert block_chunks <= ds.resident_peak <= 2 * block_chunks  # ~two blocks, not all 40
 
@@ -166,7 +164,6 @@ def test_cache_decode_once_across_epochs(write_zarr, tmp_path, kind) -> None:
     ds = InSituDataset(
         url,
         manifest,
-        split=SplitName.TRAIN,
         batch_size=4,
         block_chunks=4,
         shuffle=True,
@@ -178,7 +175,7 @@ def test_cache_decode_once_across_epochs(write_zarr, tmp_path, kind) -> None:
     try:
         for epoch in range(2):
             ds.set_epoch(epoch)
-            for _ in ds:
+            for _ in ds.train:
                 pass
     finally:
         ds.close()
@@ -195,5 +192,41 @@ def test_sample_range_subsets_what_the_dataset_reads(write_zarr) -> None:
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0), sample_range=(16, 40))
     ds = InSituDataset(url, manifest, shuffle=False, batch_size=8)
     ds.set_epoch(0)
-    idx = np.concatenate([b.sample_indices for b in ds])
+    idx = np.concatenate([b.sample_indices for b in ds.train])
     assert set(idx.tolist()) == set(range(16, 40))  # chunks 2,3,4 -> samples 16..39
+
+
+def test_split_views_share_one_pool_and_cover_disjoint(write_zarr) -> None:
+    """train / val / test / all are views on *one* dataset sharing *one* pool; the splits
+    are disjoint and ``all`` is their union."""
+    url, _ = write_zarr(n=80, spc=8)  # 10 chunks
+    geom = open_geometries(url)["t2m"]
+    manifest = split_by_chunk(geom, fractions=(0.6, 0.2, 0.2))
+    ds = InSituDataset(url, manifest, batch_size=8, block_chunks=4)
+    pool = ds._pool  # the one pool every view shares
+
+    seen: dict[str, set[int]] = {}
+    for name in ("train", "val", "test"):
+        ds.set_epoch(0)
+        idx = np.concatenate([b.sample_indices for b in getattr(ds, name)])
+        seen[name] = set(idx.tolist())
+        assert ds._pool is pool  # iterating a view doesn't rebuild the pool
+
+    assert seen["train"].isdisjoint(seen["val"])
+    assert seen["train"].isdisjoint(seen["test"])
+    assert seen["val"].isdisjoint(seen["test"])
+    all_idx = set(np.concatenate([b.sample_indices for b in ds.all]).tolist())
+    assert all_idx == seen["train"] | seen["val"] | seen["test"]
+
+
+def test_val_view_is_deterministic_train_shuffles(write_zarr) -> None:
+    url, _ = write_zarr(n=80, spc=8)
+    geom = open_geometries(url)["t2m"]
+    manifest = split_by_chunk(geom, fractions=(0.6, 0.2, 0.2))
+    ds = InSituDataset(url, manifest, batch_size=8, block_chunks=4, shuffle=True, seed=1)
+    ds.set_epoch(0)
+    val0 = np.concatenate([b.sample_indices for b in ds.val])
+    ds.set_epoch(5)  # different epoch
+    val5 = np.concatenate([b.sample_indices for b in ds.val])
+    np.testing.assert_array_equal(val0, val5)  # val ignores epoch (no shuffle)
+    np.testing.assert_array_equal(val0, np.sort(val0))  # and is in order

--- a/tests/test_tf.py
+++ b/tests/test_tf.py
@@ -1,8 +1,8 @@
 """TensorFlow handoff: frameworks.to_tf + as_tf_dataset. Skips if tensorflow is absent.
 
 TF has no base class to inherit -- :func:`insitubatch.frameworks.as_tf_dataset` adapts
-the stream via ``tf.data.Dataset.from_generator``; :func:`to_tf` is the per-batch
-(zero-copy DLPack) path.
+the stream via ``tf.data.Dataset.from_generator``; :func:`to_tf` is the per-batch path
+(a copy -- TF's experimental DLPack mishandles buffer ownership; torch/JAX stay zero-copy).
 """
 
 from __future__ import annotations

--- a/tests/test_tf.py
+++ b/tests/test_tf.py
@@ -12,7 +12,7 @@ import pytest
 
 tf = pytest.importorskip("tensorflow")
 
-from insitubatch import SplitName, open_geometries, split_by_chunk  # noqa: E402
+from insitubatch import open_geometries, split_by_chunk  # noqa: E402
 from insitubatch.frameworks import as_tf_dataset, to_tf  # noqa: E402
 from insitubatch.source import InSituDataset  # noqa: E402
 
@@ -21,9 +21,7 @@ def _ds(write_zarr):
     url, srcs = write_zarr(n=40, spc=8)
     geom = open_geometries(url)["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
-    ds = InSituDataset(
-        url, manifest, split=SplitName.TRAIN, shuffle=False, batch_size=8, block_chunks=2
-    )
+    ds = InSituDataset(url, manifest, shuffle=False, batch_size=8, block_chunks=2)
     ds.set_epoch(0)
     return ds, srcs
 
@@ -31,7 +29,7 @@ def _ds(write_zarr):
 def test_to_tf_roundtrip(write_zarr) -> None:
     ds, srcs = _ds(write_zarr)
     seen = []
-    for batch in ds:
+    for batch in ds.train:
         tensors = to_tf(batch)
         assert isinstance(tensors["t2m"], tf.Tensor)
         seen.append(tensors["t2m"].numpy())
@@ -40,6 +38,6 @@ def test_to_tf_roundtrip(write_zarr) -> None:
 
 def test_as_tf_dataset_roundtrip(write_zarr) -> None:
     ds, srcs = _ds(write_zarr)
-    tfds = as_tf_dataset(ds, prefetch=2)
+    tfds = as_tf_dataset(ds.train, prefetch=2)
     seen = [b["t2m"].numpy() for b in tfds]
     np.testing.assert_array_equal(np.concatenate(seen, axis=0), srcs["t2m"])

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -12,7 +12,7 @@ torch = pytest.importorskip("torch")
 
 from torch.utils.data import DataLoader  # noqa: E402
 
-from insitubatch import SplitName, open_geometries, split_by_chunk  # noqa: E402
+from insitubatch import open_geometries, split_by_chunk  # noqa: E402
 from insitubatch.frameworks import as_torch, to_torch  # noqa: E402
 from insitubatch.source import InSituDataset  # noqa: E402
 
@@ -21,16 +21,14 @@ def _ds(write_zarr):
     url, srcs = write_zarr(n=40, spc=8)
     geom = open_geometries(url)["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
-    ds = InSituDataset(
-        url, manifest, split=SplitName.TRAIN, shuffle=False, batch_size=8, block_chunks=2
-    )
+    ds = InSituDataset(url, manifest, shuffle=False, batch_size=8, block_chunks=2)
     ds.set_epoch(0)
     return ds, srcs
 
 
 def test_to_torch_yields_tensors_zero_copy(write_zarr) -> None:
     ds, _ = _ds(write_zarr)
-    batch = next(iter(ds))
+    batch = next(iter(ds.train))
     tensors = to_torch(batch)
     assert isinstance(tensors, dict)
     assert isinstance(tensors["t2m"], torch.Tensor)
@@ -45,6 +43,6 @@ def test_as_torch_dataloader_roundtrip(write_zarr) -> None:
     src = srcs["t2m"]
     # batch_size=None: the dataset already yields assembled batches; num_workers=0:
     # parallelism is in insitubatch's event loop, not in worker processes.
-    loader = DataLoader(as_torch(ds), batch_size=None, num_workers=0)
+    loader = DataLoader(as_torch(ds.train), batch_size=None, num_workers=0)
     recon = torch.cat([b["t2m"] for b in loader], dim=0).numpy()
     np.testing.assert_array_equal(recon, src)  # shuffle=False + all chunks -> src in order

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -64,13 +64,12 @@ def test_chunk_transform_normalizes_batches(tmp_path) -> None:
     ds = InSituDataset(
         url,
         manifest,
-        split=SplitName.TRAIN,
         batch_size=10,
         block_chunks=4,
         chunk_transforms=[sc],
     )
     ds.set_epoch(0)
-    for batch in ds:
+    for batch in ds.train:
         idx = batch.sample_indices
         np.testing.assert_allclose(
             batch.arrays["t2m"], (src[idx] - m) / (s + 1e-8), rtol=1e-4, atol=1e-4
@@ -99,13 +98,12 @@ def test_cross_variable_windspeed_is_a_batch_transform(tmp_path) -> None:
     ds = InSituDataset(
         url,
         manifest,
-        split=SplitName.TRAIN,
         batch_size=8,
         block_chunks=4,
         batch_transforms=[windspeed],
     )
     ds.set_epoch(0)
-    for batch in ds:
+    for batch in ds.train:
         idx = batch.sample_indices
         expected = np.sqrt(su[idx] ** 2 + sv[idx] ** 2)
         np.testing.assert_allclose(batch.arrays["wspd"], expected, rtol=1e-5)

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -1,0 +1,46 @@
+"""M-W phase 1: offset variables (`ArrayGeometry.shift`) + anchor range validity.
+
+Pure coordinate-space behavior -- no engine. A variable is ``(path, offset)``; a window
+is a set of offsets around a shared anchor; the only validity the engine enforces is that
+every read ``anchor + offset`` stays on the array.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from insitubatch import valid_anchor_range
+from insitubatch.types import ArrayGeometry
+
+
+def _geom(n: int = 20, offset: int = 0) -> ArrayGeometry:
+    return ArrayGeometry(
+        path="t2m", shape=(n, 4, 4), chunks=(4, 4, 4), dtype=np.dtype("f4"), offset=offset
+    )
+
+
+def test_offset_defaults_zero_and_shift_composes() -> None:
+    g = _geom()
+    assert g.offset == 0
+    s = g.shift(1)
+    assert s.offset == 1
+    # same array, only the offset moves -- two views that will share decoded slots
+    assert (s.path, s.shape, s.chunks, s.dtype) == (g.path, g.shape, g.chunks, g.dtype)
+    assert s.shift(1).offset == 2  # composes relatively
+    assert g.shift(-3).offset == -3
+    assert g.offset == 0  # frozen: the original is untouched
+
+
+def test_valid_anchor_range_drops_edge_anchors() -> None:
+    T = 20
+    assert valid_anchor_range([0], T) == (0, T)  # no window -> every anchor
+    assert valid_anchor_range([0, 1], T) == (0, T - 1)  # +1 target -> drop last
+    assert valid_anchor_range([-1, 0], T) == (1, T)  # -1 history -> drop first
+    assert valid_anchor_range([-1, 0, 1], T) == (1, T - 1)  # both ends
+    assert valid_anchor_range([-2, 3], T) == (2, T - 3)  # asymmetric
+    assert valid_anchor_range([], T) == (0, T)  # no offsets
+
+
+def test_valid_anchor_range_empty_when_window_exceeds_array() -> None:
+    lo, hi = valid_anchor_range([0, 25], 20)  # window wider than the array
+    assert lo >= hi  # no anchor can satisfy it

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -14,7 +14,7 @@ import pytest
 
 from insitubatch import open_geometries, split_by_chunk, valid_anchor_range
 from insitubatch.source import InSituDataset
-from insitubatch.types import ArrayGeometry
+from insitubatch.types import ArrayGeometry, Batch
 
 
 def _geom(n: int = 20, offset: int = 0) -> ArrayGeometry:
@@ -50,6 +50,33 @@ def test_valid_anchor_range_empty_when_window_exceeds_array() -> None:
     assert lo >= hi  # no anchor can satisfy it
 
 
+# -- Batch offsets metadata + projection helpers -------------------------------
+
+
+def test_batch_read_indices_and_stack() -> None:
+    arrays = {
+        "t_m1": np.arange(6).reshape(3, 2),
+        "t_0": np.arange(6, 12).reshape(3, 2),
+        "t_1": np.arange(12, 18).reshape(3, 2),
+    }
+    batch = Batch(
+        arrays=arrays,
+        sample_indices=np.array([5, 6, 7]),
+        offsets={"t_m1": -1, "t_0": 0, "t_1": 1},
+    )
+    # read_indices = anchor + offset (label provenance); absent label defaults to 0.
+    np.testing.assert_array_equal(batch.read_indices("t_0"), [5, 6, 7])
+    np.testing.assert_array_equal(batch.read_indices("t_m1"), [4, 5, 6])
+    np.testing.assert_array_equal(batch.read_indices("t_1"), [6, 7, 8])
+    np.testing.assert_array_equal(batch.read_indices("missing"), [5, 6, 7])
+
+    # stack assembles a multi-step window along a new axis, in the given label order.
+    window = batch.stack(["t_m1", "t_0", "t_1"])
+    assert window.shape == (3, 3, 2)
+    for k, label in enumerate(["t_m1", "t_0", "t_1"]):
+        np.testing.assert_array_equal(window[:, k], arrays[label])
+
+
 # -- end-to-end windowed sampling through the real dataset ---------------------
 
 
@@ -81,6 +108,22 @@ def test_windowed_forecast_target_leads_input(write_zarr, shuffle) -> None:
     # Edge anchor (t = T-1, whose +1 read is off the array) is dropped; all others
     # are covered exactly once.
     assert sorted(anchors.tolist()) == list(range(39))
+
+
+def test_windowed_batch_carries_offsets(write_zarr) -> None:
+    """The Batch records each label's offset, so a label's true read indices and a
+    stacked window can be recovered downstream (the Phase 3 metadata + helpers)."""
+    ds, src = _forecast_dataset(write_zarr, n=40, spc=8, shuffle=False, batch_size=7, seed=0)
+    ds.set_epoch(0)
+    batch = list(ds)[0]
+
+    assert batch.offsets == {"x": 0, "y": 1}
+    np.testing.assert_array_equal(batch.read_indices("x"), batch.sample_indices)
+    np.testing.assert_array_equal(batch.read_indices("y"), batch.sample_indices + 1)
+    # the stacked window aligns with the per-label arrays it was built from
+    window = batch.stack(["x", "y"])
+    np.testing.assert_array_equal(window[:, 0], batch.arrays["x"])
+    np.testing.assert_array_equal(window[:, 1], batch.arrays["y"])
 
 
 def test_windowed_history_and_target(write_zarr) -> None:

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -98,7 +98,7 @@ def test_windowed_forecast_target_leads_input(write_zarr, shuffle) -> None:
     ds, src = _forecast_dataset(write_zarr, n=40, spc=8, shuffle=shuffle, batch_size=7, seed=3)
     ds.set_epoch(0)
     seen = []
-    for batch in ds:
+    for batch in ds.train:
         anchor = batch.sample_indices
         np.testing.assert_array_equal(batch.arrays["x"], src[anchor])  # x = array[t]
         np.testing.assert_array_equal(batch.arrays["y"], src[anchor + 1])  # y = array[t+1]
@@ -115,7 +115,7 @@ def test_windowed_batch_carries_offsets(write_zarr) -> None:
     stacked window can be recovered downstream (the Phase 3 metadata + helpers)."""
     ds, src = _forecast_dataset(write_zarr, n=40, spc=8, shuffle=False, batch_size=7, seed=0)
     ds.set_epoch(0)
-    batch = list(ds)[0]
+    batch = list(ds.train)[0]
 
     assert batch.offsets == {"x": 0, "y": 1}
     np.testing.assert_array_equal(batch.read_indices("x"), batch.sample_indices)
@@ -137,7 +137,7 @@ def test_windowed_history_and_target(write_zarr) -> None:
     ds.set_epoch(0)
 
     anchors = []
-    for batch in ds:
+    for batch in ds.train:
         a = batch.sample_indices
         np.testing.assert_array_equal(batch.arrays["prev"], src[a - 1])
         np.testing.assert_array_equal(batch.arrays["now"], src[a])
@@ -164,7 +164,7 @@ def test_windowed_eviction_and_cross_epoch_reuse(write_zarr) -> None:
     for epoch in range(3):
         ds.set_epoch(epoch)
         anchors = []
-        for batch in ds:
+        for batch in ds.train:
             a = batch.sample_indices
             np.testing.assert_array_equal(batch.arrays["x"], src[a])
             np.testing.assert_array_equal(batch.arrays["y"], src[a + 1])
@@ -198,7 +198,7 @@ def test_windowed_partial_iteration_then_clean_epoch(write_zarr) -> None:
 
     # epoch 0: pull one batch, let the producer pin + read ahead (in-flight), then abort.
     ds.set_epoch(0)
-    it = iter(ds)
+    it = iter(ds.train)
     next(it)
     time.sleep(0.2)
     it.close()  # GeneratorExit -> teardown; leaves pins/partials in the persistent pool
@@ -206,7 +206,7 @@ def test_windowed_partial_iteration_then_clean_epoch(write_zarr) -> None:
     # epoch 1: full pass must be correct despite the leftovers.
     ds.set_epoch(1)
     anchors = []
-    for batch in ds:
+    for batch in ds.train:
         a = batch.sample_indices
         np.testing.assert_array_equal(batch.arrays["x"], src[a])
         np.testing.assert_array_equal(batch.arrays["y"], src[a + 1])
@@ -217,3 +217,24 @@ def test_windowed_partial_iteration_then_clean_epoch(write_zarr) -> None:
     assert ds._pool._pinned == {}
     assert all(slot.ready for slot in ds._pool._slots.values())
     ds.close()
+
+
+def test_windowed_val_correct_after_train_shared_pool(write_zarr) -> None:
+    """The shared pool across split views, with windowing: iterate train (which warms --
+    and via windowed spill *pollutes* -- the pool with chunks near the train/val boundary),
+    then val. Val's forecast pairs must still be exact (boundary chunks are reused, not
+    corrupted) -- the cross-split overlap the single shared pool is meant to exploit."""
+    url, srcs = write_zarr(n=120, spc=8)  # 15 chunks
+    src = srcs["t2m"]
+    geom = open_geometries(url)["t2m"]
+    geoms = {"x": geom, "y": geom.shift(1)}  # forecast: input x[t], target y[t]=x[t+1]
+    manifest = split_by_chunk(geom, fractions=(0.7, 0.3, 0.0))
+    ds = InSituDataset(url, manifest, geometries=geoms, batch_size=6, block_chunks=2)
+
+    ds.set_epoch(0)
+    for _ in ds.train:  # warm/pollute the shared pool (windowed reads spill across the split)
+        pass
+    for batch in ds.val:
+        a = batch.sample_indices
+        np.testing.assert_array_equal(batch.arrays["x"], src[a])
+        np.testing.assert_array_equal(batch.arrays["y"], src[a + 1])

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -7,9 +7,13 @@ every read ``anchor + offset`` stays on the array.
 
 from __future__ import annotations
 
-import numpy as np
+import time
 
-from insitubatch import valid_anchor_range
+import numpy as np
+import pytest
+
+from insitubatch import open_geometries, split_by_chunk, valid_anchor_range
+from insitubatch.source import InSituDataset
 from insitubatch.types import ArrayGeometry
 
 
@@ -44,3 +48,129 @@ def test_valid_anchor_range_drops_edge_anchors() -> None:
 def test_valid_anchor_range_empty_when_window_exceeds_array() -> None:
     lo, hi = valid_anchor_range([0, 25], 20)  # window wider than the array
     assert lo >= hi  # no anchor can satisfy it
+
+
+# -- end-to-end windowed sampling through the real dataset ---------------------
+
+
+def _forecast_dataset(write_zarr, *, n, spc, shuffle, **kw):
+    """A dataset with two views of one array: input ``x`` at the anchor, target ``y``
+    one step ahead (``shift(1)``) -- the canonical forecast setup, no reshard."""
+    url, srcs = write_zarr(n=n, spc=spc)
+    geom = open_geometries(url)["t2m"]
+    geoms = {"x": geom, "y": geom.shift(1)}
+    manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(url, manifest, geometries=geoms, shuffle=shuffle, **kw)
+    return ds, srcs["t2m"]
+
+
+@pytest.mark.parametrize("shuffle", [False, True])
+def test_windowed_forecast_target_leads_input(write_zarr, shuffle) -> None:
+    """Each row pairs input x[t] with target y[t+1] from the same in-place array, and
+    every batch holds that relation regardless of shuffle (gather is anchor-indexed)."""
+    ds, src = _forecast_dataset(write_zarr, n=40, spc=8, shuffle=shuffle, batch_size=7, seed=3)
+    ds.set_epoch(0)
+    seen = []
+    for batch in ds:
+        anchor = batch.sample_indices
+        np.testing.assert_array_equal(batch.arrays["x"], src[anchor])  # x = array[t]
+        np.testing.assert_array_equal(batch.arrays["y"], src[anchor + 1])  # y = array[t+1]
+        seen.append(anchor)
+
+    anchors = np.concatenate(seen)
+    # Edge anchor (t = T-1, whose +1 read is off the array) is dropped; all others
+    # are covered exactly once.
+    assert sorted(anchors.tolist()) == list(range(39))
+
+
+def test_windowed_history_and_target(write_zarr) -> None:
+    """A three-view window {-1, 0, +1} drops both edge anchors and reads each offset."""
+    url, srcs = write_zarr(n=24, spc=4)
+    src = srcs["t2m"]
+    geom = open_geometries(url)["t2m"]
+    geoms = {"prev": geom.shift(-1), "now": geom, "next": geom.shift(1)}
+    manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(url, manifest, geometries=geoms, shuffle=True, batch_size=5, seed=1)
+    ds.set_epoch(0)
+
+    anchors = []
+    for batch in ds:
+        a = batch.sample_indices
+        np.testing.assert_array_equal(batch.arrays["prev"], src[a - 1])
+        np.testing.assert_array_equal(batch.arrays["now"], src[a])
+        np.testing.assert_array_equal(batch.arrays["next"], src[a + 1])
+        anchors.append(a)
+    # valid anchors for {-1,0,1} over T=24 are [1, 23): both ends dropped.
+    assert sorted(np.concatenate(anchors).tolist()) == list(range(1, 23))
+
+
+def test_windowed_eviction_and_cross_epoch_reuse(write_zarr) -> None:
+    """Windowed forecast with a budget far smaller than the split, over several epochs:
+    chunks are admitted, evicted, and (cross-epoch) reused under churn. Every batch must
+    still pair x[t] with y[t+1] -- the regression guard for the cross-epoch eviction race
+    where a chunk freed for a miss was gathered as stale memory."""
+    url, srcs = write_zarr(n=160, spc=8)  # 20 chunks
+    src = srcs["t2m"]
+    geom = open_geometries(url)["t2m"]
+    geoms = {"x": geom, "y": geom.shift(1)}
+    manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
+    # block_chunks=2, no override: the windowed working set holds only a few blocks, so
+    # 20 chunks force repeated eviction. shuffle=False keeps the read-union local (the
+    # tight budget is viable) while still exercising churn and cross-epoch reuse.
+    ds = InSituDataset(url, manifest, geometries=geoms, shuffle=False, batch_size=5, block_chunks=2)
+    for epoch in range(3):
+        ds.set_epoch(epoch)
+        anchors = []
+        for batch in ds:
+            a = batch.sample_indices
+            np.testing.assert_array_equal(batch.arrays["x"], src[a])
+            np.testing.assert_array_equal(batch.arrays["y"], src[a + 1])
+            anchors.append(a)
+        assert sorted(np.concatenate(anchors).tolist()) == list(range(159))  # drop t=159
+
+
+def test_windowed_partial_iteration_then_clean_epoch(write_zarr) -> None:
+    """Abort a windowed epoch mid-stream, then run a full one.
+
+    An early break leaves pinned and in-flight (not-ready) chunks in the persistent
+    pool. The next epoch must reconstruct the forecast correctly -- no deadlock, no
+    stale data -- and afterwards the pool's counters and slots must be clean: every
+    reference released and no abandoned not-ready partial lingering.
+    """
+    url, srcs = write_zarr(n=160, spc=8)  # 20 chunks
+    src = srcs["t2m"]
+    geom = open_geometries(url)["t2m"]
+    geoms = {"x": geom, "y": geom.shift(1)}
+    manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(
+        url,
+        manifest,
+        geometries=geoms,
+        shuffle=True,
+        batch_size=4,
+        block_chunks=2,
+        prefetch_depth=2,
+        seed=2,
+    )
+
+    # epoch 0: pull one batch, let the producer pin + read ahead (in-flight), then abort.
+    ds.set_epoch(0)
+    it = iter(ds)
+    next(it)
+    time.sleep(0.2)
+    it.close()  # GeneratorExit -> teardown; leaves pins/partials in the persistent pool
+
+    # epoch 1: full pass must be correct despite the leftovers.
+    ds.set_epoch(1)
+    anchors = []
+    for batch in ds:
+        a = batch.sample_indices
+        np.testing.assert_array_equal(batch.arrays["x"], src[a])
+        np.testing.assert_array_equal(batch.arrays["y"], src[a + 1])
+        anchors.append(a)
+    assert sorted(np.concatenate(anchors).tolist()) == list(range(159))
+
+    # counters/slots clean: all references released, no abandoned not-ready slot.
+    assert ds._pool._pinned == {}
+    assert all(slot.ready for slot in ds._pool._slots.values())
+    ds.close()

--- a/tests/test_zarr_v2.py
+++ b/tests/test_zarr_v2.py
@@ -21,7 +21,6 @@ import pytest
 import zarr
 
 from insitubatch import (
-    SplitName,
     ensure_local_dir,
     open_geometries,
     split_by_chunk,
@@ -55,7 +54,6 @@ def test_iterates_store_v2_and_v3(
     ds = InSituDataset(
         url,
         manifest,
-        split=SplitName.TRAIN,
         shuffle=False,
         batch_size=8,
         block_chunks=2,
@@ -63,5 +61,5 @@ def test_iterates_store_v2_and_v3(
     ds.set_epoch(0)
 
     # Every chunk (and every inner tile) decoded + scattered into the right place.
-    recon = np.concatenate([b.arrays["t2m"] for b in ds], axis=0)
+    recon = np.concatenate([b.arrays["t2m"] for b in ds.train], axis=0)
     np.testing.assert_array_equal(recon, src)

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -673,6 +682,25 @@ wheels = [
 ]
 
 [[package]]
+name = "etils"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/ce/6e067242fde898841922ac6fc82b0bb2fe35c38e995880bdffdfbe30182a/etils-1.14.0.tar.gz", hash = "sha256:8136e7f4c4173cd0af0ca5481c4475152f0b8686192951eefa60ee8711e1ede4", size = 108127, upload-time = "2026-03-04T17:41:36.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/3d/589663aeeacd59bb2f3e8596bfd3e81cf0fb18d70bb433199041f469771b/etils-1.14.0-py3-none-any.whl", hash = "sha256:b5df7341f54dbe1405a4450b2741207b4a8c279780402b45f87202b94dfc52b4", size = 172934, upload-time = "2026-03-04T17:41:35.01Z" },
+]
+
+[package.optional-dependencies]
+epath = [
+    { name = "fsspec" },
+    { name = "typing-extensions" },
+    { name = "zipp" },
+]
+epy = [
+    { name = "typing-extensions" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.4"
 source = { registry = "https://pypi.org/simple" }
@@ -687,6 +715,27 @@ version = "25.12.19"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "flax"
+version = "0.12.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jax" },
+    { name = "msgpack" },
+    { name = "numpy" },
+    { name = "optax" },
+    { name = "orbax-checkpoint" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "tensorstore" },
+    { name = "treescope" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/19/4a8e128e2296eede00dc7a8586d374ef0b2770146a5cda1f50aa86f001ee/flax-0.12.7.tar.gz", hash = "sha256:abfd6acb17d6b93d1d7d7dfae7d3856222b92b35d35ab2487b77639c31dc673a", size = 5476434, upload-time = "2026-04-22T06:07:12.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/65/4bd2abfd4cb6e917b2626de5cbfc034dfc94b74dd95b8272d93f2ad66bed/flax-0.12.7-py3-none-any.whl", hash = "sha256:79d590793fa3a282ac36b4464f2ea9d1e69fe1d026c4618451b01731e8086e32", size = 525130, upload-time = "2026-04-22T06:07:10.254Z" },
 ]
 
 [[package]]
@@ -1123,6 +1172,15 @@ wheels = [
 ]
 
 [[package]]
+name = "humanize"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/66/a3921783d54be8a6870ac4ccffcd15c4dc0dd7fcce51c6d63b8c63935276/humanize-4.15.0.tar.gz", hash = "sha256:1dd098483eb1c7ee8e32eb2e99ad1910baefa4b75c3aff3a82f4d78688993b10", size = 83599, upload-time = "2025-12-20T20:16:13.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/7b/bca5613a0c3b542420cf92bd5e5fb8ebd5435ce1011a091f66bb7693285e/humanize-4.15.0-py3-none-any.whl", hash = "sha256:b1186eb9f5a9749cd9cb8565aee77919dd7c8d076161cf44d70e59e3301e1769", size = 132203, upload-time = "2025-12-20T20:16:11.67Z" },
+]
+
+[[package]]
 name = "icechunk"
 version = "2.0.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1225,7 +1283,9 @@ icechunk = [
     { name = "icechunk" },
 ]
 jax = [
+    { name = "flax" },
     { name = "jax" },
+    { name = "optax" },
 ]
 tf = [
     { name = "tensorflow" },
@@ -1251,6 +1311,7 @@ dev = [
 requires-dist = [
     { name = "arraylake", marker = "extra == 'arraylake'", specifier = ">=0.14" },
     { name = "cupy-cuda12x", marker = "extra == 'gpu'", specifier = ">=13.0" },
+    { name = "flax", marker = "extra == 'jax'", specifier = ">=0.8" },
     { name = "gcsfs", marker = "extra == 'bench'", specifier = ">=2024.6" },
     { name = "icechunk", marker = "extra == 'icechunk'", specifier = ">=0.2" },
     { name = "jax", marker = "extra == 'jax'", specifier = ">=0.4.30" },
@@ -1259,6 +1320,7 @@ requires-dist = [
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.26" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "obstore", specifier = ">=0.3" },
+    { name = "optax", marker = "extra == 'jax'", specifier = ">=0.2" },
     { name = "plotly", marker = "extra == 'bench'", specifier = ">=5.20" },
     { name = "psutil", marker = "extra == 'bench'", specifier = ">=5.9" },
     { name = "py-spy", marker = "extra == 'bench'", specifier = ">=0.4" },
@@ -1748,6 +1810,58 @@ wheels = [
 ]
 
 [[package]]
+name = "msgpack"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/dd/9e8cbd8f5582ca4b590336f2b91ee5662f6a6ca562b565abaf696a0f81ff/msgpack-1.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35", size = 83531, upload-time = "2026-06-18T16:12:58.249Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2e/ebdb85a8da151397a2790363676b7ed7c125924fe618e4c6d8befb0cc62c/msgpack-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c", size = 82657, upload-time = "2026-06-18T16:12:59.396Z" },
+    { url = "https://files.pythonhosted.org/packages/26/aa/753ad8b007b464e1d8aa0c8e650b9c5f4f725e658fc5ac8a7635c55b7f6e/msgpack-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0", size = 410634, upload-time = "2026-06-18T16:13:00.383Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/6adabd4f6d5e686f97dd02ce7fce3fe4cf672cbac36b8f67ff4040e8ad8b/msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a", size = 419989, upload-time = "2026-06-18T16:13:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/85039b7b0eb168aaad7383a23c97e291a11f08351cb45a606ce865e4e3f1/msgpack-1.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6", size = 377544, upload-time = "2026-06-18T16:13:03.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bf/35963899493b32030c85fc513b723ae66144ac70c11ebc52e889e16e3d99/msgpack-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a", size = 400842, upload-time = "2026-06-18T16:13:05.012Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/df/8e2ac970c8f99264cd9997d1c73df5466bc19da3301d7dc5500862a9b089/msgpack-1.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1", size = 374108, upload-time = "2026-06-18T16:13:06.232Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dd/fa8bd265110dfa51c20cb529f9e6d240a16fafe7e645004c6af2d01353ba/msgpack-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64", size = 414939, upload-time = "2026-06-18T16:13:07.478Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8377a5ad8953fc0437c70cc98d9ae29f27fe5ac5109fbec0812085865735/msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac", size = 64504, upload-time = "2026-06-18T16:13:08.822Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7f/ce1e377df7e62461fefd9eb23bfb93a4a523f40a517b377b8f844d836828/msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24", size = 71421, upload-time = "2026-06-18T16:13:09.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/32/ebfe84c9929f08f188d56c7a2fd913406a9ddad76a634697c1c43b8112e6/msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07", size = 64775, upload-time = "2026-06-18T16:13:11.056Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ac/dcddcab6f6c20ecb387ca5e980371cdb3f87ff69aeca388be97eebc4c074/msgpack-1.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064", size = 83151, upload-time = "2026-06-18T16:13:12.173Z" },
+    { url = "https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056", size = 82351, upload-time = "2026-06-18T16:13:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/10/ddf7b06db879e8792d13934ddda09ff20bd2a583fd84c9b59aae9b0e650b/msgpack-1.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc", size = 407518, upload-time = "2026-06-18T16:13:14.233Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d", size = 416405, upload-time = "2026-06-18T16:13:15.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/84/e8e9598b557c0ba6ddae901a73780a4c75ac667dddf59414b1e56a42fb34/msgpack-1.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155", size = 376257, upload-time = "2026-06-18T16:13:17.022Z" },
+    { url = "https://files.pythonhosted.org/packages/40/16/738fe6d875ad7e2a9429c165322a4ec088f4f273cdfae63d96a89c467961/msgpack-1.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402", size = 397469, upload-time = "2026-06-18T16:13:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/be/6d5952df75a7f24f35833af764c3a6860780364cb3a0030beb8099e1b2b4/msgpack-1.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c", size = 372802, upload-time = "2026-06-18T16:13:19.685Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/39/e2ef7dbf0473bcb8dc7c50bf782a892d67414877b63e47fc88eb189ef5e6/msgpack-1.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6", size = 411273, upload-time = "2026-06-18T16:13:21.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c5/133f4512a56e983a93445c836c9d94d88f3bc2e0980ff4b9e577bd8416ce/msgpack-1.2.1-cp313-cp313-win32.whl", hash = "sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707", size = 64471, upload-time = "2026-06-18T16:13:22.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/577e10b055096a7dd40732358cabaf7180a20c79ed1dcdbb618e4b9deac7/msgpack-1.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9", size = 71274, upload-time = "2026-06-18T16:13:23.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ee/0c0048e7cfbef23c6a94791b8959ab28155232e7956de8a305b5ff588f05/msgpack-1.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a", size = 64795, upload-time = "2026-06-18T16:13:24.687Z" },
+    { url = "https://files.pythonhosted.org/packages/77/58/cce442852c6b9e1639c7c8ac8fd9143121cb32dab0f308df4d1426a8eb9c/msgpack-1.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d", size = 83610, upload-time = "2026-06-18T16:13:25.724Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5c/15b4c7a0182f75ffa90751958ba36a9c01cafee367d49a3edc10ed140b01/msgpack-1.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7", size = 83138, upload-time = "2026-06-18T16:13:26.781Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/99e58722feaffc5f2fbcc0c8c0d1451ab9f84097f7af87291b46af2390f4/msgpack-1.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889", size = 406090, upload-time = "2026-06-18T16:13:28.072Z" },
+    { url = "https://files.pythonhosted.org/packages/19/03/8c63e8cf52958534ef688625965ab04c269a6cadd8caef16758b380a821a/msgpack-1.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720", size = 412106, upload-time = "2026-06-18T16:13:29.427Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d2/155d9e71b40e41fd934bc0c48b9b2770f22263e1ac20aad8e29fdca7be3f/msgpack-1.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190", size = 374851, upload-time = "2026-06-18T16:13:30.631Z" },
+    { url = "https://files.pythonhosted.org/packages/98/48/deaf2326262a8d5ea3295ce9649912ecd3f551ba7ec8e33c665d2ba583f3/msgpack-1.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d", size = 396168, upload-time = "2026-06-18T16:13:31.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/2a/b4410f906c2ec0008f1608d3ab5143afc3ad3f4e6da0fed3ea2231d0bef4/msgpack-1.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24", size = 371959, upload-time = "2026-06-18T16:13:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/59/86/1edc67270099a528fa2093ea60fe191233cd238e4bd30cfacf7db79fc959/msgpack-1.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7", size = 408457, upload-time = "2026-06-18T16:13:34.567Z" },
+    { url = "https://files.pythonhosted.org/packages/82/90/8b630fef07d8c5ab457b71ff2c217910c83d333c7a68472c186e87cc504a/msgpack-1.2.1-cp314-cp314-win32.whl", hash = "sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb", size = 65942, upload-time = "2026-06-18T16:13:36.056Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f1/467b81e98b24dd3885d7b1857728797b4ffc76a7a7483af4fb321a07de3c/msgpack-1.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b", size = 72627, upload-time = "2026-06-18T16:13:37.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/1d/5d8c4c89985feb6acefb82a09e501c60392261856d2408d20bfe4f0360b1/msgpack-1.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7", size = 66908, upload-time = "2026-06-18T16:13:38.23Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ad2afb678b4de94496cd432b581759b756a92c1192d8c767edd6b132efdc/msgpack-1.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273", size = 86000, upload-time = "2026-06-18T16:13:39.44Z" },
+    { url = "https://files.pythonhosted.org/packages/54/74/0b797484013128837f3b1cbb6cea019277c4de4e377dc512b4d9a0f92940/msgpack-1.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1", size = 86544, upload-time = "2026-06-18T16:13:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b4/b774d7eb95561739907fec675582f83203cf41c597a418c2589b4bfb8e9d/msgpack-1.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc", size = 427661, upload-time = "2026-06-18T16:13:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f9/3243191dc9937e00756c8bc1b0272fed8f23758e43df2a3b46f533e5090f/msgpack-1.2.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde", size = 426375, upload-time = "2026-06-18T16:13:42.936Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c7/1693111db9944ba4ad4b67a1e788400d78a0b6af7a6523dc7e4e58f8274b/msgpack-1.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4", size = 380495, upload-time = "2026-06-18T16:13:44.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2b/92f86956a0c13e8662f7e2ad630c4eb4db07497b967589bd5245e018b2c1/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d", size = 410897, upload-time = "2026-06-18T16:13:45.629Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ea/1479f72d200313a76fc2f823a79d1e07ed052ab7b8a0280640aa7b95de42/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355", size = 378519, upload-time = "2026-06-18T16:13:46.998Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4d/fa006060ffa1011d32bfae826fe766fe73e02982183601633b7121058ab3/msgpack-1.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c", size = 419815, upload-time = "2026-06-18T16:13:48.205Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/aab6c946570496b78e67804721f3d5e2d62a93081b9b37df77764ef56347/msgpack-1.2.1-cp314-cp314t-win32.whl", hash = "sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1", size = 70914, upload-time = "2026-06-18T16:13:49.385Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0a/e608956488a2af014cfe6e3d665e090b8ee42aa14b07f8f95b8880d66b09/msgpack-1.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2", size = 77999, upload-time = "2026-06-18T16:13:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8a/27e2e57055176e366a46b85d02d68e7a5bcfbdd8474c9706375d965f24d3/msgpack-1.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107", size = 71160, upload-time = "2026-06-18T16:13:51.498Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1915,6 +2029,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/62/3c/c4ef2164a71c1a63d7f1ae411c4082c5fa872405106db60a4b7114989ad7/narwhals-2.22.1.tar.gz", hash = "sha256:d62920805a0a43b7ff8b54b0c0d3142d796f8a9301836ada37e573d6a33cbcd9", size = 647493, upload-time = "2026-06-05T12:34:34.051Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl", hash = "sha256:60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53", size = 454815, upload-time = "2026-06-05T12:34:32.289Z" },
+]
+
+[[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
 ]
 
 [[package]]
@@ -2266,6 +2389,21 @@ wheels = [
 ]
 
 [[package]]
+name = "optax"
+version = "0.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "jax" },
+    { name = "jaxlib" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/f9/e3d11ae6f298ee941a0690e353a323d158ba5dedc436e75621c310845c5c/optax-0.2.8.tar.gz", hash = "sha256:5b225b35066fc3eebaa4d798f1b4173b4d57d1a480610908981f8343b50af0b0", size = 301193, upload-time = "2026-03-20T23:30:05.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/69/6a93d8600c339d7687a05857c7907bd4dd8cf88691a5ea106d7a50af90a1/optax-0.2.8-py3-none-any.whl", hash = "sha256:e3ca2d36c99daab1800ae9dbc0545034382d6bc780b24d969e1b0df65fa31cb4", size = 402960, upload-time = "2026-03-20T23:30:03.886Z" },
+]
+
+[[package]]
 name = "optree"
 version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2335,6 +2473,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/eb/489d22ef3cadb2f5f3bbd6e6099d17b5a521ff533e086f78f005c3358017/optree-0.19.1-cp314-cp314t-win32.whl", hash = "sha256:312048e69dc88de26915674f961bf38980a765a6b48ead2f1672858a39402c41", size = 357465, upload-time = "2026-05-06T02:32:15.424Z" },
     { url = "https://files.pythonhosted.org/packages/e0/34/7f48b7034ff75d2eb3e94e2196709ddbf762798fb621f9508899fa66b44e/optree-0.19.1-cp314-cp314t-win_amd64.whl", hash = "sha256:60e9345405d7b06cafdf1b1dd2e2261ceddddce10f35729240f90e2bab845a0b", size = 397783, upload-time = "2026-05-06T02:32:16.853Z" },
     { url = "https://files.pythonhosted.org/packages/07/42/6d6f93416c66820cb8753e65b5ff43c47480af9c4911bd2b8406ff0f7f27/optree-0.19.1-cp314-cp314t-win_arm64.whl", hash = "sha256:4e103e212d1e8fe0399ed076eff80a905fb14929729bbd994d3660110a27a252", size = 396064, upload-time = "2026-05-06T02:32:18.077Z" },
+]
+
+[[package]]
+name = "orbax-checkpoint"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "aiofiles" },
+    { name = "etils", extra = ["epath", "epy"] },
+    { name = "humanize" },
+    { name = "jax" },
+    { name = "msgpack" },
+    { name = "nest-asyncio", marker = "sys_platform == 'win32'" },
+    { name = "numpy" },
+    { name = "prometheus-client" },
+    { name = "protobuf" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "simplejson" },
+    { name = "tensorstore" },
+    { name = "typing-extensions" },
+    { name = "uvloop", marker = "sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/70/e8b4c7f382c77d198128c50076611b9b3b7b18e795f6d7d5931755af0106/orbax_checkpoint-0.12.1.tar.gz", hash = "sha256:e9b014ccad4c9b2648cdb9946cd2550339bc3eb388ac1f494a27fda4739b4e19", size = 703150, upload-time = "2026-06-24T19:13:15.993Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/87/0ae1baf8271a7a68bcc5b91103892b201cd723ac3dd67bc6ef3e5fc4747e/orbax_checkpoint-0.12.1-py3-none-any.whl", hash = "sha256:e123b4d6e5d9f9144bb9b5a1d88b1eddc81c71f8a12b07b995f61e0d3022b0f1", size = 1311120, upload-time = "2026-06-24T19:13:14.262Z" },
 ]
 
 [[package]]
@@ -2483,6 +2648,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]
@@ -3101,6 +3275,59 @@ wheels = [
 ]
 
 [[package]]
+name = "simplejson"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/2a/54837395a3487c725669428d513293612a48d82b95a0642c936932e5d898/simplejson-4.1.1.tar.gz", hash = "sha256:c08eb9f7a90f77ae470e19a07472e9a79ebc0d1c2315d86a72767665bd5ba79f", size = 118860, upload-time = "2026-04-24T19:24:59.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/25/e90998fe8e480eb43b966c09e835379887d427567ebd496563d3b1e16b19/simplejson-4.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:19040a17154dc03d289bab68d73ce0a6a0be01de30c584bbdd93490bead14b22", size = 112414, upload-time = "2026-04-24T19:23:06.084Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a0/abd4785f36c3400f1fbb21f517be39295a750a714f04b7ee175adf6ef580/simplejson-4.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a94ebaecdbaa80d9551a3ec6bf0c9302fc8b53ab6c1b2bfd498a1df4cb28158d", size = 91120, upload-time = "2026-04-24T19:23:07.877Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/78/fc060d2e3b13c6ec59288574b8efac64075e316b2afba4396a56b2422f78/simplejson-4.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:67341c95c0a168ab4a6d1e807e50463f1c8da932c3286d81e201266c427061fa", size = 91055, upload-time = "2026-04-24T19:23:09.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b6/156a8de1e1b47694f0e7de6675866936608d45dc68388fd017d36f8693be/simplejson-4.1.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45ec18e337fec538b7e902d489505c450b2454653d1290f3f50385e6fd8aa607", size = 190297, upload-time = "2026-04-24T19:23:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/86/1c/e4d0eab695be3eb21d0f46bce820752031f03e7113f9c80a9b3c73ee7157/simplejson-4.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:820c69a4710400e9b248d5670647d60be58824369282d3925e516b3ff1a7cd82", size = 187002, upload-time = "2026-04-24T19:23:12.982Z" },
+    { url = "https://files.pythonhosted.org/packages/76/0e/7f5a59d29426b062d5928fb88b403c3f797129d53be7102f955dbe51aa44/simplejson-4.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e708d373a10e4378ef2d59f8361850c7150fd907ed49efe49bc5492160476d1", size = 195146, upload-time = "2026-04-24T19:23:14.517Z" },
+    { url = "https://files.pythonhosted.org/packages/78/18/9943db224dd4d5fa3c090c3e56a94c37b254338c83995ec5680285111c40/simplejson-4.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:980fc33353f81fd12d8c49d44f8c2760d1dc8192285e627c5180d141035b228a", size = 183931, upload-time = "2026-04-24T19:23:16.742Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/08/9a690da9a766161c06c627d805362cf159f1abe480969372b2897649b955/simplejson-4.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:de2ed102fff88dacf543699f53ee3a533cc11539a39baa176b7e09dd783069d6", size = 192228, upload-time = "2026-04-24T19:23:18.33Z" },
+    { url = "https://files.pythonhosted.org/packages/05/88/bd8aad36b451ffb0e0a3f721d695a88befa6d1ac7d1e02ae788ca7ff4029/simplejson-4.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2785ff8edc0e28bf773a32543a6bbed46351453c997b3f6709c744e3c2f7eabb", size = 187808, upload-time = "2026-04-24T19:23:21.165Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ee/14f91db0d1f481533b651dafbf8cd0da088d9817f7af30c68f7f19f9c847/simplejson-4.1.1-cp312-cp312-win32.whl", hash = "sha256:2e0d5ead6d14610467ec356ec1f6b5d8a56aa216abaad8d41c8b873b16cf313f", size = 88512, upload-time = "2026-04-24T19:23:22.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c4/90de06b2d8737c68c05ff9274113f854dbf6a5f28b7a955212111672cb57/simplejson-4.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:63a5451f557d6be48a231bae932458655c620902b868170b2f1c8afed496f6b4", size = 90748, upload-time = "2026-04-24T19:23:24.494Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a9/47b445eeb559c9593453a0648e0fd6d08e8adff64dd5e5ced66726da8a09/simplejson-4.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dff52fc7af272e84fc21cc5a06c927c823ca6ae00af14f3b0d7707b42775ed98", size = 113160, upload-time = "2026-04-24T19:23:26.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/cb72db31523c164dea5dc55b02dad065a40c478856bc7534b279d2b51906/simplejson-4.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:971aed0647ad6e840a3943bec812fcda5f2d26a5497a4981d1fb49aa4f9a396c", size = 91521, upload-time = "2026-04-24T19:23:27.572Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e5/54cb7c50ad5fdc1e0a86b7df4b135c2cbd5c4623605aa94466659098e8da/simplejson-4.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:249e2e220aa6d9b9d936bde84eb7bf79d5b6c5a8273c6e411f8b1635a9073f2d", size = 91407, upload-time = "2026-04-24T19:23:28.991Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/21a3ede87f0bf82d6c7bcb90480d50a6490eb974c6ab20881188e440957c/simplejson-4.1.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e5cdd6a5d52299f345c15ab5678cc4249e24f383f361d986afbc3c7072a6b6b", size = 192451, upload-time = "2026-04-24T19:23:30.56Z" },
+    { url = "https://files.pythonhosted.org/packages/59/df/9903edd3102bf0b5984edfcb90c88612330996efa3b4fbf8a971d6e17839/simplejson-4.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642cec364e0676e2d5a73fa4d31d0c7c55886997caa2fde24e8292ca44d32728", size = 189015, upload-time = "2026-04-24T19:23:32.647Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cd/33230927a780e1398b857e3944abb914556994d252b1d765ae40d112cb25/simplejson-4.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:76fe296ca1df23d290033f10aaacf534fd1b3e3007e7f9ff8aa68b21413aaa78", size = 196658, upload-time = "2026-04-24T19:23:34.563Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/84/2c5a7444eb53e9a86d3738299bffddd9f53aeed799ded2f45368221fdb19/simplejson-4.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8f0ad25b7dc4e0fb23858355819f2e994f1a5badcdcde8737eac7921c2f1ed2a", size = 185967, upload-time = "2026-04-24T19:23:36.191Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/68/454378e06d059cd412a7ed5d87fb6d29fd5b60f13a4d89fc1f764ff434df/simplejson-4.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:a59ebd0533f03fd06ff0c42ba0f02d93cbcdd7944922bf3b93911327a95b901f", size = 193940, upload-time = "2026-04-24T19:23:38.151Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d5/a15bf915f623a2c5a079d6e3be8256fdb8ef06f110669493a09b9d6933e0/simplejson-4.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bccbf4419676b517939852e5aeff2af6aee4dc046881c67a1581fa6f1cb01abd", size = 189795, upload-time = "2026-04-24T19:23:40.139Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c9/37212ae7dc4b607f0978c408e8633f05c810884e054c33113184c6c2c8a2/simplejson-4.1.1-cp313-cp313-win32.whl", hash = "sha256:6c845363eb5fd166fb7c72243da38f4fcfde666ede7fdf2cc6fd7762894626f7", size = 88773, upload-time = "2026-04-24T19:23:41.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a5/c7a0a47883a9015b54c9d8a4b62f2aba17bd4335b1787b9b8a0fc2fa6d52/simplejson-4.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:104d8324c34f25b4b90800bc5fa363780cbc3d8496aef061cba7ce1af9162270", size = 90888, upload-time = "2026-04-24T19:23:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/18/4a118a6a92eb33bb08c8e2fe7ec85cb96f0673491bb2b829930831ee4fbe/simplejson-4.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ed7473602b6625de793b6acba49aa949f144a475f538792067e4cf2fda2071f5", size = 110492, upload-time = "2026-04-24T19:23:44.957Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f4/84d160e9fa8cada1e0a9381cae4fa81eecd573577a5b34366d8ced59bdf7/simplejson-4.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:225c9caa324c5b554d009fb9cac22aee7711e71bd96f487938c659af467e828e", size = 90152, upload-time = "2026-04-24T19:23:46.355Z" },
+    { url = "https://files.pythonhosted.org/packages/68/31/9a5432c433a7671107182cdc9a20ea78a70f99c4e5334aa54b6d4d0d79ed/simplejson-4.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:95407269340c7f22f09776ea7b717a52cf56cfcf119b5e45f66faa4a26445bea", size = 90115, upload-time = "2026-04-24T19:23:47.743Z" },
+    { url = "https://files.pythonhosted.org/packages/78/91/3635cdb13318cb0a328abaa69e2b91251caad39d6779aa308098f341f6cb/simplejson-4.1.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3851658d642c1184d2023f0e6c9ce44a21eb1629e74e7c84ef956b128841fe12", size = 184036, upload-time = "2026-04-24T19:23:49.472Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/149b6ec5393f6849d98c59cadba888b710a8ef4b805ab91e11a566960d40/simplejson-4.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95a3bb0f78e85f4937f99092239f2011ce06f0f2d803df5c299cc05abbeae008", size = 180543, upload-time = "2026-04-24T19:23:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7c/a5d968d0b527a748b667e62bea94309ccbcb1e2b108e8f0cf8547efaa12b/simplejson-4.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbfdaa7c0603f75b7b14b211b7f2be44696d4e26833ad2d91d5c87bf5fb9a920", size = 188725, upload-time = "2026-04-24T19:23:52.995Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e3/6a8d11181d587ef00e2db9112357e6832111e56dd56b01b5c11758a1965d/simplejson-4.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:39e3c584071dced8c21b4689f0254303521daeb9b5bc1f4289755d71fa3cb0d3", size = 177492, upload-time = "2026-04-24T19:23:54.581Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e3/8b0eb8b06e8198cfbd1270487da163d0093df05cc4f557350cd65e2f7e79/simplejson-4.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:036a27bd0469b9d79557cbddb392969f876cd7f278cfbd0fba81534927a06575", size = 185281, upload-time = "2026-04-24T19:23:56.13Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/5f/64990f07ec9e2cb1a814c674e2e21b5693207f74ac70eb72151b847ea4e6/simplejson-4.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b70bfd2f67f3351baba08aa3ae9233c83f21fd95ae5e6b3d0ecb8c647929112f", size = 181848, upload-time = "2026-04-24T19:23:57.92Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/bbc1bc0447f339f79f99ab8c37f7f037cb2f1f93af75d6a4d553096bb0c3/simplejson-4.1.1-cp314-cp314-win32.whl", hash = "sha256:37233c72ce88d06acb92747347742b3c07871eba6789f060c179c9302dde8efe", size = 88761, upload-time = "2026-04-24T19:23:59.397Z" },
+    { url = "https://files.pythonhosted.org/packages/18/72/ec1b5cbdcb140c132e6c7bdf99bd73e4f675439e77126c88f472fcffa09c/simplejson-4.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:cc0442dea71cd9cbf30a0b8b9929ab5aa6c02c0443a3d977351e6ec5bada4388", size = 91018, upload-time = "2026-04-24T19:24:00.85Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/97/4fa437f68ff72219bac3bf3d050de9c6265691f3a170e16954bd69d7cddd/simplejson-4.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:c996a4d38290c515af347740659ce095b425449c164a5c9fa3977caa6eff5dbe", size = 113919, upload-time = "2026-04-24T19:24:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/83/59de041d09eb4a9577f7015d7263c32095dfb7fde49717dff62145d89809/simplejson-4.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c65c763fb20d7ca113c1c14dce2fc04a0fc3a57aceff533d6fdac707c7bffb40", size = 91904, upload-time = "2026-04-24T19:24:03.812Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8e/46bb345d540f6eb31427d984a4e518cdb182d0621814fee4fee045e8815b/simplejson-4.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0da5c9f57206ee7ef280ff7f1d924937b0a64f9a271a5ef371a2ecdbebba7421", size = 91752, upload-time = "2026-04-24T19:24:05.622Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e2/1b2ce97f068835eb3d253c116a4df7a3f436b7bf2fb5ff1ba29287e8b0ec/simplejson-4.1.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ea3426e786425d10e9e82f8a6eda74a7d6eb10d99165ac3d0d3bbcb65c0ea343", size = 214021, upload-time = "2026-04-24T19:24:07.447Z" },
+    { url = "https://files.pythonhosted.org/packages/48/70/d93e556df6a0786298644a7c08304fcbeddc248325f23f38acbebeb21165/simplejson-4.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d75cea7a1025edd7e439b2966b3d977c45b5b899e2adaf422811b3ac702ed9fb", size = 213530, upload-time = "2026-04-24T19:24:09.289Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a5/c93bf305b9f00d7259e09e713d60e75bd0f7f53da970f716ab90491770e7/simplejson-4.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:63c2ada8e58f266491f19eed2eeeb7c25c6141e52f8f9e820f6bb94156cf8dbc", size = 218282, upload-time = "2026-04-24T19:24:10.991Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/20/a9b5d2e27ec44b069ee251bd55544fc76929a067107b1050001566ba86f3/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d1fffb56305c5b475ee746cf9e04f97423ba5aaacd292dc1255bd75b1d3b124b", size = 209249, upload-time = "2026-04-24T19:24:12.662Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e4/e06ee682ed5df67592181f5ecb062e35878967e27f5b6e087237d4548d95/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a6525ec733f43d0541206cffa64fd2aad5a7ae3eb76566aff49cd4db6382209a", size = 213963, upload-time = "2026-04-24T19:24:14.302Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/9f/1e160e4cd8cdbf062bf6a454cdf814dc7a48eb47e566fdb8f80ccb202605/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:861e393260508efa64d8805a8e49c416c3484907e3f146ce966c69552b49b9a3", size = 210474, upload-time = "2026-04-24T19:24:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e6/cecd913df322df5bbe7ebb8ba39e0708e505a165553900da8a7761026d6f/simplejson-4.1.1-cp314-cp314t-win32.whl", hash = "sha256:d083b89d30948a751d3d97476c2ed91e4caaa24a1a1459bdbadb8876242c71fe", size = 91134, upload-time = "2026-04-24T19:24:17.635Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/f540dde99cc1d393bd062ab3b5735b777561a5d8f8a5f2e241164444d77a/simplejson-4.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4cbb299d0528ec0447fe366d8c9641860e28f997a62730690fef905f1f41046e", size = 94467, upload-time = "2026-04-24T19:24:19.109Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/6a/8b74c52ffd33dbbde00fe7251fee6a0acdc8cea33f7a43805aed258fb79b/simplejson-4.1.1-py3-none-any.whl", hash = "sha256:2ce92b3748f02423e26d2bfb636fb9d7a8f67c8f5854dcae69d350d123b2eee2", size = 69195, upload-time = "2026-04-24T19:24:57.962Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3165,6 +3392,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/72/72/343b86b4c9bfe28e81f749439f908c1e26aeac73d9f12b8dcdb996eb8ecb/tensorflow-2.21.0-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:a10abdfb8b1189210c251021a3f153b7ccc52a8e6521351f3dc3331e8ba593e0", size = 282213003, upload-time = "2026-03-06T17:24:59.859Z" },
     { url = "https://files.pythonhosted.org/packages/86/6c/10d075ffc09754c7f10e749ba3c9d46dd809fb007990c7f788128044180c/tensorflow-2.21.0-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:e9d8da8dcab9650efb45f032ba70af2f016f907e6e0c6bda29dd101bba945406", size = 572881074, upload-time = "2026-03-06T17:25:14.453Z" },
     { url = "https://files.pythonhosted.org/packages/86/91/dedad8403e7b0036d99be4878987693b7b7f62097eb8537fa6ce62ea131c/tensorflow-2.21.0-cp313-cp313-win_amd64.whl", hash = "sha256:76cccbe0a95d9392dee1ae501ae0656b6c73c1cac29a7f8f32d570e0670863f7", size = 351205371, upload-time = "2026-03-06T17:25:33.144Z" },
+]
+
+[[package]]
+name = "tensorstore"
+version = "0.1.84"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/18/c8e8b4faffab1a434b6c013d54cf7f5b754a6849429d9dbb718297705796/tensorstore-0.1.84.tar.gz", hash = "sha256:3cb091dfde68600e6d8f03a389ccc92ffa7c0798a0c600d1013c0138d7163e6b", size = 7208048, upload-time = "2026-05-16T06:17:58.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/8a/1b5231e965257c3ee7d4615cb49a0fac53a71a1c34b293bcf524bb7c6d13/tensorstore-0.1.84-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:915371fc2c27540e8b69c573b7a06217fb8d161ec231cedfa9f3d264615a326d", size = 16571584, upload-time = "2026-05-16T06:17:13.283Z" },
+    { url = "https://files.pythonhosted.org/packages/88/5d/52e52aa00a5ae3ebe1116ca52ac9f47ef98e94f6c4e411649cd3d1bb79cc/tensorstore-0.1.84-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4477eabe26e2f5131f1b1a3444cd9167fe69fabc29579eab8259d218399b9e6b", size = 14905169, upload-time = "2026-05-16T06:17:15.638Z" },
+    { url = "https://files.pythonhosted.org/packages/61/36/f88b4bf267902f12cd2ca33aff10fabd6839dd1ce7d51876ebefa98aaf2c/tensorstore-0.1.84-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ace00cf2e45dc5d64fe3a10c2cbef61343915683808a10a3e081233566a7231", size = 19345134, upload-time = "2026-05-16T06:17:17.984Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7c/b7b24e10e5cb0213c85204d53fcd60d0568d986ea0001a00a815e14e01e1/tensorstore-0.1.84-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64c8039558d5607b73903948fce058725731df410c5c196cf58b3fc6222395b5", size = 20968745, upload-time = "2026-05-16T06:17:20.569Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/36/33ad454a2b667a93b35e74595a351dbf9b8693440bd68665990663b79164/tensorstore-0.1.84-cp312-cp312-win_amd64.whl", hash = "sha256:08e7ec5b35db5d4c4b6a867be8500448f9bd4e0c9d5a52d7f0b460650622baf6", size = 13398458, upload-time = "2026-05-16T06:17:22.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/27/3c637c0f987866f6fb92cf96ee4d40eee4b5ab699135803ada851f2a56ad/tensorstore-0.1.84-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:9337d96693b4a0e555fbe63bb228e3e2e681a80e4d371f351fb67810f197f74e", size = 16571472, upload-time = "2026-05-16T06:17:24.885Z" },
+    { url = "https://files.pythonhosted.org/packages/41/83/4f3c6ef9bed01f384036c2030b3901cf075bbc8eff6e4529e502f0283ab5/tensorstore-0.1.84-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:028455cccdc05c31f194048cf459a26669b26d38f0516caf9213e7219b1ee79a", size = 14905288, upload-time = "2026-05-16T06:17:26.753Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/28/03e46405ba7c616e7a1ec5425a8f4a1b3f4d6ec2be359cb2f248199849e4/tensorstore-0.1.84-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50afb06c57a509091015af6a85da6f483a7f5ad0372284dd95d5513d877336e4", size = 19344890, upload-time = "2026-05-16T06:17:28.956Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c6/82669e70cef67c803852285ba6f59d7e3d102983c0ab4be8269c14756677/tensorstore-0.1.84-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ea53a851ea86aad3d99c14a790c85468d6324be14c7ac211f1f0265e8fab707", size = 20968230, upload-time = "2026-05-16T06:17:31.374Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/12/97d8ad183e3130e168f2feb860edd68f1b72e57f29268d980f3b70e34cd0/tensorstore-0.1.84-cp313-cp313-win_amd64.whl", hash = "sha256:fe9bf1c7fef69884a91222179550f9b5ba6c1454f9534429221824d9b15c00ec", size = 13398858, upload-time = "2026-05-16T06:17:33.658Z" },
+    { url = "https://files.pythonhosted.org/packages/39/bd/fda828e7915ddb61704a6f4568b5b7ce9fe607c33b7535cf51b4fd900b38/tensorstore-0.1.84-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:97e767a64415297f019dd1e4b9af6a23d72e126e2a2d05cf41083253abe81428", size = 16576451, upload-time = "2026-05-16T06:17:35.993Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/99/2e72fcb19404de43f9412880c542a8ef8651bd30183c85454d6ca14ebe56/tensorstore-0.1.84-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7d01775985fcaa2b0f100349766a953c5086e92e746bf395e936151d4d8f9ac", size = 14907896, upload-time = "2026-05-16T06:17:38.458Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d4/9a3964cdfdc5a15df6d0485694de9684c13990a5b0f5d88bfa365e0a2936/tensorstore-0.1.84-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b2ff5d5536a8a9b1596c51b9075cc9d40b4c4ea4e6cc03c0480111dbe5d956d", size = 19347021, upload-time = "2026-05-16T06:17:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/43/19/70532cb2bf2f6fc3bf252f850bfb528b26eeb9c30c3cafffb075cbb7c77a/tensorstore-0.1.84-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c9108ae6c29adc90b72ca267ba2b577386c5e410ea2f8e87eabce5ebdad327e", size = 20970345, upload-time = "2026-05-16T06:17:43.874Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/22/a523e7576c83a6c35bd1415e5f4530b0f1e448c099d7e22684f55792755c/tensorstore-0.1.84-cp314-cp314-win_amd64.whl", hash = "sha256:4096220f4b9a2411c3751597dd8ced2f671d7a217575613c915191e19d5ea150", size = 13787429, upload-time = "2026-05-16T06:17:46.135Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/23/40b0a0a91973431770ac09a8b69039bd7a051169f6707b63a1c51ad36782/tensorstore-0.1.84-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:70284a7225d94adad5989de7f9238638ec9fec2bdd8c0fdb86d567f16d59e615", size = 16652804, upload-time = "2026-05-16T06:17:49.226Z" },
+    { url = "https://files.pythonhosted.org/packages/01/99/2ea3b37864adb2e9f6e724c6959ab2b7f56aa4dad01964d4b32adf211e68/tensorstore-0.1.84-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:98e10cae5b3fc0828967b8ddf36242b3b26ac8bc79880bc3e36346063259212a", size = 14990904, upload-time = "2026-05-16T06:17:51.464Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/26/fe72887d7b91e832bef3033d244c4c548993d1b6fb19177dff3895659c12/tensorstore-0.1.84-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98edbc57d453ba8ebcf0d19bc28e4de6de95922bee2eca0805955b0833b8ce26", size = 19365698, upload-time = "2026-05-16T06:17:53.748Z" },
+    { url = "https://files.pythonhosted.org/packages/37/74/35a1d41343f86f6e2ef135e81f6b8107b9f16c777a3e8be9e3fbce541d18/tensorstore-0.1.84-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bd20de85c1b83dd3ca94db24e7bd449bdb055590a1b162b05691f6b81fff00f", size = 20986107, upload-time = "2026-05-16T06:17:56.571Z" },
 ]
 
 [[package]]
@@ -3249,6 +3507,18 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/d4/af694ef718aedbe95a72760ab9ff7a6a7a44ace2d7f70c27bfeb67c5c503/torchdata-0.11.0-py3-none-any.whl", hash = "sha256:52b940fbbe0e00fb21cabddf528449d1bec5bfb0d0823b7487b15f951658ee33", size = 61968, upload-time = "2025-02-20T22:26:30.666Z" },
+]
+
+[[package]]
+name = "treescope"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/2a/d13d3c38862632742d2fe2f7ae307c431db06538fd05ca03020d207b5dcc/treescope-0.1.10.tar.gz", hash = "sha256:20f74656f34ab2d8716715013e8163a0da79bdc2554c16d5023172c50d27ea95", size = 138870, upload-time = "2025-08-08T05:43:48.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/2b/36e984399089c026a6499ac8f7401d38487cf0183839a4aa78140d373771/treescope-0.1.10-py3-none-any.whl", hash = "sha256:dde52f5314f4c29d22157a6fe4d3bd103f9cae02791c9e672eefa32c9aa1da51", size = 182255, upload-time = "2025-08-08T05:43:46.673Z" },
 ]
 
 [[package]]
@@ -3388,6 +3658,38 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
 ]
 
 [[package]]
@@ -3650,4 +3952,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/93/8d/aeb164004f87543b06ef54f885d02c342c31ceb274e2bbec470a98927621/zarr-3.2.1.tar.gz", hash = "sha256:71565b738a0e7e8ed226f0516eba8c6bb53440ad7669a8c48ebb3534a161d035", size = 675161, upload-time = "2026-05-05T12:37:22.383Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/0a/469e2bd01be1490336e6c8707386845655d59261543315778a3ccc7e8019/zarr-3.2.1-py3-none-any.whl", hash = "sha256:f78cdd3d9687ad0e9f9cba2c5683b64f0c52589c19f685eeabe872e93cc0d2c7", size = 319617, upload-time = "2026-05-05T12:37:20.66Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
Implements the **M-W milestone** — windowed / multi-offset sampling for forecasting, train-in-place, **no reshard**. A variable becomes a `(label, path, offset)` view that reads `array[anchor + offset]`; forecasting is expressed by duplicating a variable at different offsets (`{"x": g, "y": g.shift(1)}`). One PR, phased.

## Design (locked)
- A variable = `(label, path, offset)`. `Batch` stays a flat `{label: array}` dict (offsets metadata + projection helpers land in Phase 3).
- **Decode-once**: pool slots key on the array *path*, so several windowed views of one array share a single decode.
- **No guard band**: the engine enforces *range validity only* (`anchor + offset` on-array via `valid_anchor_range`). Whether offset choices define a meaningful (non-leaky) task is the user's call. Partitioned anchors give disjoint train/val labels for any offset (injective translation); the shared boundary timestep is only ever a val *input*, never scored.

## Phases
- **0** (`3c7ffd6`) — pool keys slots by array path.
- **rename** (`b7a318a`) — `ArrayGeometry.name → path` (real zarr path, e.g. nested `surface/hourly/t2m`).
- **1** (`1dd283d`) — `ArrayGeometry.offset` + `.shift(k)`; `valid_anchor_range(offsets, n_samples)`.
- **2a** (`f3a9155`) — plan + scheduler key reads/opens by `geom.path` with dedup (decode-once proven end-to-end).
- **2b** (`89a130f`) — offset applied end to end: anchor-indexed gather at `anchor + offset`, edge-anchor drop, per-block read-union with **reference-counted** residency.

## Residency & a cross-epoch race
Residency is reference-counted (`_pinned: dict[key,int]`), not boolean — windows let one chunk feed several blocks. The driver references a chunk on admit so it stays resident from in-flight fetch to last use (the single-pass driver can't re-fetch, so an early eviction would deadlock).

A cross-epoch reference leak (found by the windowed partial-iteration test) is fixed with a per-epoch `_Slot.claimed` flag: the consumer's `wait_ready` won't gather a chunk until the driver has claimed it, so the order is always **pin → consume → release**.

windowed+shuffle holds the whole split resident (shuffle spills reads into arbitrary blocks — decode-once, the accepted memory cost; spill to NVMe via `cache_dir`). Bounded-residency windowed+shuffle (per-block driving + re-fetch) is a deferred follow-up.

## Tests
Forecast leads by one (shuffle on/off), `{-1,0,+1}` history+target drops both edges, windowed eviction + 3-epoch cross-epoch reuse, windowed partial-iteration leaves clean counters/slots, refcount needs matching unpins, `unpin_all` drops abandoned partials but keeps ready, scheduler decode-once + lead. Full suite green across repeated runs (incl. the free-threaded 3.13t CI job); non-windowed behavior unchanged.

Still to come (not in this PR): **Phase 3** `Batch.offsets` + projection helpers, **Phase 4** torch/JAX/TF advected-field examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)