### PR TITLE
Cross-run cache persistence + observability + transform fingerprint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,10 @@ jobs:
       matrix:
         include:
           # torch + the cold-start bench deps + the Icechunk handoff (no jax/tf in this env).
+          # cache pulls cloudpickle so the cross-run cache fingerprint exercises its
+          # cloudpickle path here rather than importorskip-skipping it.
           - python: "3.12"
-            extras: "--extra torch --extra bench --extra icechunk"
+            extras: "--extra torch --extra bench --extra icechunk --extra cache"
           # JAX alone.
           - python: "3.12"
             extras: "--extra jax"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -38,7 +38,7 @@ arrive DLPack-ready with no labeled-array machinery in the loop. (xarray is stil
 | Neighbor | Why insitubatch is different |
 |---|---|
 | **MosaicML Streaming / WebDataset** | They require **resharding** into a sample-oriented format (MDS/tar) — a full ETL copy, and a "sample" becomes an opaque blob. insitubatch trains **in place** on the existing ndim Zarr; splits/shuffle/batches live in **coordinate space**. |
-| **xbatcher + DataLoader (worker stack)** | xbatcher (an xarray-contrib community project) is the standard, elegant way to *define* ndim batches — **xarray-native**, yielding `xr.DataArray`. Its torch-worker engine (N **processes**) is strongest at the GRIB / one-sample-per-chunk end, and elsewhere pays worker cold start, memory ∝ workers, and per-sample decode on the uncached path. insitubatch keeps the same ndim batch semantics but stays at the **numpy/tensor** level on a *different engine* — one async loop — winning **cold start** (inference) and **memory** across the chunk spectrum (training). The caches differ in kind: insitu's in-place decoded-chunk pool (deduped, no second copy) vs xbatcher's opt-in **materialized-batch** zarr store — which *does* persist across runs, where insitu's does not yet. Complementary tools; pick by regime (and we tune xbatcher well before any comparison). |
+| **xbatcher + DataLoader (worker stack)** | xbatcher (an xarray-contrib community project) is the standard, elegant way to *define* ndim batches — **xarray-native**, yielding `xr.DataArray`. Its torch-worker engine (N **processes**) is strongest at the GRIB / one-sample-per-chunk end, and elsewhere pays worker cold start, memory ∝ workers, and per-sample decode on the uncached path. insitubatch keeps the same ndim batch semantics but stays at the **numpy/tensor** level on a *different engine* — one async loop — winning **cold start** (inference) and **memory** across the chunk spectrum (training). The caches differ in kind: insitu's in-place decoded-chunk pool (deduped, no second copy) vs xbatcher's opt-in **materialized-batch** zarr store; both now persist across runs (insitu via `persist=True`). Complementary tools; pick by regime (and we tune xbatcher well before any comparison). |
 | **Earth2Studio (NVIDIA)** | An **xarray-centric** inference framework: its `DataSource` yields `xr.DataArray`, and xarray is load-bearing down to `prep_data_array`. insitubatch doesn't build xarray — *inside* their loop the win is an obstore store-swap (an obstore contribution, not ours); *around* their models it feeds `(tensor, coords)` batches straight to `model.create_iterator`, where `coords` is a light metadata dict, not the xarray machinery. |
 | **DALI / kvikio / nvCOMP** | The GPU compute/decompress path — a *peer* we interop with (cupy→dlpack→torch, optional nvCOMP), not the orchestration. |
 | **anemoi-datasets** | Weather-locked, opinionated schema. We are general ndim arrays. |
@@ -207,9 +207,9 @@ parameterized by:
 Caveats: (1) **mmap isn't free for read-once** — scattering into mmap is NVMe write
 traffic even when never reused, so default the pool to **heap** for streaming and
 use mmap only to spill a working set past RAM or for cross-epoch reuse. (2)
-**cross-*run* persistence is still extra** — intra-run/cross-epoch reuse is
-intrinsic (just don't evict), but surviving process exit needs a stable content key
-+ index rebuild on reopen (the deferred cache item below).
+**cross-*run* persistence is now a flag** (`persist=True`, M-C2 ✅) — intra-run/
+cross-epoch reuse is intrinsic (just don't evict); surviving process exit adds a
+manifest of completed slots + a chunk-transform fingerprint, revived on reopen.
 
 Internals are **validated** (`bench/spike_v2_decode.py`, zarr 3.2): key via
 `chunk_key_encoding.encode_chunk_key`, bytes via `store.get`, decode via
@@ -226,8 +226,9 @@ Internals are **validated** (`bench/spike_v2_decode.py`, zarr 3.2): key via
   cross-epoch decode-once reuse (the scheduler skips fetch+decode+transform on a
   still-resident chunk). The pool is dataset-owned (persists across epochs); B1's
   `resident_cap` admission unified into the budget (consumer `unpin` replaces
-  `evict`, eviction is unpinned-LRU). Remaining: cross-*run* persistence (stable
-  content key + index rebuild on reopen).
+  `evict`, eviction is unpinned-LRU). **M-C2 ✅** later added cross-*run* persistence
+  (`persist=True`): a manifest of completed slots + a chunk-transform fingerprint
+  survive `close` and revive on reopen.
 
 Demonstrate: on `era5_fatspatial`, plot throughput **and** peak heap vs concurrency
 — v1 (concurrency = `block_chunks`) rises in both; V2 (`block_chunks` fixed small,
@@ -434,8 +435,9 @@ at `2*block_chunks`); the v1 shuffle-block buffer is retired. **Acceptance passe
 on fat-spatial S3: 1052 MB/s at `max_inflight=32` (beats the 930 v1 peak) with
 residency flat across the concurrency sweep. **B2 done** — the `ChunkPool` is now
 the cache too (byte budget + pin/unpin + LRU, heap or mmap backing; cross-epoch
-decode-once reuse via `cache_dir`/`cache_budget_bytes`). **Not yet built:** cross-*run*
-cache persistence, `Regrid` + the GPU/device transform stage (M2), bounded read-ahead (M-RA).
+decode-once reuse via `cache_dir`/`cache_budget_bytes`; cross-*run* persistence via
+`persist=True`, M-C2). **Not yet built:** `Regrid` + the GPU/device transform stage (M2),
+bounded read-ahead (M-RA).
 
 ## Roadmap / milestones
 
@@ -499,15 +501,24 @@ Engine track (make it real for models — see [docs/architecture.md](docs/archit
   intercept and the standalone cache classes were retired — caching is no longer a
   separate intercept, it became "don't evict." Deferred: an L1/L2 (RAM+NVMe) tier and
   cached cross-variable derived variables (cross-*run* persistence is M-C2).
-- **M-C2 — cross-run persistent cache.** The mmap'd `.npy` slots under `cache_dir`
-  already *survive* the process (they are files on NVMe), but nothing rebuilds the
-  index to reuse them — so each new run re-fetches + re-decodes from S3. Add a
-  **persisted slot index** (`(array, chunk_index) → file`, with shape/dtype and the
-  chunk-transform version) rebuilt on startup, gated by a **content fingerprint**
-  (store URL + zarr metadata + codec + chunk-transform identity) so stale slots are
-  invalidated when the data or pipeline changes. Then decode-once amortizes across
-  *runs*, not just epochs — a relaunched job, a hyperparameter sweep, or several
-  processes on one box read decoded chunks straight from NVMe (no S3, no decode).
+- **M-C2 — cross-run persistent cache ✅.** `persist=True` (with `cache_dir`) keeps the
+  mmap'd `.npy` slots past `close` and writes a JSON **manifest** of completed entries
+  (`(array, chunk_index) → file`); a new pool over the same dir **revives** them as ready
+  hits on first touch, so decode-once amortizes across *runs* — a relaunched job, a
+  hyperparameter sweep, or several processes on one box read decoded chunks straight from
+  NVMe (no S3, no decode). Invalidation has two automatic guards: a **chunk-transform
+  fingerprint** in the manifest header (explicit `transform.cache_key` → optional
+  cloudpickle hash of closures+globals → best-effort source hash that warns) and a
+  per-entry **shape/dtype** check on revive; either mismatch is a *miss* (re-fetch +
+  overwrite), never an error. Crash-safe (only completed chunks are listed; atomic write).
+  Observability: per-epoch `cache_hits`/`cache_misses` + one WARN when persistence was
+  asked for but served nothing. **Deliberately not in the key:** the store URL —
+  Icechunk/Arraylake session stores have no round-trippable URL, so the `cache_dir` path
+  *is* the dataset identity (bury a version in it); content/etag drift is the user's call.
+  The key's `chunk_index` is the *global* zarr index, so subsets/splits share entries.
+  *Still deferred:* a reshaping `chunk_transform` (`Regrid`) on the mmap tier (slot sized
+  at source shape), a raw-decoded tier keyed by source only, orphaned-file GC across
+  version bumps, and the kvikio/GDS NVMe→GPU feed off the persistent tier.
   Scope: a read-through cache keyed by fingerprint; a shared/networked cache tier and
   the L1/L2 split above are later.
 - **M-W — windowed / multi-offset sampling (sample geometry v2).** The forecasting

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ tiles scatter into a **`ChunkPool`** that is the assembly buffer *and* the cache
 (byte budget + pin/LRU, heap or mmap-on-NVMe). **Read concurrency and
 residency/shuffle span are independent dials** — the decoupling reaches ~1 GB/s at
 flat, low memory (validated on S3; see below). Built: planner + chunk-aligned
-splits, async obstore reads, the scheduler + pool (with **cross-epoch decode-once
-caching**), chunk/batch **transforms** (incl. a fitted `StandardScaler`),
-**prefetch**, the torch / JAX / TF surfaces, and runnable [examples](examples/);
-validated free-threading-correct on 3.13t. Not yet built: `Regrid` + the **GPU/device**
-transform stage, and cross-*run* cache persistence — see the roadmap in [DESIGN.md](DESIGN.md).
+splits, async obstore reads, the scheduler + pool (with **decode-once caching**,
+cross-epoch and **cross-run** via `persist=True`), chunk/batch **transforms** (incl. a
+fitted `StandardScaler`), **prefetch**, the torch / JAX / TF surfaces, and runnable
+[examples](examples/); validated free-threading-correct on 3.13t. Not yet built:
+`Regrid` + the **GPU/device** transform stage — see the roadmap in [DESIGN.md](DESIGN.md).
 
 📖 **Docs:** <https://emfdavid.github.io/insitubatch/>
 (see [Tuning](https://emfdavid.github.io/insitubatch/tuning/) for the

--- a/bench/benchmark_plan.md
+++ b/bench/benchmark_plan.md
@@ -276,6 +276,27 @@ uv run python -m bench --url-prefix s3://$BUCKET/era5 --storage s3 \
   --repeats 3 --cache-dir /mnt/nvme/insitu-cache --plot
 ```
 
+#### Cache-vs-cache (xbatcher `cache=` enabled) — future work, not yet wired
+
+The story-3 run above is insitu's chunk cache vs xbatcher's *uncached* path: the
+xbatcher engine (`bench/engines.py:_run_xbatcher`) builds
+`BatchGenerator(da, input_dims=...)` with **no `cache=`**. A fair cache-vs-cache
+comparison needs two changes first:
+
+1. **Wire xbatcher's batch cache** into `_run_xbatcher`: pass
+   `BatchGenerator(..., cache=zarr.storage.DirectoryStore("/mnt/nvme/xb-cache"))`
+   behind a new `--caches` value (e.g. `xb-disk`) so the harness can select it.
+2. **Match shuffle semantics.** xbatcher's cache freezes batch composition (only
+   batch *order* reshuffles via the DataLoader); insitu re-draws membership each
+   epoch. Either disable shuffle on both for the throughput number, or report the
+   shuffle asymmetry alongside it — don't quietly compare a frozen-composition warm
+   read against insitu's full reshuffle. See the caching-continuum table in
+   [architecture.md](../docs/architecture.md).
+
+Run it on the **`c6id.8xlarge`** bench box (32 vCPU + NVMe), not a small instance —
+both caches want the instance-store NVMe and enough cores to keep the warm path
+loader-bound, not CPU-bound.
+
 ### Story 4 — efficiency vs the raw-GET ceiling
 
 The probe's sec-2 raw-GET section (on by default) reads the same bytes with no

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -458,34 +458,77 @@ shortcut: it is exactly what lets xbatcher's cache survive process exit today.
 | key | `(array, chunk_index)` | batch index → zarr store |
 | backing | heap or mmap'd `.npy` (reclaimable NVMe page cache) | zarr store (local dir or cloud) |
 | cross-epoch reuse | intrinsic (just don't evict) | yes |
-| cross-run persistence | **not yet** (see below) | **yes** — survives restarts |
+| cross-run persistence | **yes** — `persist=True` (see below) | **yes** — survives restarts |
 | shuffle | sits *before* shuffle: sample→batch membership re-drawn every epoch | batch composition frozen; only batch *order* reshuffles |
 | sweet spot | many samples per chunk, fat-chunk, multi-epoch, scoring reuse | one-sample-per-chunk, stable batch defs reused across runs |
 
-The two rows that decide it: insitu avoids the second copy and keeps a stronger
-per-epoch shuffle (the cache is upstream of shuffling), while xbatcher's batch cache
-**persists across runs** and insitu's does not — yet. Closing that one gap is the
-cross-run work below.
+Both persist across runs now; the distinction is the **unit**. insitu caches deduped
+decoded chunks (no second copy, `gather` views the slot in place) and keeps a stronger
+per-epoch shuffle because the cache is *upstream* of shuffling; xbatcher caches
+materialized batches with frozen composition. Pick by regime, not by a missing feature.
 
-### Cross-run persistence (planned)
+### Cross-run persistence
 
-Intra-run cross-epoch reuse is intrinsic (just don't evict). Surviving process exit
-is the one place the batch-cache model leads today, and it is the gap this closes — a
-deduped decoded-chunk tier on NVMe rather than a separate materialized batch copy:
+`persist=True` (with a `cache_dir`) turns the mmap tier into a cache that **survives
+process exit**: ready slot files are kept on `close`, a JSON manifest records the
+completed entries, and a fresh dataset over the same `cache_dir` revives them as ready
+hits on first touch — the fetch driver's existing hit path skips fetch *and* decode
+*and* transform, so a warm run re-decodes **zero** chunks. Without `persist`,
+`cache_dir` is ephemeral spill (files unlinked on close).
 
-- **A content key.** Within a run the key is `(array, chunk_index)` because one pool
-  == one fixed pipeline. A cross-run key must add a fingerprint of (a) source
-  identity (store URL + array + chunk version/etag) and (b) the chunk-transform
-  pipeline (stats + transform list), so changed data *or* transforms invalidate.
-  Require transforms to expose a stable `version` / config hash.
-- **Index rebuild on reopen.** The slot files persist; a dir scan on init (parse
-  `(array, chunk)` + size) recovers entries written by earlier runs.
-- **A raw-decoded tier** keyed by source identity only (decode being the expensive
-  cloud + decompress step), beneath the prepped tier, would let transform
-  experimentation reuse decoded chunks without a fingerprint.
-- **GDS synergy.** A persistent NVMe tier of prepped `.npy` chunks is the natural
-  feed for the kvikio/GDS NVMe→GPU path; cross-process reuse then needs atomic
-  writes / immutable files + light locking.
+```python
+ds = InSituDataset(store, manifest, cache_dir="/mnt/nvme/era5/v3",
+                   persist=True, cache_budget_bytes=...)
+```
+
+Two automatic guards keep a reopened cache honest, and **either mismatch is a miss
+(re-fetch + overwrite), never an error** — the cache is a transparent optimization:
+
+1. a **chunk-transform fingerprint** in the manifest — change your `chunk_transforms`
+   and the whole cache is discarded (cold start), never served stale; and
+2. a per-entry **shape/dtype check** on revive — a chunk whose stored geometry no
+   longer matches the current array is ignored.
+
+The fingerprint resolves each transform by, in order: an explicit `transform.cache_key`
+(authoritative), a `cloudpickle` hash (the optional `cache` extra — captures closures
+and referenced globals, so a changed closed-over constant invalidates), or a
+best-effort source hash (catches an edited body but not a changed closure/global — it
+warns once so the weaker guarantee is visible).
+
+**Observability.** `dataset.cache_hits` / `cache_misses` give per-epoch counts; a plain
+miss is silent, but `persist=True` serving **zero** hits while the cache was
+consulted-and-rejected emits one WARNING per epoch — a cache you configured but that
+isn't working is loud, not silent.
+
+**Invariants the engine guarantees:**
+
+- The cache key is `(array_path, global chunk_index)` — the *absolute* zarr chunk index,
+  not relative to a split or `sample_range`. So overlapping subsets/splits and a later
+  fuller run **share** entries: chunk 5 is always the same `.npy`.
+- A hit returns the **prepped** chunk (post-`chunk_transform`), no copy — `gather` views
+  the slot in place.
+- **Crash-safe:** the manifest lists only *completed* chunks (written atomically on
+  `close`), so a `.npy` left half-written by a crash is ignored on reopen.
+
+**What you must ensure (the guarantee boundary):**
+
+- **The `cache_dir` path is the dataset identity.** The **store URL is not in the key**
+  (an Icechunk/Arraylake session store has no round-trippable URL), so pointing one
+  `cache_dir` at two sources that share array paths + geometry would serve the wrong
+  chunks. Use a distinct dir per dataset and bury a version in the path (`…/era5/v3/`)
+  that you bump when the **source data** changes — content/etag drift is deliberately
+  not detected.
+- **`chunk_transforms` must be deterministic** (they are baked into the cached chunk).
+  If you rely on auto-invalidation when you edit one, install the `cache` extra
+  (cloudpickle) or set an explicit `transform.cache_key`; the source-only fallback can
+  miss closure/global changes.
+
+**Limitations (deferred).** A **reshaping** `chunk_transform` (e.g. `Regrid`) on the
+mmap tier still raises — the slot is sized at the source shape, so the persistent cache
+covers shape-preserving transforms today. A raw-decoded tier (keyed by source only, for
+transform experimentation), orphaned-file GC across version bumps, and the kvikio/GDS
+NVMe→GPU feed off the persistent `.npy` tier remain on the roadmap
+([DESIGN.md](https://github.com/emfdavid/insitubatch/blob/main/DESIGN.md)).
 
 ## Earth2Studio integration
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -443,12 +443,35 @@ fat-chunk regime (one chunk → many batches); scoring/verification (reference c
 reused across metrics, lead times, models); datasets that fit in RAM/NVMe
 (effectively in-memory at GPU-fed speed after the first pass).
 
-### Cross-run persistence (deferred)
+### Two cache models: chunks vs batches
+
+insitubatch and xbatcher both cache — they cache *different things*, and each choice
+buys something real. [xbatcher](https://github.com/xarray-contrib/xbatcher) serializes
+**assembled batches** to a zarr store; insitubatch retains **decoded, chunk-transformed
+chunks** in the pool. Caching whole batches is a deliberate design choice, not a
+shortcut: it is exactly what lets xbatcher's cache survive process exit today.
+
+| dimension | insitubatch — chunk pool | xbatcher — batch cache |
+|---|---|---|
+| unit cached | decoded + chunk-transformed **chunk** (deduped) | **assembled batch**, in batch layout |
+| extra copy | none — `gather` views the slot in place | a separate materialized copy |
+| key | `(array, chunk_index)` | batch index → zarr store |
+| backing | heap or mmap'd `.npy` (reclaimable NVMe page cache) | zarr store (local dir or cloud) |
+| cross-epoch reuse | intrinsic (just don't evict) | yes |
+| cross-run persistence | **not yet** (see below) | **yes** — survives restarts |
+| shuffle | sits *before* shuffle: sample→batch membership re-drawn every epoch | batch composition frozen; only batch *order* reshuffles |
+| sweet spot | many samples per chunk, fat-chunk, multi-epoch, scoring reuse | one-sample-per-chunk, stable batch defs reused across runs |
+
+The two rows that decide it: insitu avoids the second copy and keeps a stronger
+per-epoch shuffle (the cache is upstream of shuffling), while xbatcher's batch cache
+**persists across runs** and insitu's does not — yet. Closing that one gap is the
+cross-run work below.
+
+### Cross-run persistence (planned)
 
 Intra-run cross-epoch reuse is intrinsic (just don't evict). Surviving process exit
-needs more (xbatcher's batch cache, by contrast, *does* persist across runs — it writes
-assembled batches to a zarr store; the trade-off is a separate materialized copy in batch
-layout rather than a deduped decoded-chunk cache):
+is the one place the batch-cache model leads today, and it is the gap this closes — a
+deduped decoded-chunk tier on NVMe rather than a separate materialized batch copy:
 
 - **A content key.** Within a run the key is `(array, chunk_index)` because one pool
   == one fixed pipeline. A cross-run key must add a fingerprint of (a) source

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -121,9 +121,10 @@ The cross-epoch probe on `fat_g16` confirms it independently (1006 → 4509, 4.5
     xbatcher **without** caching (the bench engine builds `BatchGenerator` with no `cache=`).
     xbatcher *does* have an opt-in cache
     ([docs](https://xbatcher.readthedocs.io/en/latest/user-guide/caching.html)): it serializes
-    **assembled batches** to a zarr store that persists across epochs *and across runs* —
-    insitu's chunk cache is in-process and cross-run persistence isn't built yet, so on that
-    axis xbatcher is ahead. The designs differ in kind: insitu caches **decoded chunks** in
+    **assembled batches** to a zarr store that persists across epochs *and across runs*. insitu
+    now persists across runs too (`persist=True`), but **this figure uses neither** persistent
+    cache — it measures insitu's in-process cross-epoch cache against the uncached worker stacks.
+    The designs differ in kind: insitu caches **decoded chunks** in
     the pool (no second copy, deduped across samples/splits, reusable under any shuffle order
     or batch transform); xbatcher caches **materialized batches** (a separate copy in batch
     layout with a fixed shuffle/augmentation baked in). A fair cache-vs-cache run (xbatcher

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,11 +93,11 @@ uv sync --extra gpu      # CUDA box only: cupy + kvikio zero-copy path
 
 **Alpha — validated on real cloud IO.** Built: planner + chunk-aligned splits, async
 obstore reads, the decoupled fetch **`Scheduler`** + **`ChunkPool`** (assembly buffer
-*and* cross-epoch cache — byte budget + pin/LRU, heap or mmap-on-NVMe), approximate
-(shuffle-block) shuffle, chunk/batch **transforms** (incl. a fitted `StandardScaler`),
-**prefetch**, and the **torch / JAX / TF** surfaces. Not yet built: `Regrid` + the
-**GPU/device** transform stage, multi-timestep windows that cross chunk boundaries, and
-cross-*run* cache persistence.
+*and* cache — byte budget + pin/LRU, heap or mmap-on-NVMe, with **cross-run
+persistence** via `persist=True`), approximate (shuffle-block) shuffle, chunk/batch
+**transforms** (incl. a fitted `StandardScaler`), **prefetch**, and the **torch / JAX /
+TF** surfaces. Not yet built: `Regrid` + the **GPU/device** transform stage, and
+multi-timestep windows that cross chunk boundaries.
 
 [DESIGN.md](https://github.com/emfdavid/insitubatch/blob/main/DESIGN.md) is the single
 source of truth for status, the roadmap, and the scope limits.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,13 @@ gpu = [
 virtual = [
     "virtualizarr>=1.2",
 ]
+# Stronger cross-run cache invalidation: cloudpickle fingerprints a chunk_transform
+# (closures + referenced globals), so editing one invalidates the persisted cache
+# automatically. Optional -- without it the fingerprint falls back to a best-effort
+# source hash (and warns); an explicit `transform.cache_key` is always honored.
+cache = [
+    "cloudpickle>=3",
+]
 # Benchmark suite extras: the xbatcher baseline (B2), plotting, and the py-spy
 # sampling profiler (probe_decode --profile). (pandas comes in transitively via
 # xarray.)

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -21,10 +21,14 @@ Buffer and cache differ only in budget + backing, so they are the same code:
 With ``persist=True`` (requires a ``backing_dir``) the mmap tier becomes a **cross-run
 cache**: slot files survive ``close`` (only budget eviction removes them), a JSON
 manifest records the completed entries, and a new pool over the same dir revives them
-as ready hits -- no fetch/decode. The ``backing_dir`` path *is* the dataset+pipeline
-identity (bury a version in it); the only automatic guard is a structural shape/dtype
-check on revive, and a mismatch is treated as a miss (recompute + overwrite), not an
-error. Without ``persist`` a ``backing_dir`` is ephemeral spill (unlinked on close).
+as ready hits -- no fetch/decode. The ``backing_dir`` path *is* the dataset identity
+(bury a version in it; the store URL is not in the key). Two automatic guards: the
+manifest carries a **chunk_transform fingerprint** (changed transforms -> whole cache
+discarded) and revive does a **shape/dtype** check per entry; either mismatch is a miss
+(recompute + overwrite), never an error. The fingerprint uses cloudpickle when present
+(``--extra cache``; captures closures/globals), else a best-effort source hash (warned),
+and always honors an explicit ``transform.cache_key``. Without ``persist`` a
+``backing_dir`` is ephemeral spill (unlinked on close).
 
 See [docs/architecture.md] for where this sits in the pipeline.
 
@@ -51,6 +55,8 @@ So the GIL build is just the serialized (slower) case; free threading is upside.
 from __future__ import annotations
 
 import contextlib
+import hashlib
+import inspect
 import json
 import logging
 import os
@@ -65,6 +71,11 @@ import numpy as np
 
 from .types import ArrayGeometry, Batch, ChunkRead, DecodedChunk
 
+try:  # optional: stronger transform fingerprint (closures + globals). `--extra cache`.
+    import cloudpickle
+except ImportError:  # pragma: no cover - exercised by the no-cloudpickle fallback path
+    cloudpickle = None
+
 logger = logging.getLogger(__name__)
 
 ChunkTransform = Callable[[DecodedChunk], DecodedChunk]
@@ -72,6 +83,35 @@ ChunkTransform = Callable[[DecodedChunk], DecodedChunk]
 
 def _safe(name: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "_", name)
+
+
+def _transform_token(fn: ChunkTransform) -> str:
+    """A stable identity for one chunk_transform, for the cross-run cache fingerprint.
+
+    Precedence: an explicit ``fn.cache_key`` (user-owned, strongest) -> a cloudpickle
+    hash if available (captures closure cells + referenced globals) -> a best-effort
+    source/qualname hash (catches an edited body, but NOT a changed closed-over constant
+    or a called helper -- the same blind spot joblib has). The method is encoded in the
+    token, so toggling cloudpickle on/off changes the fingerprint (honest re-compute
+    rather than a false match).
+    """
+    key = getattr(fn, "cache_key", None)
+    if key is not None:
+        return f"key:{key}"
+    if cloudpickle is not None:
+        with contextlib.suppress(Exception):  # unpicklable -> fall through to source
+            return "pickle:" + hashlib.sha256(cloudpickle.dumps(fn)).hexdigest()
+    try:
+        src = inspect.getsource(fn)
+    except (OSError, TypeError):
+        src = ""  # C funcs / REPL: no source -> lean on the qualname alone
+    name = getattr(fn, "__qualname__", repr(fn))
+    return "src:" + hashlib.sha256(f"{name}\n{src}".encode()).hexdigest()
+
+
+def _has_weak_token(transforms: Sequence[ChunkTransform]) -> bool:
+    """True if any transform falls back to the source hash (no cache_key, no cloudpickle)."""
+    return cloudpickle is None and any(getattr(t, "cache_key", None) is None for t in transforms)
 
 
 @dataclass(slots=True)
@@ -149,7 +189,23 @@ class ChunkPool:
             raise ValueError("persist=True requires cache_dir (a backing_dir) to keep files in")
         # key -> on-disk filename for completed entries known to survive a run.
         self._persisted: dict[tuple[str, int], str] = {}
+        # Fingerprint of the chunk_transform pipeline (only chunk_transforms are baked into
+        # cached chunks; batch_transforms run post-cache). A run whose fingerprint differs
+        # from the manifest's discards the cache (changed transforms -> stale). batch
+        # transforms and the store identity are out of scope (the cache_dir path is the
+        # dataset identity -- see the class docstring).
+        self._pipeline_fp = ""
         if persist:
+            self._pipeline_fp = hashlib.sha256(
+                "\n".join(_transform_token(t) for t in self._chunk_transforms).encode()
+            ).hexdigest()
+            if _has_weak_token(self._chunk_transforms):
+                logger.warning(
+                    "persist: cloudpickle not installed and a chunk_transform has no "
+                    "cache_key -> cache invalidation on transform changes is best-effort "
+                    "(source only; closure/global changes may not invalidate). Install "
+                    "`insitubatch[cache]` or set a `cache_key` attribute for a stronger guarantee."
+                )
             self._load_manifest()
         self._budget = budget_bytes  # None => unbounded (never self-evicts)
         self._bytes = 0
@@ -574,6 +630,13 @@ class ChunkPool:
                 self._MANIFEST_FORMAT,
             )
             return
+        if doc.get("pipeline_hash") != self._pipeline_fp:
+            logger.warning(
+                "persist: chunk_transform fingerprint changed since %s was written; "
+                "ignoring the stale cache (starting cold)",
+                path,
+            )
+            return
         for entry in doc.get("entries", []):
             self._persisted[(entry["array"], int(entry["chunk_index"]))] = entry["file"]
         self.manifest_entries = len(self._persisted)
@@ -585,7 +648,11 @@ class ChunkPool:
             {"array": array, "chunk_index": cid, "file": fname}
             for (array, cid), fname in sorted(self._persisted.items())
         ]
-        doc = {"format_version": self._MANIFEST_FORMAT, "entries": entries}
+        doc = {
+            "format_version": self._MANIFEST_FORMAT,
+            "pipeline_hash": self._pipeline_fp,
+            "entries": entries,
+        }
         tmp = self._dir / (self._MANIFEST_NAME + ".tmp")
         tmp.write_text(json.dumps(doc))
         os.replace(tmp, self._dir / self._MANIFEST_NAME)

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -18,6 +18,14 @@ Buffer and cache differ only in budget + backing, so they are the same code:
   the scatter writing straight into the slot either way; mmap keeps the working set
   as reclaimable page cache rather than anon heap.
 
+With ``persist=True`` (requires a ``backing_dir``) the mmap tier becomes a **cross-run
+cache**: slot files survive ``close`` (only budget eviction removes them), a JSON
+manifest records the completed entries, and a new pool over the same dir revives them
+as ready hits -- no fetch/decode. The ``backing_dir`` path *is* the dataset+pipeline
+identity (bury a version in it); the only automatic guard is a structural shape/dtype
+check on revive, and a mismatch is treated as a miss (recompute + overwrite), not an
+error. Without ``persist`` a ``backing_dir`` is ephemeral spill (unlinked on close).
+
 See [docs/architecture.md] for where this sits in the pipeline.
 
 Thread-safety / free-threading (the load-bearing invariant)
@@ -43,6 +51,7 @@ So the GIL build is just the serialized (slower) case; free threading is upside.
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import re
 import threading
@@ -93,6 +102,9 @@ class ChunkPool:
     the *assembled* array, so a hit reflects decode + transform.
     """
 
+    _MANIFEST_NAME = "insitu_cache.json"
+    _MANIFEST_FORMAT = 1
+
     def __init__(
         self,
         geometries: dict[str, ArrayGeometry],
@@ -100,6 +112,7 @@ class ChunkPool:
         chunk_transforms: Sequence[ChunkTransform] = (),
         backing_dir: str | Path | None = None,
         budget_bytes: int | None = None,
+        persist: bool = False,
     ) -> None:
         self._geom = geometries  # label -> geometry (a label is one (array, offset) view)
         # Slots are keyed by the underlying array *path*, not the variable label, so two
@@ -115,6 +128,17 @@ class ChunkPool:
         self._dir = Path(backing_dir) if backing_dir is not None else None
         if self._dir is not None:
             self._dir.mkdir(parents=True, exist_ok=True)
+        # Cross-run persistence: keep slot files past close, write a manifest of completed
+        # entries, and revive them on reopen. Requires a dir to keep the files in. The dir
+        # path is the dataset+pipeline identity (the user buries a version in it); we only
+        # auto-check shape/dtype on revive (a mismatch is a miss, not an error).
+        self._persistent = persist
+        if persist and self._dir is None:
+            raise ValueError("persist=True requires cache_dir (a backing_dir) to keep files in")
+        # key -> on-disk filename for completed entries known to survive a run.
+        self._persisted: dict[tuple[str, int], str] = {}
+        if persist:
+            self._load_manifest()
         self._budget = budget_bytes  # None => unbounded (never self-evicts)
         self._bytes = 0
         # OrderedDict in recency order (LRU front -> MRU back). Eviction targets only
@@ -189,21 +213,61 @@ class ChunkPool:
     def pin_if_ready(self, array: str, chunk_index: int) -> bool:
         """Incref + return ``True`` iff the chunk is resident, ready, and not failed.
 
-        A cross-epoch cache hit the driver can skip fetching -- but it must still be
-        referenced so it stays resident through the consumer's use (released at last
-        use like an admitted chunk), else it could be evicted before the waiter gathers
-        it and, since the driver fetches each chunk once, deadlock. One lock so the
-        check and the incref cannot race an eviction in between.
+        A cross-epoch (or, with ``persist``, cross-*run*) cache hit the driver can skip
+        fetching -- but it must still be referenced so it stays resident through the
+        consumer's use (released at last use like an admitted chunk), else it could be
+        evicted before the waiter gathers it and, since the driver fetches each chunk
+        once, deadlock. One lock so the check and the incref cannot race an eviction in
+        between. A persisted-on-disk chunk is revived here on first touch (see
+        :meth:`_revive`), so a cross-run hit costs no fetch.
         """
         with self._cv:
             key = (array, chunk_index)
             slot = self._slots.get(key)
-            if slot is not None and slot.ready and slot.error is None:
-                self._pin(key)
-                slot.claimed = True  # publish the claim so a waiter may now proceed
-                self._cv.notify_all()
-                return True
+            if not (slot is not None and slot.ready and slot.error is None):
+                if not self._revive(key):
+                    return False
+                slot = self._slots[key]
+            self._pin(key)
+            slot.claimed = True  # publish the claim so a waiter may now proceed
+            self._cv.notify_all()
+            return True
+
+    def _revive(self, key: tuple[str, int]) -> bool:  # call under the lock
+        """Bring a persisted on-disk chunk back as a ready slot (a cross-run hit).
+
+        Returns ``True`` iff the slot is now resident + ready. Validates the stored
+        ``.npy`` shape/dtype against the current geometry; a mismatch (or an unreadable
+        file) is a **miss** -- the entry is dropped from the registry and the stale file
+        is overwritten when the chunk is next fetched. Charges the slot to the budget,
+        evicting unpinned-LRU for room; if none can be freed it stays a miss (the driver
+        re-fetches -- correct, just uncached this once).
+        """
+        if not self._persistent or key in self._slots:
             return False
+        fname = self._persisted.get(key)
+        if fname is None:
+            return False
+        array, chunk_index = key
+        geom = self._by_path.get(array)
+        assert self._dir is not None
+        try:
+            data = np.lib.format.open_memmap(self._dir / fname, mode="r")
+        except (OSError, ValueError):
+            self._persisted.pop(key, None)
+            return False
+        if geom is None or data.shape != geom.slot_shape(chunk_index) or data.dtype != geom.dtype:
+            del data  # drop the mmap ref; structural fingerprint mismatch -> a miss
+            self._persisted.pop(key, None)
+            return False
+        nbytes = int(data.nbytes)
+        if not self._make_room(nbytes):
+            del data
+            return False
+        self._slots[key] = _Slot(data=data, remaining=0, nbytes=nbytes, ready=True)
+        self._bytes += nbytes
+        self.max_resident = max(self.max_resident, len(self._positions()))
+        return True
 
     def pin_keys(self, keys: set[tuple[str, int]]) -> None:
         """Reference (incref) a set of ``(path, chunk_index)`` slots for a live block.
@@ -281,7 +345,13 @@ class ChunkPool:
         slot = self._slots.pop(key)
         self._pinned.pop(key, None)  # no stale refcount if dropping a (rare) pinned partial
         self._bytes -= slot.nbytes
-        self._free(slot)
+        # In persist mode a *ready* eviction is a cache demotion, not a deletion: keep the
+        # .npy on disk and register it so a later epoch/run can revive it. A not-ready
+        # partial is garbage either way -> unlink it.
+        keep = self._persistent and slot.ready
+        if keep:
+            self._register_persisted(key, slot)
+        self._free(slot, keep_file=keep)
 
     def _alloc(
         self, array: str, chunk_index: int, shape: tuple[int, ...], dtype: np.dtype
@@ -428,24 +498,69 @@ class ChunkPool:
         offsets = {var: self._geom[var].offset for var in variables}
         return Batch(arrays=arrays, sample_indices=anchor, offsets=offsets)
 
-    def _free(self, slot: _Slot) -> None:
-        """Release a slot's backing: a no-op for heap, flush+close+unlink for mmap.
+    def _free(self, slot: _Slot, *, keep_file: bool) -> None:
+        """Release a slot's backing: a no-op for heap, close (and maybe unlink) for mmap.
 
-        Dropping a slot drops its cached bytes (intra-run); cross-*run* persistence
-        (keep the file + a content-keyed index) is the deferred follow-up.
+        ``keep_file`` leaves the ``.npy`` on disk (a persisted cache entry); otherwise the
+        file is unlinked (heap/spill teardown or a discarded partial).
         """
         mmap = getattr(slot.data, "_mmap", None)
         if mmap is not None:
             fname = getattr(slot.data, "filename", None)
             mmap.close()
-            if fname:
+            if fname and not keep_file:
                 with contextlib.suppress(FileNotFoundError):
                     os.unlink(fname)
 
+    def _register_persisted(self, key: tuple[str, int], slot: _Slot) -> None:  # under the lock
+        """Record a ready mmap slot's file as a surviving cache entry (persist mode)."""
+        fname = getattr(slot.data, "filename", None)
+        if fname is not None:
+            self._persisted[key] = Path(fname).name
+
+    def _load_manifest(self) -> None:
+        """Populate the persisted-entry registry from a prior run's manifest, if any.
+
+        An unreadable manifest, a format mismatch, or a missing file is just a cold start
+        (no entries loaded) -- never an error. Per-entry shape/dtype validation is deferred
+        to :meth:`_revive`, which reads it straight from the ``.npy`` header.
+        """
+        assert self._dir is not None
+        path = self._dir / self._MANIFEST_NAME
+        try:
+            doc = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return
+        if doc.get("format_version") != self._MANIFEST_FORMAT:
+            return
+        for entry in doc.get("entries", []):
+            fname = entry["file"]
+            if (self._dir / fname).exists():
+                self._persisted[(entry["array"], int(entry["chunk_index"]))] = fname
+
+    def _write_manifest(self) -> None:  # call under the lock
+        """Atomically write the registry of completed cache entries (persist mode)."""
+        assert self._dir is not None
+        entries = [
+            {"array": array, "chunk_index": cid, "file": fname}
+            for (array, cid), fname in sorted(self._persisted.items())
+        ]
+        doc = {"format_version": self._MANIFEST_FORMAT, "entries": entries}
+        tmp = self._dir / (self._MANIFEST_NAME + ".tmp")
+        tmp.write_text(json.dumps(doc))
+        os.replace(tmp, self._dir / self._MANIFEST_NAME)
+
     def close(self) -> None:
-        """Free every remaining slot (mmap files included) -- e.g. on teardown."""
+        """Free every remaining slot. Persist mode keeps ready cache files + a manifest;
+        otherwise (heap/spill) mmap files are unlinked -- e.g. on teardown."""
         with self._cv:
+            if self._persistent:
+                for key, slot in self._slots.items():
+                    if slot.ready:
+                        self._register_persisted(key, slot)
+                self._write_manifest()
             for k in list(self._slots):
-                self._free(self._slots.pop(k))
+                slot = self._slots.pop(k)
+                self._free(slot, keep_file=self._persistent and slot.ready)
             self._bytes = 0
             self._pinned.clear()

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import os
 import re
 import threading
@@ -63,6 +64,8 @@ from pathlib import Path
 import numpy as np
 
 from .types import ArrayGeometry, Batch, ChunkRead, DecodedChunk
+
+logger = logging.getLogger(__name__)
 
 ChunkTransform = Callable[[DecodedChunk], DecodedChunk]
 
@@ -128,6 +131,15 @@ class ChunkPool:
         self._dir = Path(backing_dir) if backing_dir is not None else None
         if self._dir is not None:
             self._dir.mkdir(parents=True, exist_ok=True)
+        # Observability. hits/misses (+ the revive failure breakdown) are per-epoch --
+        # reset by unpin_all at each epoch boundary -- so the driver can warn when a
+        # configured persist cache served nothing. manifest_entries is load-time (how
+        # many entries a prior run left us) and does NOT reset.
+        self.hits = 0
+        self.misses = 0
+        self.revive_mismatch = 0  # persisted entry whose stored shape/dtype no longer matches
+        self.revive_missing = 0  # persisted entry whose .npy was unreadable/gone
+        self.manifest_entries = 0
         # Cross-run persistence: keep slot files past close, write a manifest of completed
         # entries, and revive them on reopen. Requires a dir to keep the files in. The dir
         # path is the dataset+pipeline identity (the user buries a version in it); we only
@@ -193,6 +205,7 @@ class ChunkPool:
                 return True
             if not self._make_room(nbytes):
                 return False
+            self.misses += 1  # a fresh slot allocated to fetch -> a cache miss
             self._slots[key] = _Slot(
                 data=self._alloc(array, chunk_index, geom.slot_shape(chunk_index), geom.dtype),
                 remaining=geom.n_inner_chunks(chunk_index),
@@ -228,6 +241,7 @@ class ChunkPool:
                 if not self._revive(key):
                     return False
                 slot = self._slots[key]
+            self.hits += 1  # resident (cross-epoch) or revived (cross-run) -> no fetch
             self._pin(key)
             slot.claimed = True  # publish the claim so a waiter may now proceed
             self._cv.notify_all()
@@ -253,10 +267,21 @@ class ChunkPool:
         assert self._dir is not None
         try:
             data = np.lib.format.open_memmap(self._dir / fname, mode="r")
-        except (OSError, ValueError):
+        except (OSError, ValueError) as exc:
+            self.revive_missing += 1
+            logger.debug("cache: persisted %s unreadable (%s); refetching", key, exc)
             self._persisted.pop(key, None)
             return False
         if geom is None or data.shape != geom.slot_shape(chunk_index) or data.dtype != geom.dtype:
+            self.revive_mismatch += 1
+            logger.debug(
+                "cache: persisted %s shape/dtype %s/%s != current %s/%s; refetching",
+                key,
+                data.shape,
+                data.dtype,
+                None if geom is None else geom.slot_shape(chunk_index),
+                None if geom is None else geom.dtype,
+            )
             del data  # drop the mmap ref; structural fingerprint mismatch -> a miss
             self._persisted.pop(key, None)
             return False
@@ -313,6 +338,10 @@ class ChunkPool:
                 self._drop(key)
             for slot in self._slots.values():
                 slot.claimed = False  # a retained chunk must be re-claimed next epoch
+            # Per-epoch observability resets here (the epoch boundary); manifest_entries
+            # is load-time and persists.
+            self.hits = self.misses = 0
+            self.revive_mismatch = self.revive_missing = 0
             self._cv.notify_all()
 
     def _pin(self, key: tuple[str, int]) -> None:  # call under the lock
@@ -521,22 +550,33 @@ class ChunkPool:
     def _load_manifest(self) -> None:
         """Populate the persisted-entry registry from a prior run's manifest, if any.
 
-        An unreadable manifest, a format mismatch, or a missing file is just a cold start
-        (no entries loaded) -- never an error. Per-entry shape/dtype validation is deferred
-        to :meth:`_revive`, which reads it straight from the ``.npy`` header.
+        No manifest is a cold start (silent -- the expected first run). An unreadable
+        manifest or a format mismatch is a cold start too, but WARNed: persistence was
+        asked for and a prior cache could not be honored. Per-entry validation
+        (existence, shape, dtype) is deferred to :meth:`_revive`, which reads it from the
+        ``.npy`` header -- so a stale/missing file shows up as a per-epoch revive failure
+        the driver can warn on, not a silent drop here.
         """
         assert self._dir is not None
         path = self._dir / self._MANIFEST_NAME
+        if not path.exists():
+            return  # cold start: no prior cache (the expected first run)
         try:
             doc = json.loads(path.read_text())
-        except (OSError, json.JSONDecodeError):
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("persist: cache manifest %s unreadable (%s); starting cold", path, exc)
             return
         if doc.get("format_version") != self._MANIFEST_FORMAT:
+            logger.warning(
+                "persist: cache manifest %s format %r != %d; starting cold",
+                path,
+                doc.get("format_version"),
+                self._MANIFEST_FORMAT,
+            )
             return
         for entry in doc.get("entries", []):
-            fname = entry["file"]
-            if (self._dir / fname).exists():
-                self._persisted[(entry["array"], int(entry["chunk_index"]))] = fname
+            self._persisted[(entry["array"], int(entry["chunk_index"]))] = entry["file"]
+        self.manifest_entries = len(self._persisted)
 
     def _write_manifest(self) -> None:  # call under the lock
         """Atomically write the registry of completed cache entries (persist mode)."""

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -116,6 +116,7 @@ class InSituDataset:
         prefetch_depth: int = 2,
         cache_dir: str | None = None,
         cache_budget_bytes: int | None = None,
+        persist: bool = False,
         on_bad_chunk: str = "raise",
         chunk_transforms: Sequence[Callable[[DecodedChunk], DecodedChunk]] = (),
         batch_transforms: Sequence[Callable[[Batch], Batch]] = (),
@@ -188,11 +189,17 @@ class InSituDataset:
             n_train_chunks = len(self.manifest.chunks[SplitName.TRAIN.value])
             working_set = max(working_set, n_train_chunks * per_chunk_all_vars)
         self.cache_budget_bytes = max(int(cache_budget_bytes or 0), working_set)
+        # persist turns the cache_dir mmap tier into a cross-run cache (files + manifest
+        # survive close; reopen revives them as hits). It needs a dir to keep files in;
+        # the dir path is the dataset+pipeline identity (bury a version in it).
+        if persist and cache_dir is None:
+            raise ValueError("persist=True requires cache_dir to keep the cache files in")
         self._pool = ChunkPool(
             self.geometries,
             chunk_transforms=self.chunk_transforms,
             backing_dir=cache_dir,
             budget_bytes=self.cache_budget_bytes,
+            persist=persist,
         )
 
         # One concurrency dial (max_inflight, network), independent of the shuffle
@@ -381,10 +388,12 @@ class InSituDataset:
                 self.bad_chunks = list(sched.bad_chunks)  # tiles NaN-filled this epoch
 
     def close(self) -> None:
-        """Release the cache pool's backing (mmap files, cached chunks).
+        """Release the cache pool's backing (mmap handles, cached chunks).
 
         The pool persists across epochs, so close it when done training -- not per
-        epoch. Idempotent; also called on GC.
+        epoch. With ``persist=True`` the cache files + manifest are kept on disk for a
+        future run (only the in-memory handles are released); otherwise the mmap spill
+        files are unlinked. Idempotent; also called on GC.
         """
         self._pool.close()
 

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -27,6 +27,7 @@ residency budget are independent dials. See [docs/architecture.md] for the pipel
 from __future__ import annotations
 
 import contextlib
+import logging
 import queue
 import threading
 from collections.abc import Callable, Iterator, Sequence
@@ -40,6 +41,8 @@ from .shuffle import block_shuffled_order, sequential_order
 from .split import SplitManifest, valid_anchor_range
 from .store import StoreLike, open_geometries
 from .types import ArrayGeometry, Batch, DecodedChunk, SplitName, StoredChunkRead
+
+logger = logging.getLogger(__name__)
 
 # Default for the single concurrency dial when the caller does not pin it.
 # max_inflight is independent of the shuffle window -- sized to saturate the
@@ -149,7 +152,10 @@ class InSituDataset:
         self.chunk_transforms = tuple(chunk_transforms)
         self.batch_transforms = tuple(batch_transforms)
         self._epoch = 0
+        self._persist = persist
         self.resident_peak = 0  # peak resident outer chunks (observability)
+        self.cache_hits = 0  # chunks served without a fetch this epoch (cross-epoch/run)
+        self.cache_misses = 0  # chunks fetched + decoded this epoch
         # Stored tiles NaN-filled in the last epoch (when on_bad_chunk="nan") -- which
         # (array, chunk_index, inner_coord) reads were corrupt/truncated. len() is the
         # count. Inspect after iterating to log/quarantine bad chunks.
@@ -384,8 +390,25 @@ class InSituDataset:
                     with contextlib.suppress(queue.Empty):
                         out_q.get(timeout=0.05)
                 producer.join(timeout=10)
-                self.resident_peak = sched.pool.max_resident  # peak residency this epoch
+                pool = sched.pool
+                self.resident_peak = pool.max_resident  # peak residency this epoch
+                self.cache_hits = pool.hits
+                self.cache_misses = pool.misses
                 self.bad_chunks = list(sched.bad_chunks)  # tiles NaN-filled this epoch
+                # Persistence was asked for but served nothing, and the cache *was*
+                # consulted (entries existed and every revive failed) -> almost certainly
+                # a stale cache_dir or changed data/transforms. Loud once per epoch; a
+                # plain miss (no persisted entry for a chunk) is silent (normal).
+                failed_revives = pool.revive_mismatch + pool.revive_missing
+                if self._persist and pool.hits == 0 and failed_revives:
+                    logger.warning(
+                        "persist=True but 0 of %d persisted chunks were served this epoch "
+                        "(%d shape/dtype mismatches, %d missing/unreadable) -- stale cache_dir "
+                        "or changed data/transforms?",
+                        pool.manifest_entries,
+                        pool.revive_mismatch,
+                        pool.revive_missing,
+                    )
 
     def close(self) -> None:
         """Release the cache pool's backing (mmap handles, cached chunks).

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import itertools
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 
 import numpy as np
 import pytest
@@ -332,3 +333,84 @@ def test_pool_unpin_all_drops_abandoned_partial_keeps_ready(tiled_store):
     assert ("spatial", 0) not in pool._slots  # abandoned partial dropped
     assert pool.is_ready("spatial", 1)  # ready chunk retained (cross-epoch reuse)
     assert pool._bytes == bytes_ready  # the partial's bytes were reclaimed
+
+
+def test_pool_persist_requires_cache_dir(tiled_store):
+    """persist=True only makes sense with a backing dir to keep files in -- fail fast."""
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    with pytest.raises(ValueError, match="cache_dir|backing_dir"):
+        ChunkPool(geoms, persist=True)
+
+
+def _fill_chunk(pool, var, cid, geom, tiles):
+    pool.try_admit(var, cid)
+    for inner in geom.inner_coords():
+        pool.scatter(var, cid, inner, tiles[(cid, *inner)])
+    pool.wait_ready(var, cid)
+
+
+def test_pool_cross_run_persistence(tiled_store, tmp_path):
+    """A persistent cache survives process exit: a new pool over the same dir serves
+    each chunk as a ready hit (no re-scatter), reconstructing the source exactly."""
+    url, srcs = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    spc = geom.sample_chunk_size
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    backing = tmp_path / "cache"
+
+    # Run 1: populate + close. persist must KEEP the files and write a manifest.
+    pool = ChunkPool(geoms, backing_dir=backing, persist=True)
+    for cid in range(geom.n_chunks):
+        _fill_chunk(pool, "single_inner", cid, geom, tiles)
+    pool.close()
+    assert list(backing.glob("*.npy")), "persist=True must keep slot files after close()"
+    assert (backing / "insitu_cache.json").exists(), "persist must write a manifest"
+
+    # Run 2: same dir -> every chunk a ready hit, no fetch/scatter.
+    pool2 = ChunkPool(geoms, backing_dir=backing, persist=True)
+    for cid in range(geom.n_chunks):
+        assert pool2.pin_if_ready("single_inner", cid), "persisted chunk must be a hit"
+        n0 = len(geom.samples_in_chunk(cid))
+        rows = np.array([[cid, w] for w in range(n0)], dtype=np.int64)
+        got = pool2.gather(rows, ["single_inner"], spc).arrays["single_inner"]
+        assert np.array_equal(got, srcs["single_inner"][cid * spc : cid * spc + n0])
+    pool2.close()
+
+
+def test_pool_persist_invalidates_on_geometry_mismatch(tiled_store, tmp_path):
+    """A persisted entry whose stored shape/dtype no longer matches the current
+    geometry is ignored (a miss), not served -- the structural fingerprint check.
+    The dataset/pipeline identity is the cache_dir path; the user versions that."""
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    backing = tmp_path / "cache"
+
+    pool = ChunkPool(geoms, backing_dir=backing, persist=True)
+    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    pool.close()
+
+    # Reopen with a structurally different dtype for the same array -> mismatch -> miss.
+    drifted = {"single_inner": replace(geom, dtype=np.dtype("f8"))}
+    pool2 = ChunkPool(drifted, backing_dir=backing, persist=True)
+    assert not pool2.pin_if_ready("single_inner", 0), "geometry drift must invalidate"
+    pool2.close()
+
+
+def test_pool_spill_unlinks_without_persist(tiled_store, tmp_path):
+    """Without persist, a backing dir is scratch: files are unlinked on close and no
+    manifest is written (the persistence machinery is persist-only)."""
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    backing = tmp_path / "spill"
+
+    pool = ChunkPool(geoms, backing_dir=backing)
+    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    pool.close()
+    assert not list(backing.glob("*.npy")), "spill must unlink slot files on close()"
+    assert not (backing / "insitu_cache.json").exists(), "no manifest without persist"

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -364,18 +364,21 @@ def test_pool_cross_run_persistence(tiled_store, tmp_path):
     pool = ChunkPool(geoms, backing_dir=backing, persist=True)
     for cid in range(geom.n_chunks):
         _fill_chunk(pool, "single_inner", cid, geom, tiles)
+    assert pool.misses == geom.n_chunks and pool.hits == 0  # cold: every chunk a miss
     pool.close()
     assert list(backing.glob("*.npy")), "persist=True must keep slot files after close()"
     assert (backing / "insitu_cache.json").exists(), "persist must write a manifest"
 
     # Run 2: same dir -> every chunk a ready hit, no fetch/scatter.
     pool2 = ChunkPool(geoms, backing_dir=backing, persist=True)
+    assert pool2.manifest_entries == geom.n_chunks
     for cid in range(geom.n_chunks):
         assert pool2.pin_if_ready("single_inner", cid), "persisted chunk must be a hit"
         n0 = len(geom.samples_in_chunk(cid))
         rows = np.array([[cid, w] for w in range(n0)], dtype=np.int64)
         got = pool2.gather(rows, ["single_inner"], spc).arrays["single_inner"]
         assert np.array_equal(got, srcs["single_inner"][cid * spc : cid * spc + n0])
+    assert pool2.hits == geom.n_chunks and pool2.misses == 0  # warm: every chunk a hit
     pool2.close()
 
 
@@ -397,6 +400,7 @@ def test_pool_persist_invalidates_on_geometry_mismatch(tiled_store, tmp_path):
     drifted = {"single_inner": replace(geom, dtype=np.dtype("f8"))}
     pool2 = ChunkPool(drifted, backing_dir=backing, persist=True)
     assert not pool2.pin_if_ready("single_inner", 0), "geometry drift must invalidate"
+    assert pool2.revive_mismatch == 1 and pool2.hits == 0  # the mismatch is counted
     pool2.close()
 
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import itertools
+import logging
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 
@@ -402,6 +403,123 @@ def test_pool_persist_invalidates_on_geometry_mismatch(tiled_store, tmp_path):
     assert not pool2.pin_if_ready("single_inner", 0), "geometry drift must invalidate"
     assert pool2.revive_mismatch == 1 and pool2.hits == 0  # the mismatch is counted
     pool2.close()
+
+
+def test_pool_persist_invalidates_on_transform_change(tiled_store, tmp_path):
+    """The manifest carries a chunk_transform fingerprint: the same transform reopens as
+    a hit; a changed transform discards the whole cache (cold start), not a false hit."""
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    backing = tmp_path / "cache"
+
+    def scale_a(chunk):
+        chunk.data = chunk.data * 2.0
+        return chunk
+
+    pool = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[scale_a])
+    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    pool.close()
+
+    same = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[scale_a])
+    assert same.manifest_entries == 1 and same.pin_if_ready("single_inner", 0)  # same fp -> hit
+    same.close()
+
+    def scale_b(chunk):  # different body -> different fingerprint
+        chunk.data = chunk.data * 3.0
+        return chunk
+
+    changed = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[scale_b])
+    assert changed.manifest_entries == 0  # stale cache discarded, not loaded
+    assert not changed.pin_if_ready("single_inner", 0)
+    changed.close()
+
+
+def test_pool_persist_cache_key_overrides_fingerprint(tiled_store, tmp_path):
+    """An explicit transform.cache_key is authoritative: distinct function objects sharing
+    a key reopen as a hit; bumping the key invalidates."""
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    backing = tmp_path / "cache"
+
+    def t1(chunk):
+        return chunk
+
+    t1.cache_key = "v1"  # type: ignore[attr-defined]
+    pool = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[t1])
+    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    pool.close()
+
+    def t2(chunk):  # a different object/body, same declared key -> treated as identical
+        return chunk
+
+    t2.cache_key = "v1"  # type: ignore[attr-defined]
+    same = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[t2])
+    assert same.pin_if_ready("single_inner", 0)
+    same.close()
+
+    t2.cache_key = "v2"  # type: ignore[attr-defined]  # bump the key -> invalidate
+    changed = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[t2])
+    assert changed.manifest_entries == 0
+    changed.close()
+
+
+def test_pool_persist_cloudpickle_catches_closure_change(tiled_store, tmp_path):
+    """cloudpickle's stronger guarantee: two closures with identical source but a different
+    closed-over constant get different fingerprints (a source hash would falsely match)."""
+    pytest.importorskip("cloudpickle")
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    backing = tmp_path / "cache"
+
+    def make_scaler(factor):  # identical source text; only the closure cell differs
+        def scale(chunk):
+            chunk.data = chunk.data * factor
+            return chunk
+
+        return scale
+
+    pool = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[make_scaler(2.0)])
+    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    pool.close()
+
+    changed = ChunkPool(
+        geoms, backing_dir=backing, persist=True, chunk_transforms=[make_scaler(3.0)]
+    )
+    assert changed.manifest_entries == 0  # closure-value change caught -> cache discarded
+    changed.close()
+
+
+def test_pool_persist_without_cloudpickle_warns_and_falls_back(
+    tiled_store, tmp_path, monkeypatch, caplog
+):
+    """No cloudpickle + no cache_key -> a best-effort source fingerprint, with a one-time
+    warning. The source hash still reopens an unchanged transform as a hit."""
+    monkeypatch.setattr("insitubatch.pool.cloudpickle", None)
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    backing = tmp_path / "cache"
+
+    def scale(chunk):
+        chunk.data = chunk.data * 2.0
+        return chunk
+
+    with caplog.at_level(logging.WARNING, logger="insitubatch.pool"):
+        pool = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[scale])
+    assert any("best-effort" in r.message for r in caplog.records), caplog.text
+    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    pool.close()
+
+    same = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[scale])
+    assert same.pin_if_ready("single_inner", 0)  # source hash matches -> hit
+    same.close()
 
 
 def test_pool_spill_unlinks_without_persist(tiled_store, tmp_path):

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -250,8 +250,14 @@ def test_persist_warns_when_cache_unusable(write_zarr, tmp_path, caplog) -> None
 
     def make() -> InSituDataset:
         return InSituDataset(
-            url, manifest, batch_size=4, block_chunks=4, shuffle=False,
-            cache_dir=str(cache), persist=True, cache_budget_bytes=10_000_000,
+            url,
+            manifest,
+            batch_size=4,
+            block_chunks=4,
+            shuffle=False,
+            cache_dir=str(cache),
+            persist=True,
+            cache_budget_bytes=10_000_000,
         )
 
     ds = make()

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -184,6 +184,57 @@ def test_cache_decode_once_across_epochs(write_zarr, tmp_path, kind) -> None:
     assert all(v == 1 for v in transformed.values()), dict(transformed)  # once, not twice
 
 
+def test_cache_persists_across_runs(write_zarr, tmp_path) -> None:
+    # persist=True keeps the mmap cache + manifest past close(); a fresh dataset over the
+    # same cache_dir serves every chunk from disk -- no re-decode (the chunk transform
+    # never runs in run 2) -- and yields byte-identical batches in the same draw order.
+    url, _ = write_zarr(n=160, spc=8)  # 20 chunks
+    geom = open_geometries(url)["t2m"]
+    manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
+    cache = str(tmp_path / "cache")
+
+    decoded: collections.Counter[int] = collections.Counter()
+
+    def count(chunk):  # runs once per outer chunk, on the miss (decode) path only
+        decoded[chunk.read.chunk_index] += 1
+        return chunk
+
+    def make() -> InSituDataset:
+        return InSituDataset(
+            url,
+            manifest,
+            batch_size=4,
+            block_chunks=4,
+            shuffle=True,
+            seed=0,
+            chunk_transforms=[count],
+            cache_dir=cache,
+            persist=True,
+            cache_budget_bytes=10_000_000,  # >> the split -> nothing evicted
+        )
+
+    ds = make()
+    try:
+        ds.set_epoch(0)
+        run1 = [b.arrays["t2m"].copy() for b in ds.train]
+    finally:
+        ds.close()
+    assert set(decoded) == set(manifest.chunks[SplitName.TRAIN.value])  # all decoded in run 1
+
+    decoded.clear()
+    ds2 = make()  # fresh process-equivalent: new pool over the same persisted cache_dir
+    try:
+        ds2.set_epoch(0)
+        run2 = [b.arrays["t2m"].copy() for b in ds2.train]
+    finally:
+        ds2.close()
+
+    assert decoded == collections.Counter()  # nothing re-decoded: every chunk a cross-run hit
+    assert len(run1) == len(run2)
+    for a, b in zip(run1, run2, strict=True):
+        assert np.array_equal(a, b)
+
+
 def test_sample_range_subsets_what_the_dataset_reads(write_zarr) -> None:
     # sample_range restricts the manifest to the covering chunks; the dataset then
     # yields exactly those samples (chunk-aligned).

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import collections
+import logging
 
 import numpy as np
 import pytest
@@ -213,6 +214,7 @@ def test_cache_persists_across_runs(write_zarr, tmp_path) -> None:
             cache_budget_bytes=10_000_000,  # >> the split -> nothing evicted
         )
 
+    n_train = len(manifest.chunks[SplitName.TRAIN.value])
     ds = make()
     try:
         ds.set_epoch(0)
@@ -220,6 +222,7 @@ def test_cache_persists_across_runs(write_zarr, tmp_path) -> None:
     finally:
         ds.close()
     assert set(decoded) == set(manifest.chunks[SplitName.TRAIN.value])  # all decoded in run 1
+    assert ds.cache_misses == n_train and ds.cache_hits == 0  # cold run: all misses
 
     decoded.clear()
     ds2 = make()  # fresh process-equivalent: new pool over the same persisted cache_dir
@@ -230,9 +233,47 @@ def test_cache_persists_across_runs(write_zarr, tmp_path) -> None:
         ds2.close()
 
     assert decoded == collections.Counter()  # nothing re-decoded: every chunk a cross-run hit
+    assert ds2.cache_hits == n_train and ds2.cache_misses == 0  # warm run: all hits
     assert len(run1) == len(run2)
     for a, b in zip(run1, run2, strict=True):
         assert np.array_equal(a, b)
+
+
+def test_persist_warns_when_cache_unusable(write_zarr, tmp_path, caplog) -> None:
+    # persist=True but the cache is consulted and serves nothing (here: the .npy files
+    # were deleted under a surviving manifest) -> one loud WARNING per epoch, and the
+    # chunks are still re-fetched correctly (a miss, never a raise).
+    url, _ = write_zarr(n=80, spc=8)  # 10 chunks
+    geom = open_geometries(url)["t2m"]
+    manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
+    cache = tmp_path / "cache"
+
+    def make() -> InSituDataset:
+        return InSituDataset(
+            url, manifest, batch_size=4, block_chunks=4, shuffle=False,
+            cache_dir=str(cache), persist=True, cache_budget_bytes=10_000_000,
+        )
+
+    ds = make()
+    try:
+        ds.set_epoch(0)
+        want = np.concatenate([b.arrays["t2m"] for b in ds.train])
+    finally:
+        ds.close()
+
+    # Break the cache: keep the manifest, delete the data files it points at.
+    for f in cache.glob("*.npy"):
+        f.unlink()
+
+    ds2 = make()
+    ds2.set_epoch(0)
+    with caplog.at_level(logging.WARNING, logger="insitubatch.source"):
+        got = np.concatenate([b.arrays["t2m"] for b in ds2.train])
+    ds2.close()
+
+    assert ds2.cache_hits == 0  # nothing served from the (broken) cache
+    assert np.array_equal(got, want)  # but the data is correct -- re-fetched, not raised
+    assert any("persist=True but 0" in r.message for r in caplog.records), caplog.text
 
 
 def test_sample_range_subsets_what_the_dataset_reads(write_zarr) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1271,6 +1271,9 @@ bench = [
     { name = "scikit-learn" },
     { name = "xbatcher" },
 ]
+cache = [
+    { name = "cloudpickle" },
+]
 docs = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
@@ -1310,6 +1313,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "arraylake", marker = "extra == 'arraylake'", specifier = ">=0.14" },
+    { name = "cloudpickle", marker = "extra == 'cache'", specifier = ">=3" },
     { name = "cupy-cuda12x", marker = "extra == 'gpu'", specifier = ">=13.0" },
     { name = "flax", marker = "extra == 'jax'", specifier = ">=0.8" },
     { name = "gcsfs", marker = "extra == 'bench'", specifier = ">=2024.6" },
@@ -1333,7 +1337,7 @@ requires-dist = [
     { name = "xbatcher", marker = "extra == 'bench'", specifier = ">=0.3" },
     { name = "zarr", specifier = ">=3.0" },
 ]
-provides-extras = ["torch", "jax", "tf", "gpu", "virtual", "bench", "docs", "icechunk", "arraylake"]
+provides-extras = ["torch", "jax", "tf", "gpu", "virtual", "cache", "bench", "docs", "icechunk", "arraylake"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Finishes the persistent-cache work on top of the V2 ChunkPool. Turns the mmap cache tier into a **cross-run cache** with explicit observability and safe invalidation.

## What's in here
- **Cross-run persistence** (`persist=True`, requires `cache_dir`). Ready slot files survive `close()`, a JSON manifest records completed entries, and a new pool over the same dir revives them as ready hits — the scheduler's existing `pin_if_ready` path skips fetch/decode unchanged, so a warm run re-decodes zero chunks. Without `persist`, `cache_dir` stays ephemeral spill (unlinked on close).
- **Observability + a loud-when-broken warning.** Per-epoch `hits`/`misses` (+ `revive_mismatch`/`revive_missing`) on the pool, surfaced as `cache_hits`/`cache_misses` on the dataset. A miss is never an error and never logged on the normal path; the one WARNING fires only when `persist=True` served zero hits *and* the cache was consulted-and-rejected (stale dir / changed data or transforms) — no false positive on cold or non-overlapping runs.
- **Transform fingerprint invalidation.** The manifest carries a `pipeline_hash` over the `chunk_transforms`; a changed pipeline discards the cache (cold start) rather than serving stale chunks. Identity precedence: explicit `fn.cache_key` → cloudpickle hash (optional `[cache]` extra; captures closures/globals) → best-effort source hash (warns once). Never hard-fails when cloudpickle is absent.
- **Docs/bench:** caching feature-comparison table (chunks vs batches) in architecture.md, and a cache-vs-cache subsection in the bench plan.
- **CI:** the primary 3.12 job installs `--extra cache` so the cloudpickle fingerprint path runs (not `importorskip`-skipped).

## Decisions (recorded)
- The **`cache_dir` path is the dataset identity** (bury a version in it). The **store URL is deliberately not in the key** — Icechunk/Arraylake session stores have no round-trippable URL, so it would only cover obstore `str` stores.
- Fingerprint mismatch (geometry or pipeline) = a **miss/recompute**, not an error (joblib-style).
- The cache key's `chunk_index` is the **global** zarr chunk index, so subsets/splits share entries correctly.

## Still deferred
- Regrid / reshaping-transform **write** path on mmap (read path is already manifest-ready); store-URL/etag; orphan GC; incremental (mid-run) manifest.

## Verification
`ruff` ✓, `mypy src bench examples` ✓ (33 files), full suite ✓ (the only local failure is the pre-existing `test_xbatcher_engine`, which needs torch — installed in CI). New tests cover cross-run hits + exact reconstruction, geometry- and transform-fingerprint invalidation, the cloudpickle closure-change case, the no-cloudpickle warn+fallback, and the broken-cache warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)