### PR TITLE
feat: cache reshaping chunk_transforms (regrid write-path)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -516,9 +516,12 @@ Engine track (make it real for models — see [docs/architecture.md](docs/archit
   Icechunk/Arraylake session stores have no round-trippable URL, so the `cache_dir` path
   *is* the dataset identity (bury a version in it); content/etag drift is the user's call.
   The key's `chunk_index` is the *global* zarr index, so subsets/splits share entries.
-  *Still deferred:* a reshaping `chunk_transform` (`Regrid`) on the mmap tier (slot sized
-  at source shape), a raw-decoded tier keyed by source only, orphaned-file GC across
-  version bumps, and the kvikio/GDS NVMe→GPU feed off the persistent tier.
+  A **reshaping** `chunk_transform` (`Regrid` / dtype recast) is supported on every tier
+  including persistent mmap: it declares `output_inner -> (inner_shape, dtype)`, the cache
+  slot is sized at the output shape, and tiles assemble in a transient source-shaped scratch
+  buffer (the sample axis is invariant). *Still deferred:* a raw-decoded tier keyed by source
+  only, orphaned-file GC across version bumps, and the kvikio/GDS NVMe→GPU feed off the
+  persistent tier.
   Scope: a read-through cache keyed by fingerprint; a shared/networked cache tier and
   the L1/L2 split above are later.
 - **M-W — windowed / multi-offset sampling (sample geometry v2).** The forecasting

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -523,11 +523,18 @@ isn't working is loud, not silent.
   (cloudpickle) or set an explicit `transform.cache_key`; the source-only fallback can
   miss closure/global changes.
 
-**Limitations (deferred).** A **reshaping** `chunk_transform` (e.g. `Regrid`) on the
-mmap tier still raises — the slot is sized at the source shape, so the persistent cache
-covers shape-preserving transforms today. A raw-decoded tier (keyed by source only, for
-transform experimentation), orphaned-file GC across version bumps, and the kvikio/GDS
-NVMe→GPU feed off the persistent `.npy` tier remain on the roadmap
+**Reshaping transforms.** A **reshaping** `chunk_transform` (e.g. `Regrid`, or a dtype
+recast) is a first-class cacheable stage on every backing including the persistent mmap
+tier. The transform declares its post-transform *inner* geometry via
+`output_inner(geom) -> (inner_shape, dtype)`; the engine sizes the cache slot at that
+**output** shape and assembles decoded tiles into a transient **source**-shaped scratch
+buffer, then writes the transformed result into the slot (the sample axis is spliced back
+from the source, so a chunk_transform can never move it). Shape/dtype-preserving transforms
+omit `output_inner` and keep the zero-copy fast path (the slot is buffer and cache in one).
+
+**Limitations (deferred).** A raw-decoded tier (keyed by source only, for transform
+experimentation), orphaned-file GC across version bumps, and the kvikio/GDS NVMe→GPU feed
+off the persistent `.npy` tier remain on the roadmap
 ([DESIGN.md](https://github.com/emfdavid/insitubatch/blob/main/DESIGN.md)).
 
 ## Earth2Studio integration

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -64,7 +64,7 @@ import re
 import threading
 from collections import OrderedDict
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 import numpy as np
@@ -83,6 +83,30 @@ ChunkTransform = Callable[[DecodedChunk], DecodedChunk]
 
 def _safe(name: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "_", name)
+
+
+def output_geometry(geom: ArrayGeometry, transforms: Sequence[ChunkTransform]) -> ArrayGeometry:
+    """The geometry a chunk has *after* the chunk_transform pipeline.
+
+    A reshaping transform (regrid / dtype recast) declares ``output_inner(geom) ->
+    (inner_shape, dtype)``; the pipeline folds them so each transform sees the geometry
+    produced by the ones before it. Only the *inner* dims and dtype may change -- the
+    sample axis (``shape[0]`` / ``chunks[0]``) is spliced straight back from the source, so
+    a transform can neither move nor reshape it (the sample-geometry invariant). A transform
+    without ``output_inner`` is identity; with none reshaping, the source geometry returns
+    unchanged. Output ``chunks`` are set to the inner shape (the cache slot is one assembled
+    buffer, never inner-tiled), keeping the geometry self-consistent."""
+    inner, dt = geom.inner_shape, geom.dtype
+    for t in transforms:
+        declare = getattr(t, "output_inner", None)
+        if declare is None:
+            continue
+        current = replace(
+            geom, shape=(geom.shape[0], *inner), chunks=(geom.chunks[0], *inner), dtype=dt
+        )
+        inner, dt = declare(current)
+        inner, dt = tuple(int(s) for s in inner), np.dtype(dt)
+    return replace(geom, shape=(geom.shape[0], *inner), chunks=(geom.chunks[0], *inner), dtype=dt)
 
 
 def _transform_token(fn: ChunkTransform) -> str:
@@ -116,7 +140,14 @@ def _has_weak_token(transforms: Sequence[ChunkTransform]) -> bool:
 
 @dataclass(slots=True)
 class _Slot:
-    """One outer chunk's assembly buffer plus its completion bookkeeping."""
+    """One outer chunk's cache slot plus its completion bookkeeping.
+
+    ``data`` is the cache slot, sized at the transform's *output* geometry. ``scratch`` is
+    a transient *source*-shaped assembly buffer, present only when a reshaping transform
+    means the slot cannot also be the assembly target; tiles scatter into it and the
+    transformed result lands in ``data`` (then ``scratch`` is dropped). With no reshaping
+    transform ``scratch`` is ``None`` and tiles scatter straight into ``data`` -- the slot
+    is buffer and cache in one, no extra copy (the common path)."""
 
     data: np.ndarray
     remaining: int  # inner tiles not yet scattered; 0 => fully assembled
@@ -124,6 +155,7 @@ class _Slot:
     ready: bool = False
     error: BaseException | None = None
     claimed: bool = False  # the driver has referenced it *this epoch* (see wait_ready)
+    scratch: np.ndarray | None = None  # source-shaped assembly buffer (reshaping path only)
 
 
 class ChunkPool:
@@ -163,6 +195,22 @@ class ChunkPool:
         # representative geometry per path suffices for slot sizing (aliases share shape).
         self._by_path = {g.path: g for g in geometries.values()}
         self._chunk_transforms = tuple(chunk_transforms)
+        # Output geometry after the chunk_transform pipeline. A reshaping transform (regrid /
+        # dtype recast) makes the cached chunk differ from the source, so everything
+        # *downstream of assembly* -- slot sizing, the cache budget, gather, the revive
+        # structural check -- is sized at the OUTPUT geometry, while tile assembly stays at
+        # the SOURCE geometry (in scratch). With no reshaping transform out == source.
+        self._out_geom = {
+            label: output_geometry(g, self._chunk_transforms) for label, g in geometries.items()
+        }
+        self._out_by_path = {g.path: self._out_geom[label] for label, g in geometries.items()}
+        self._reshapes = {
+            p: (
+                out.inner_shape != self._by_path[p].inner_shape
+                or out.dtype != self._by_path[p].dtype
+            )
+            for p, out in self._out_by_path.items()
+        }
         # backing: heap (np.empty) or mmap'd .npy under backing_dir (point at NVMe).
         # The scatter writes straight into the slot either way; mmap keeps the working
         # set as reclaimable page cache rather than anon heap. Default heap: scattering
@@ -251,8 +299,11 @@ class ChunkPool:
         the budget is full of in-flight or referenced slots -- the caller awaits a release.
         """
         key = (array, chunk_index)
-        geom = self._by_path[array]
-        nbytes = int(np.prod(geom.slot_shape(chunk_index), dtype=np.int64)) * geom.dtype.itemsize
+        src, out = self._by_path[array], self._out_by_path[array]
+        # The cache slot is the OUTPUT geometry (what a reshaping transform produces and what
+        # gather reads); the budget is charged for it. Assembly tiles are SOURCE-shaped, so a
+        # reshaping path also needs a transient source-shaped scratch buffer (not cached).
+        nbytes = int(np.prod(out.slot_shape(chunk_index), dtype=np.int64)) * out.dtype.itemsize
         with self._cv:
             if key in self._slots:
                 self._pin(key)  # already resident (in-flight or ready hit) -> incref, reuse
@@ -262,11 +313,17 @@ class ChunkPool:
             if not self._make_room(nbytes):
                 return False
             self.misses += 1  # a fresh slot allocated to fetch -> a cache miss
+            scratch = (
+                np.empty(src.slot_shape(chunk_index), dtype=src.dtype)
+                if self._reshapes[array]
+                else None
+            )
             self._slots[key] = _Slot(
-                data=self._alloc(array, chunk_index, geom.slot_shape(chunk_index), geom.dtype),
-                remaining=geom.n_inner_chunks(chunk_index),
+                data=self._alloc(array, chunk_index, out.slot_shape(chunk_index), out.dtype),
+                remaining=src.n_inner_chunks(chunk_index),
                 nbytes=nbytes,
                 claimed=True,
+                scratch=scratch,
             )
             self._bytes += nbytes
             self._pin(key)
@@ -319,7 +376,7 @@ class ChunkPool:
         if fname is None:
             return False
         array, chunk_index = key
-        geom = self._by_path.get(array)
+        geom = self._out_by_path.get(array)  # the persisted .npy holds the post-transform chunk
         assert self._dir is not None
         try:
             data = np.lib.format.open_memmap(self._dir / fname, mode="r")
@@ -459,7 +516,10 @@ class ChunkPool:
         key = (array, chunk_index)
         slot = self._slots[key]  # allocated by the scheduler before any scatter
         dst, src = self._by_path[array].tile_placement(chunk_index, inner_coord)
-        slot.data[dst] = tile[src]  # disjoint, fixed-shape: lock-free (rule 1)
+        # Tiles assemble at the SOURCE shape: into scratch on a reshaping path, else straight
+        # into the slot (which is then both buffer and cache). Disjoint, fixed-shape, lock-free.
+        buffer = slot.data if slot.scratch is None else slot.scratch
+        buffer[dst] = tile[src]  # disjoint, fixed-shape: lock-free (rule 1)
 
         with self._cv:
             slot.remaining -= 1
@@ -467,29 +527,34 @@ class ChunkPool:
         if not last:
             return
 
-        # Sole owner now: assemble-stage transforms on the whole outer chunk.
-        prepped = self._apply_transforms(array, chunk_index, slot.data)
+        # Sole owner now: assemble-stage transforms on the whole (source-shaped) outer chunk,
+        # then land the (possibly reshaped) result in the output-sized slot.
+        prepped = self._apply_transforms(array, chunk_index, buffer)
         with self._cv:
             slot.data = self._persist(slot.data, prepped)
+            slot.scratch = None  # assembly done -- drop the transient source-shaped buffer
             slot.ready = True
             self._cv.notify_all()
 
     def _persist(self, current: np.ndarray, prepped: np.ndarray) -> np.ndarray:
-        """Land the prepped (post-transform) array in the slot's backing.
+        """Land the prepped (post-transform) array in the slot's (output-sized) backing.
 
-        No transform (``prepped is current``) is a no-op -- the scatter already
-        wrote the slot. With a transform, heap just holds the new array; mmap writes
-        it back into the slot's file so the cached chunk stays on NVMe (a shape-
-        changing transform like regrid would need a re-sized memmap -- deferred).
+        No transform (``prepped is current``) is a no-op -- the scatter already wrote the
+        slot. Otherwise heap just holds the new array; mmap writes it back into the slot's
+        file so the cached chunk stays on NVMe. The slot is sized at the transform's *output*
+        geometry (see :func:`output_geometry`), so a reshaping transform lands here exactly
+        like a shape-preserving one -- ``prepped.shape`` matches the slot by construction. A
+        mismatch means ``__call__`` disagreed with its declared ``output_inner``: a bug, raised.
         """
         if prepped is current or self._dir is None:
             return prepped
         if prepped.shape != current.shape:
-            raise NotImplementedError(
-                "mmap backing with a reshaping chunk_transform (e.g. regrid) is not "
-                "supported yet; use heap backing for that path."
+            raise ValueError(
+                f"chunk_transform produced shape {prepped.shape} but the cache slot is sized "
+                f"{current.shape} from the declared output geometry; a reshaping transform's "
+                "output_inner must agree with what __call__ returns."
             )
-        current[:] = prepped  # write the transformed result into the memmap
+        current[:] = prepped  # write the transformed result into the memmap (casts to slot dtype)
         return current
 
     def fail(self, array: str, chunk_index: int, error: BaseException) -> None:
@@ -571,11 +636,12 @@ class ChunkPool:
 
         arrays: dict[str, np.ndarray] = {}
         for var in variables:
-            geom = self._geom[var]
+            geom = self._geom[var]  # source: drives the read math (offset, path, chunking)
+            out_geom = self._out_geom[var]  # post-transform: shape/dtype the consumer sees
             sample = anchor + geom.offset  # this view reads array[anchor + offset]
             read_cid = sample // spc
             within = sample % spc
-            out = np.empty((n, *geom.inner_shape), dtype=geom.dtype)
+            out = np.empty((n, *out_geom.inner_shape), dtype=out_geom.dtype)
             for cid in np.unique(read_cid):
                 mask = read_cid == cid  # rows that read this chunk -> one coalesced index
                 out[mask] = self._slots[(geom.path, int(cid))].data[within[mask]]

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -118,6 +118,13 @@ def _transform_token(fn: ChunkTransform) -> str:
     or a called helper -- the same blind spot joblib has). The method is encoded in the
     token, so toggling cloudpickle on/off changes the fingerprint (honest re-compute
     rather than a false match).
+
+    On the source path a *class-based* transform (a callable instance, e.g. a dataclass
+    like :class:`StandardScaler`) is hashed by its **class** source + qualname, not the
+    instance: ``inspect.getsource(instance)`` raises and the default ``object`` repr embeds
+    the object's memory address, so the token would be unstable across runs (a spurious
+    cache miss on every reopen). A stable, non-default ``__repr__`` (dataclasses, partials)
+    is folded in so instance config still affects the token; the address-bearing default is not.
     """
     key = getattr(fn, "cache_key", None)
     if key is not None:
@@ -125,12 +132,20 @@ def _transform_token(fn: ChunkTransform) -> str:
     if cloudpickle is not None:
         with contextlib.suppress(Exception):  # unpicklable -> fall through to source
             return "pickle:" + hashlib.sha256(cloudpickle.dumps(fn)).hexdigest()
+    # Hash the routine itself, or the class of a callable instance (never the instance --
+    # its default repr carries an unstable address).
+    target = fn if inspect.isroutine(fn) else type(fn)
     try:
-        src = inspect.getsource(fn)
+        src = inspect.getsource(target)
     except (OSError, TypeError):
         src = ""  # C funcs / REPL: no source -> lean on the qualname alone
-    name = getattr(fn, "__qualname__", repr(fn))
-    return "src:" + hashlib.sha256(f"{name}\n{src}".encode()).hexdigest()
+    name = getattr(target, "__qualname__", repr(target))
+    # A class-defined repr (dataclass/partial) is stable and captures config; skip the
+    # default object repr, which would reintroduce the address.
+    config = (
+        repr(fn) if not inspect.isroutine(fn) and type(fn).__repr__ is not object.__repr__ else ""
+    )
+    return "src:" + hashlib.sha256(f"{name}\n{src}\n{config}".encode()).hexdigest()
 
 
 def _has_weak_token(transforms: Sequence[ChunkTransform]) -> bool:

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -35,7 +35,7 @@ from typing import Any
 
 import numpy as np
 
-from .pool import ChunkPool
+from .pool import ChunkPool, output_geometry
 from .scheduler import Scheduler, SchedulerConfig
 from .shuffle import block_shuffled_order, sequential_order
 from .split import SplitManifest, valid_anchor_range
@@ -151,6 +151,11 @@ class InSituDataset:
         self.prefetch_depth = max(int(prefetch_depth), 1)
         self.chunk_transforms = tuple(chunk_transforms)
         self.batch_transforms = tuple(batch_transforms)
+        # Geometry each variable presents *after* the chunk_transform pipeline (regrid / dtype
+        # recast). What the consumer and the framework adapters see, and what sizes the cache.
+        self._out_geometries = {
+            label: output_geometry(g, self.chunk_transforms) for label, g in self.geometries.items()
+        }
         self._epoch = 0
         self._persist = persist
         self.resident_peak = 0  # peak resident outer chunks (observability)
@@ -178,10 +183,14 @@ class InSituDataset:
         span = max(offsets) - min(offsets)
         windowed = any(o != 0 for o in offsets)
         window_factor = 2 + (-(-span // spc0)) if windowed else 1  # 2 + ceil(span/spc)
+        # Size from the OUTPUT geometry: the pool caches post-transform chunks, so a regrid
+        # that grows (or shrinks) the data changes the resident footprint the budget must hold.
         per_chunk_all_vars = int(
             sum(
-                g.sample_chunk_size * int(np.prod(g.inner_shape)) * g.dtype.itemsize
-                for g in self.geometries.values()
+                g.sample_chunk_size * int(np.prod(o.inner_shape)) * o.dtype.itemsize
+                for g, o in zip(
+                    self.geometries.values(), self._out_geometries.values(), strict=True
+                )
             )
         )
         working_set = 2 * block_chunks * window_factor * per_chunk_all_vars
@@ -440,7 +449,9 @@ class _SplitView:
 
     @property
     def geometries(self) -> dict[str, ArrayGeometry]:
-        return self._dataset.geometries
+        # Post-transform geometry: the adapters infer *output* tensor shapes/dtypes from
+        # this, which a reshaping chunk_transform (regrid / dtype recast) changes.
+        return self._dataset._out_geometries
 
     def __iter__(self) -> Iterator[Batch]:
         return self._dataset._iterate(self._split, self._shuffle)

--- a/src/insitubatch/transforms.py
+++ b/src/insitubatch/transforms.py
@@ -22,7 +22,7 @@ from typing import Protocol, runtime_checkable
 
 import numpy as np
 
-from .types import Batch, DecodedChunk
+from .types import ArrayGeometry, Batch, DecodedChunk
 
 
 @runtime_checkable
@@ -30,6 +30,30 @@ class ChunkTransform(Protocol):
     """Per-chunk transform applied before shuffle/gather (cacheable)."""
 
     def __call__(self, chunk: DecodedChunk) -> DecodedChunk: ...
+
+
+@runtime_checkable
+class ReshapingChunkTransform(ChunkTransform, Protocol):
+    """A chunk_transform that changes a chunk's *inner* geometry (shape and/or dtype).
+
+    The canonical case is regrid; a dtype recast (e.g. decode ``f2`` storage, cache ``f4``)
+    qualifies too. Declaring the output lets the engine size the cache slot and the gather
+    buffer at the post-transform geometry, so a reshaping transform is a first-class,
+    cacheable chunk stage rather than a heap-only special case.
+
+    ``output_inner`` returns only the **inner** geometry (everything past the sample axis):
+    a chunk_transform must never cross or reshape axis 0 (the sample-geometry invariant), so
+    it has no business naming axis 0, and the engine splices the source's sample axis back on.
+    Shape/dtype-preserving transforms (e.g. :class:`StandardScaler`) simply do **not** define
+    ``output_inner`` -- the engine treats their output geometry as identical to the source.
+    """
+
+    def output_inner(self, geom: ArrayGeometry) -> tuple[tuple[int, ...], np.dtype]:
+        """``(inner_shape, dtype)`` of this transform's output, given its input ``geom``.
+
+        Composes across a pipeline: the engine feeds each transform the geometry produced
+        by the ones before it. The sample axis (``geom.shape[0]``) is unchanged."""
+        ...
 
 
 @runtime_checkable

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -232,6 +232,130 @@ def test_pool_mmap_backing_with_transform(tiled_store, tmp_path):
     np.testing.assert_allclose(got, srcs["single_inner"][:spc] * 2.0)
 
 
+class MeanLastAxis:
+    """A *reshaping* chunk_transform: mean over the last inner axis (and an optional
+    dtype recast). Declares its output inner geometry via ``output_inner`` so the engine
+    can size the cache slot and gather buffer at the post-transform shape."""
+
+    def __init__(self, out_dtype: str | np.dtype = "f4") -> None:
+        self.out_dtype = np.dtype(out_dtype)
+
+    def __call__(self, chunk):
+        chunk.data = chunk.data.mean(axis=-1).astype(self.out_dtype)  # (n,9,7) -> (n,9)
+        return chunk
+
+    def output_inner(self, geom: ArrayGeometry) -> tuple[tuple[int, ...], np.dtype]:
+        return geom.inner_shape[:-1], self.out_dtype
+
+
+def _gather_chunk(pool, var, cid, geom, spc):
+    n0 = len(geom.samples_in_chunk(cid))
+    rows = np.array([[cid, w] for w in range(n0)], dtype=np.int64)
+    return pool.gather(rows, [var], spc).arrays[var]
+
+
+def test_pool_reshaping_transform_heap_gather(tiled_store):
+    """A reshaping chunk_transform's output shape flows through gather on heap backing.
+
+    Today gather allocates at the *source* inner_shape and assigns from the post-transform
+    slot (output shape) -> broadcast error. The output geometry must drive gather."""
+    url, srcs = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    spc = geom.sample_chunk_size
+
+    pool = ChunkPool(geoms, chunk_transforms=[MeanLastAxis()])
+    for cid in range(geom.n_chunks):
+        _fill_chunk(pool, "single_inner", cid, geom, tiles)
+        got = _gather_chunk(pool, "single_inner", cid, geom, spc)
+        n0 = len(geom.samples_in_chunk(cid))
+        expected = srcs["single_inner"][cid * spc : cid * spc + n0].mean(axis=-1)
+        assert got.shape == (n0, geom.inner_shape[0])  # (n, 9), reshaped from (n, 9, 7)
+        np.testing.assert_allclose(got, expected, rtol=1e-6)
+
+
+def test_pool_reshaping_transform_dtype_recast(tiled_store):
+    """A dtype-changing transform (f4 -> f8) propagates its dtype through gather."""
+    url, srcs = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    spc = geom.sample_chunk_size
+
+    pool = ChunkPool(geoms, chunk_transforms=[MeanLastAxis(out_dtype="f8")])
+    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    got = _gather_chunk(pool, "single_inner", 0, geom, spc)
+    assert got.dtype == np.dtype("f8")
+    np.testing.assert_allclose(got, srcs["single_inner"][:spc].mean(axis=-1), rtol=1e-12)
+
+
+def test_pool_reshaping_transform_mmap_persist_roundtrip(tiled_store, tmp_path):
+    """The fenced path: a reshaping transform on mmap backing with persist must write the
+    output-shaped result into the (output-sized) slot, survive close(), and revive as a
+    ready hit on reopen -- re-decoding zero chunks -- reconstructing the regridded data."""
+    url, srcs = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    spc = geom.sample_chunk_size
+    backing = tmp_path / "cache"
+
+    pool = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[MeanLastAxis()])
+    for cid in range(geom.n_chunks):
+        _fill_chunk(pool, "single_inner", cid, geom, tiles)
+    assert pool.misses == geom.n_chunks and pool.hits == 0
+    pool.close()
+    assert list(backing.glob("*.npy")) and (backing / "insitu_cache.json").exists()
+
+    pool2 = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[MeanLastAxis()])
+    assert pool2.manifest_entries == geom.n_chunks
+    for cid in range(geom.n_chunks):
+        assert pool2.pin_if_ready("single_inner", cid), "regridded chunk must revive as a hit"
+        n0 = len(geom.samples_in_chunk(cid))
+        got = _gather_chunk(pool2, "single_inner", cid, geom, spc)
+        expected = srcs["single_inner"][cid * spc : cid * spc + n0].mean(axis=-1)
+        assert got.shape == (n0, geom.inner_shape[0])
+        np.testing.assert_allclose(got, expected, rtol=1e-6)
+    assert pool2.hits == geom.n_chunks and pool2.misses == 0
+    pool2.close()
+
+
+def test_pool_reshaping_transform_structural_mismatch_is_miss(tiled_store, tmp_path):
+    """A persisted output-shaped entry whose *output* geometry no longer matches (the
+    transform now yields a different inner shape) is invalidated structurally -- a miss."""
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    backing = tmp_path / "cache"
+
+    class MeanBothAxes(MeanLastAxis):  # output inner () vs (9,) -> structural drift
+        def __call__(self, chunk):
+            chunk.data = chunk.data.mean(axis=(-2, -1)).astype(self.out_dtype)
+            return chunk
+
+        def output_inner(self, geom):
+            return (), self.out_dtype
+
+    # Share a cache_key so the transform *fingerprint* matches across the two runs; only
+    # the declared output inner shape differs ((9,) -> ()). That isolates the structural
+    # backstop: the persisted .npy header no longer matches the current output geometry.
+    t_old = MeanLastAxis()
+    t_old.cache_key = "k"  # type: ignore[attr-defined]
+    pool = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[t_old])
+    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    pool.close()
+
+    t_new = MeanBothAxes()
+    t_new.cache_key = "k"  # type: ignore[attr-defined]
+    pool2 = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[t_new])
+    assert pool2.manifest_entries == 1, "same fingerprint -> entry is consulted"
+    assert not pool2.pin_if_ready("single_inner", 0), "output-geometry drift must invalidate"
+    assert pool2.revive_mismatch == 1 and pool2.hits == 0
+    pool2.close()
+
+
 def test_pool_wait_ready_raises_on_failure(tiled_store):
     """A poisoned tile surfaces on the waiting consumer (fail-fast), not a hang."""
     url, _ = tiled_store

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -290,10 +290,21 @@ def test_pool_reshaping_transform_dtype_recast(tiled_store):
     np.testing.assert_allclose(got, srcs["single_inner"][:spc].mean(axis=-1), rtol=1e-12)
 
 
-def test_pool_reshaping_transform_mmap_persist_roundtrip(tiled_store, tmp_path):
+@pytest.mark.parametrize("no_cloudpickle", [False, True], ids=["cloudpickle", "source-hash"])
+def test_pool_reshaping_transform_mmap_persist_roundtrip(
+    tiled_store, tmp_path, monkeypatch, no_cloudpickle
+):
     """The fenced path: a reshaping transform on mmap backing with persist must write the
     output-shaped result into the (output-sized) slot, survive close(), and revive as a
-    ready hit on reopen -- re-decoding zero chunks -- reconstructing the regridded data."""
+    ready hit on reopen -- re-decoding zero chunks -- reconstructing the regridded data.
+
+    Parametrized over the transform-fingerprint path: with cloudpickle (the torch CI job) and
+    on the source-hash fallback (the tf/jax/freethreaded jobs, no ``cache`` extra). The latter
+    is a regression guard -- a class-based transform (``MeanLastAxis``) must fingerprint stably
+    without cloudpickle; hashing ``repr(instance)`` embedded the object address and discarded
+    the cache on every reopen (``manifest_entries == 0``)."""
+    if no_cloudpickle:
+        monkeypatch.setattr("insitubatch.pool.cloudpickle", None)
     url, srcs = tiled_store
     geoms = open_geometries(url, variables=["single_inner"])
     geom = geoms["single_inner"]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -76,6 +76,31 @@ def test_chunk_transform_normalizes_batches(tmp_path) -> None:
         )
 
 
+def test_reshaping_chunk_transform_through_dataset(tmp_path) -> None:
+    """A reshaping chunk_transform (mean over the last inner axis, (3,4)->(3,)) flows
+    end-to-end through InSituDataset: every batch carries the post-transform geometry."""
+    url, src = _write(tmp_path, inner=(3, 4))
+    geoms = open_geometries(url)
+    manifest = split_by_chunk(geoms["t2m"], fractions=(0.8, 0.1, 0.1))
+
+    class MeanLastAxis:
+        def __call__(self, chunk):
+            chunk.data = chunk.data.mean(axis=-1)  # (n,3,4) -> (n,3)
+            return chunk
+
+        def output_inner(self, geom):
+            return geom.inner_shape[:-1], geom.dtype
+
+    ds = InSituDataset(
+        url, manifest, batch_size=10, block_chunks=4, chunk_transforms=[MeanLastAxis()]
+    )
+    ds.set_epoch(0)
+    for batch in ds.train:
+        idx = batch.sample_indices
+        assert batch.arrays["t2m"].shape == (len(idx), 3)  # reshaped inner
+        np.testing.assert_allclose(batch.arrays["t2m"], src[idx].mean(axis=-1), rtol=1e-5)
+
+
 def test_cross_variable_windspeed_is_a_batch_transform(tmp_path) -> None:
     # Validates the documented capability: U10,V10 -> windspeed lives at the BATCH
     # stage (the chunk stage sees one variable at a time).


### PR DESCRIPTION
## What

Make a **reshaping** `chunk_transform` (regrid / dtype recast) a first-class, cacheable chunk stage on every backing — including the persistent mmap tier. Previously it was fenced off: `ChunkPool._persist` raised `NotImplementedError` on mmap because the slot was *both* the source-shaped assembly buffer *and* the cache.

## How

- **Transform declares its output geometry.** New optional `output_inner(geom) -> (inner_shape, dtype)` on the `ChunkTransform` protocol (`ReshapingChunkTransform`). Inner-only, so the sample-axis invariant is *unrepresentable* to violate — the engine splices axis 0 back from the source. dtype changes (e.g. f16 store → f32 cache) are supported. `pool.output_geometry(geom, transforms)` folds it across the pipeline.
- **Decouple scratch from slot.** `_Slot` gains `scratch`: the cache **slot** (`data`) is sized at the **output** geometry and charged to the budget; decoded tiles assemble into a transient **source**-shaped **scratch** heap buffer; `_persist` writes the transformed result into the slot. The non-reshaping path is unchanged (`scratch is None`, zero extra copy — slot is buffer and cache in one).
- **Downstream uses the output geometry:** `gather`, the `_revive` structural check, the cache-budget heuristic, and the TF `TensorSpec` (via `InSituDataset._out_geometries`).
- `_persist`'s `NotImplementedError` → fail-fast `ValueError`, raised only when a transform's `__call__` disagrees with its declared `output_inner`.

## Coupled decode-path zero-copy audit

- **Zero-copy decode→slot confirmed:** `decoded.as_numpy_array()` is `np.asanyarray(self._data)` (no copy; runtime-verified `shares_memory`), `tile[src]` edge-clip is a view, `buffer[dst]=tile[src]` is the *one* intentional memcpy. Reshaping adds exactly one more (scratch→slot). No stray `np.copy`/`astype`/`ascontiguousarray`.
- **GIL-released decode confirmed:** runs in the decode pool; `decode_threads` sweep scales 1→8 (704→1574 MB/s).
- **Flamegraph** (py-spy --native, local `file://` synthetic): no fat Python frame; cost is intentional C memcpy + zstd (~13%). Scratch is per-chunk alloc+free, **not** pooled — no alloc churn observed to justify a free-list.

## Tests

TDD — reshaping tests in `test_pool.py` (heap gather shape, dtype recast, mmap+persist cross-run round-trip, structural-mismatch miss) + an end-to-end test in `test_transforms.py`.

- `uv run pytest -q` → **99 passed, 5 skipped** (torch-less xbatcher)
- `ruff check` + `ruff format --check` + `mypy src bench examples` → clean

Docs corrected: the "reshaping deferred" limitation removed from `architecture.md` and `DESIGN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)