### PR TITLE
feat: add insitubatch-check-transform development CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,43 @@ for batch in ds.train:      # JAX: iterate a view, convert each batch
 tfds = as_tf_dataset(ds.val)  # a tf.data.Dataset
 ```
 
+## Transforms — and checking one before you train
+
+Two hooks, placed by cost: a **`chunk_transform`** `(DecodedChunk) -> DecodedChunk` runs per
+decoded chunk (one variable), before the cache boundary, so its output is **cached** — the home
+for scaling, unit conversion, dtype cast, regrid; and a **`batch_transform`** `(Batch) -> Batch`
+runs per assembled batch (all variables aligned), **uncached** — for cross-variable derived
+fields and per-sample random augmentation. Both are pure numpy; see
+[`examples/transforms.py`](examples/transforms.py) (K→C chunk stage + windspeed batch stage).
+
+A `chunk_transform` must be **vectorized numpy that releases the GIL** (a per-element Python
+loop serializes the decode pool), and a **reshaping** one (regrid) must declare
+`output_inner(geom) -> (inner_shape, dtype)` so the cache can size its slot. Check both against
+**one chunk of your real store** before training:
+
+```console
+$ insitubatch-check-transform \
+    gs://weatherbench2/datasets/era5/1959-2022-6h-128x64_equiangular_with_poles_conservative.zarr \
+    --var 2m_temperature --transform examples/transforms.py:kelvin_to_celsius --skip-signature
+
+  sample axis : 92040 samples, 40/chunk, 2301 chunks
+  chunk 0    : 40 samples -> source shape (40, 128, 64) = 1.3 MB decoded
+transform output:
+  (40, 128, 64) float32  ->  (40, 128, 64) float32   shape- and dtype-preserving
+cacheability: shape/dtype-preserving, no output_inner needed -> cacheable as-is.
+GIL-release probe (thread-scaling, 4 threads):
+  speedup 3.50x (>= 2.40) -> releases the GIL (vectorized).
+PASS: chunk_transform checks all passed.
+```
+
+The target is `module:attr` or `path/to/file.py:attr` (a transform class is instantiated).
+It reports the chunk geometry, validates a declared `output_inner` against the real output
+(catching the mismatch the cache would later reject), and gives a GIL-release verdict — a
+non-zero exit gates a pre-commit hook. Pass `--no-gil-probe` for a fast structural-only check;
+the GIL probe needs a realistically-sized chunk (a toy array is dominated by call overhead). For
+the **reshaping** path, try `--transform examples/transforms.py:Coarsen` — a chunk-local regrid
+that halves the grid and declares `output_inner`, so the report shows the validated shape change.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -322,17 +322,22 @@ get wrong and otherwise only surface at training time. Run the bundled CLI again
 of your real store** while you write the transform:
 
 ```bash
-python -m insitubatch.check_transform s3://bucket/era5.zarr --var t2m \
-    --transform ./prep.py:Regrid      # or  module.path:attr  (a class is instantiated)
-# also installed as:  insitubatch-check-transform ...
+# a runnable example against the public WeatherBench2 ERA5, checking the bundled K->C transform:
+insitubatch-check-transform \
+    gs://weatherbench2/datasets/era5/1959-2022-6h-128x64_equiangular_with_poles_conservative.zarr \
+    --var 2m_temperature --transform examples/transforms.py:kelvin_to_celsius --skip-signature
+# your own:  insitubatch-check-transform s3://bucket/era5.zarr --var t2m --transform ./prep.py:Regrid
+#            (target is module:attr or path.py:attr; a transform class is instantiated)
 ```
 
 It prints the chunk geometry (the decoded MB the cache will hold), runs the transform on real
-data, **validates the declared `output_inner` against the actual output** (catching the
-mismatch `ChunkPool._persist` would later raise), and runs a thread-scaling probe that flags a
-transform holding the GIL — a pure-Python per-element transform that would serialize the decode
-pool. Non-zero exit on a failed check, so it can gate a pre-commit hook. `--no-gil-probe` does
-the geometry + cacheability checks only (fast, deterministic).
+data, **validates a declared `output_inner` against the actual output** (catching the mismatch
+`ChunkPool._persist` would later raise, or a reshape that forgot to declare one), and runs a
+thread-scaling probe that flags a transform holding the GIL — a pure-Python per-element transform
+that would serialize the decode pool. Non-zero exit on a failed check, so it can gate a
+pre-commit hook. `--no-gil-probe` does the geometry + cacheability checks only (fast,
+deterministic); the GIL probe wants a realistically-sized chunk (a toy array is dominated by
+per-call overhead). `--skip-signature` / `--request-payer` read public / Requester-Pays stores.
 
 ## Bad / corrupt chunks
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -302,11 +302,37 @@ class Regrid:
     def __call__(self, chunk: DecodedChunk) -> DecodedChunk:
         chunk.data = _apply_weights(chunk.data, self._idx, self._w)
         return chunk
+    def output_inner(self, geom: ArrayGeometry) -> tuple[tuple[int, ...], np.dtype]:
+        return (len(self.dst_lat), len(self.dst_lon)), geom.dtype  # new inner shape
 ```
+
+A **reshaping** `chunk_transform` declares `output_inner` so the cache can size its slot at
+the post-transform shape (see [the caching section](#the-caching-continuum)); a
+shape/dtype-preserving one (scaling) omits it. Only the inner dims and dtype may change — the
+sample axis is the engine's to keep.
 
 - **Fat chunks** → `chunk_transform` (amortized over the chunk's samples).
 - **ARCO `chunk-1`** → reuse the same weights as a sparse tensor in a
   `device_transform` (batched on GPU), since per-chunk == per-sample there.
+
+### Developing a transform — `check_transform`
+
+Both transform contracts (vectorized/GIL-releasing, and a correct `output_inner`) are easy to
+get wrong and otherwise only surface at training time. Run the bundled CLI against **one chunk
+of your real store** while you write the transform:
+
+```bash
+python -m insitubatch.check_transform s3://bucket/era5.zarr --var t2m \
+    --transform ./prep.py:Regrid      # or  module.path:attr  (a class is instantiated)
+# also installed as:  insitubatch-check-transform ...
+```
+
+It prints the chunk geometry (the decoded MB the cache will hold), runs the transform on real
+data, **validates the declared `output_inner` against the actual output** (catching the
+mismatch `ChunkPool._persist` would later raise), and runs a thread-scaling probe that flags a
+transform holding the GIL — a pure-Python per-element transform that would serialize the decode
+pool. Non-zero exit on a failed check, so it can gate a pre-commit hook. `--no-gil-probe` does
+the geometry + cacheability checks only (fast, deterministic).
 
 ## Bad / corrupt chunks
 

--- a/examples/transforms.py
+++ b/examples/transforms.py
@@ -15,10 +15,12 @@ needs to see* (the full model is in docs/architecture.md, "Transforms"):
   output is **recomputed every draw** (never cached).
 
 The rule of thumb: per-variable + per-chunk + deterministic -> chunk stage (cacheable);
-cross-variable or per-sample-random -> batch stage. This example makes the split concrete:
-a Kelvin->Celsius conversion is a chunk_transform (one variable, elementwise), while
-windspeed = sqrt(u10^2 + v10^2) *must* be a batch_transform -- a chunk_transform cannot see
-``u10`` and ``v10`` at once.
+cross-variable or per-sample-random -> batch stage. This example makes the split concrete with
+three transforms: :func:`kelvin_to_celsius` (a shape-preserving chunk stage) and :class:`Coarsen`
+(a *reshaping* chunk stage -- a chunk-local regrid that halves the grid and declares its output
+geometry so the cache can size the slot), then ``windspeed = sqrt(u10^2 + v10^2)`` at the batch
+stage -- which *must* be a batch_transform, since a chunk_transform cannot see ``u10`` and
+``v10`` at once. Validate any of them against a real store with ``insitubatch-check-transform``.
 
     uv run python -m examples.transforms
 """
@@ -27,13 +29,14 @@ from __future__ import annotations
 
 import shutil
 import tempfile
+from dataclasses import dataclass
 
 import numpy as np
 import zarr
 
 from insitubatch import ensure_local_dir, open_geometries, split_by_chunk, store_from_url
 from insitubatch.source import InSituDataset
-from insitubatch.types import Batch, DecodedChunk
+from insitubatch.types import ArrayGeometry, Batch, DecodedChunk
 
 VARIABLES = ("t2m", "u10", "v10")
 
@@ -61,15 +64,60 @@ def build_store(tmp: str, *, n: int = 64, lat: int = 16, lon: int = 32, spc: int
     return url
 
 
+# Temperature fields this K->C transform understands: the synthetic ``t2m`` here and the public
+# WeatherBench2 ERA5 name (``2m_temperature``), so the same callable works against real cloud data.
+TEMPERATURE_VARS = ("t2m", "2m_temperature")
+
+
 def kelvin_to_celsius(chunk: DecodedChunk) -> DecodedChunk:
-    """A chunk_transform: convert temperature to Celsius in place.
+    """A chunk_transform: convert 2 m temperature from Kelvin to Celsius, vectorized.
 
     Gated on the variable name, because a chunk_transform is called once per (variable,
-    chunk) and should only touch the field it understands. Leaves u10/v10 untouched.
+    chunk) and should only touch the field it understands (leaves u10/v10 untouched). It is
+    per-variable, per-chunk, deterministic and elementwise -- the textbook cacheable chunk
+    stage -- and pure vectorized numpy, so it releases the GIL on the decode pool.
+
+    Check it against one chunk of your real store before training (geometry, cacheability, and
+    an empirical GIL-release verdict)::
+
+        insitubatch-check-transform <URL> --var 2m_temperature \\
+            --transform examples/transforms.py:kelvin_to_celsius --skip-signature
     """
-    if chunk.read.array == "t2m":
+    if chunk.read.array in TEMPERATURE_VARS:
         chunk.data = chunk.data - 273.15
     return chunk
+
+
+@dataclass
+class Coarsen:
+    """A *reshaping* chunk_transform: block-mean the spatial grid by ``factor`` (a local regrid).
+
+    ``(n, lat, lon) -> (n, lat//factor, lon//factor)`` -- the canonical geometry-changing chunk
+    stage. Because the output shape differs from the source, it declares ``output_inner`` so the
+    cache can size its slot at the coarsened shape (a reshaping transform that *forgot* to declare
+    it is rejected -- try deleting the method and running ``check-transform``). Pure vectorized
+    numpy (a strided reshape + mean), so it releases the GIL on the decode pool. Assumes a 2-D
+    ``(lat, lon)`` inner grid; a ragged edge (not divisible by ``factor``) is trimmed.
+
+    Check the reshaping path against real data (validates the declared vs actual output shape)::
+
+        insitubatch-check-transform <URL> --var 2m_temperature \\
+            --transform examples/transforms.py:Coarsen --skip-signature
+    """
+
+    factor: int = 2
+
+    def __call__(self, chunk: DecodedChunk) -> DecodedChunk:
+        n, lat, lon = chunk.data.shape
+        f = self.factor
+        lat2, lon2 = (lat // f) * f, (lon // f) * f  # trim the ragged edge to a multiple of f
+        blocks = chunk.data[:, :lat2, :lon2].reshape(n, lat2 // f, f, lon2 // f, f)
+        chunk.data = blocks.mean(axis=(2, 4)).astype(chunk.data.dtype)  # (n, lat//f, lon//f)
+        return chunk
+
+    def output_inner(self, geom: ArrayGeometry) -> tuple[tuple[int, ...], np.dtype]:
+        lat, lon = geom.inner_shape
+        return (lat // self.factor, lon // self.factor), geom.dtype
 
 
 def add_windspeed(batch: Batch) -> Batch:
@@ -93,7 +141,10 @@ def run_demo(
     try:
         geoms = open_geometries(url, variables=list(VARIABLES))
         manifest = split_by_chunk(geoms["t2m"], fractions=(0.8, 0.1, 0.1))
+        source_inner = geoms["t2m"].inner_shape
 
+        # Two chunk stages: K->C (shape-preserving) then a reshaping Coarsen (halves the grid).
+        # The cache slot is sized at the *coarsened* shape via Coarsen.output_inner.
         ds = InSituDataset(
             url,
             manifest,
@@ -101,7 +152,7 @@ def run_demo(
             batch_size=batch_size,
             block_chunks=block_chunks,
             shuffle=False,
-            chunk_transforms=[kelvin_to_celsius],
+            chunk_transforms=[kelvin_to_celsius, Coarsen(factor=2)],
             batch_transforms=[add_windspeed],
         )
 
@@ -113,13 +164,16 @@ def run_demo(
             "windspeed_mean": float(wind.mean()),
             "windspeed_nonneg": bool((wind >= 0.0).all()),
             "samples": int(t2m.shape[0]),
-            "sample_shape": tuple(t2m.shape[1:]),
+            "source_inner": tuple(source_inner),
+            "sample_shape": tuple(t2m.shape[1:]),  # coarsened by the reshaping chunk_transform
         }
         if verbose:
+            src, out = summary["source_inner"], summary["sample_shape"]
             print(f"batch variables: {summary['variables']}")
             print(f"t2m  (chunk_transform K->C): mean {summary['t2m_mean_c']:+.2f} C")
+            print(f"grid (chunk_transform Coarsen): {src} -> {out}")
             print(f"windspeed (batch_transform): mean {summary['windspeed_mean']:.2f} m/s")
-            print("both transform stages ran.")
+            print("all three stages ran: K->C + reshaping Coarsen (chunk), windspeed (batch).")
         return summary
     finally:
         if tmp is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ dependencies = [
     "obstore>=0.3",
 ]
 
+[project.scripts]
+# A development tool (not on the training hot path): probe one chunk of a real store to
+# check a chunk_transform's geometry, declared output_inner, and GIL-release behavior.
+insitubatch-check-transform = "insitubatch.check_transform:main"
+
 [project.urls]
 Documentation = "https://emfdavid.github.io/insitubatch/"
 Homepage = "https://emfdavid.github.io/insitubatch/"

--- a/src/insitubatch/check_transform.py
+++ b/src/insitubatch/check_transform.py
@@ -1,0 +1,300 @@
+"""Develop a ``chunk_transform`` against your real dataset, before training.
+
+A ``chunk_transform`` carries two contracts that otherwise only fail at training time:
+
+* it must be **vectorized numpy that releases the GIL** -- a pure-Python per-element
+  transform silently serializes the decode thread pool and kills IO overlap;
+* a **reshaping** transform must declare ``output_inner(geom) -> (inner_shape, dtype)``
+  that *agrees* with what ``__call__`` produces -- the cross-run cache sizes its slot from
+  it (a disagreement raises deep in :meth:`ChunkPool._persist`).
+
+This CLI runs the transform on **one chunk of the real store** and reports the chunk
+geometry, the input->output shape/dtype, whether the declared output geometry matches, and
+an empirical GIL-release verdict (a thread-scaling probe that models the decode-pool overlap)::
+
+    python -m insitubatch.check_transform s3://bucket/era5.zarr --var t2m \\
+        --transform my_pkg.transforms:Regrid
+
+    insitubatch-check-transform ./era5.zarr --var t2m --transform ./prep.py:scale
+
+The target is ``module.path:attr`` or ``./file.py:attr``. Exit code is non-zero when a check
+fails (declared-output mismatch, an undeclared reshape, or a GIL-held verdict), so it can
+gate a pre-commit / CI step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.util
+import os
+import statistics
+import sys
+import time
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import numpy as np
+import zarr
+
+from .pool import output_geometry
+from .store import as_store, open_geometries
+from .types import ArrayGeometry, ChunkRead, DecodedChunk
+
+ChunkTransform = Callable[[DecodedChunk], DecodedChunk]
+
+
+def load_transform(target: str) -> ChunkTransform:
+    """Resolve ``module.path:attr`` or ``./file.py:attr`` to a callable transform."""
+    if ":" not in target:
+        raise ValueError(f"--transform must be 'module:attr' or 'file.py:attr', got {target!r}")
+    mod_part, _, attr = target.partition(":")
+    if not attr:
+        raise ValueError(f"--transform is missing the ':attr' part, got {target!r}")
+    if mod_part.endswith(".py") or os.sep in mod_part or "/" in mod_part:
+        path = Path(mod_part).expanduser().resolve()
+        if not path.is_file():
+            raise FileNotFoundError(f"transform file not found: {path}")
+        spec = importlib.util.spec_from_file_location(path.stem, path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"could not load a module from {path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    else:
+        module = importlib.import_module(mod_part)
+    if not hasattr(module, attr):
+        raise AttributeError(f"{attr!r} not found in {mod_part}")
+    fn = getattr(module, attr)
+    if isinstance(fn, type):  # a transform *class* -> instantiate it (no-arg ctor)
+        try:
+            fn = fn()
+        except TypeError as exc:
+            raise TypeError(
+                f"{target} is a class whose constructor needs arguments ({exc}); expose a "
+                "configured instance at module scope instead (e.g. `my_transform = Regrid(...)`) "
+                "and point --transform at that."
+            ) from exc
+    if not callable(fn):
+        raise TypeError(f"{target} resolved to {type(fn).__name__}, which is not callable")
+    return fn
+
+
+def read_chunk(url: str, var: str, chunk_index: int, geom: ArrayGeometry) -> DecodedChunk:
+    """Decode exactly one outer chunk of ``var`` into a :class:`DecodedChunk`.
+
+    Uses a plain zarr slice -- this is a one-off development read, not the training hot path
+    (the no-getitem stance is about throughput), so zarr stitching the inner grid is fine."""
+    group = zarr.open_group(store=as_store(url), mode="r")
+    arr = group[var]
+    samples = geom.samples_in_chunk(chunk_index)
+    data = np.asarray(arr[samples.start : samples.stop])  # type: ignore[index]
+    return DecodedChunk(read=ChunkRead(var, chunk_index), data=data, sample_offset=samples.start)
+
+
+def _fresh(base: DecodedChunk) -> DecodedChunk:
+    """A pristine source-shaped copy of the input chunk (transforms may mutate in place)."""
+    return DecodedChunk(read=base.read, data=base.data.copy(), sample_offset=base.sample_offset)
+
+
+def _run_iters(
+    fn: ChunkTransform, pristine: np.ndarray, read: ChunkRead, offset: int, iters: int
+) -> None:
+    """Run ``fn`` ``iters`` times, each on a fresh source-shaped copy of ``pristine``.
+
+    A fresh copy per call is required for correctness: transforms may mutate ``chunk.data``
+    in place, and a reshaping transform cannot be re-run on its own (changed-shape) output."""
+    for _ in range(iters):
+        fn(DecodedChunk(read=read, data=pristine.copy(), sample_offset=offset))
+
+
+def gil_probe(
+    fn: ChunkTransform, base: DecodedChunk, *, threads: int, min_seconds: float, repeats: int
+) -> dict[str, float]:
+    """Thread-scaling speedup of ``fn``: vectorized (GIL-releasing) work scales with threads;
+    a pure-Python per-element transform stays ~1x because it holds the GIL.
+
+    Each worker runs ``iters`` calls on its *own* pristine source buffer (memory is bounded by
+    ``threads``, not the call count, so even a sub-millisecond transform gets a full
+    ``min_seconds`` window). serial = 1 thread doing ``iters``; parallel = ``threads`` threads
+    each doing ``iters`` (so ``threads x`` the work). speedup = threads * t_serial / t_parallel
+    -> ~threads when the GIL is released, ~1 when it is held. The per-call source copy is
+    included symmetrically; it releases the GIL too, so it never *masks* a GIL-holding
+    transform (which dominates the timing) -- it only avoids false alarms on fast ones."""
+    read, pristine, offset = base.read, base.data, base.sample_offset
+    _run_iters(fn, pristine, read, offset, 1)  # warm up: imports / lazy alloc / page faults
+
+    t0 = time.perf_counter()
+    _run_iters(fn, pristine, read, offset, 1)
+    one = max(time.perf_counter() - t0, 1e-6)
+    iters = max(1, int(min_seconds / one) + 1)
+
+    def serial() -> float:
+        t = time.perf_counter()
+        _run_iters(fn, pristine, read, offset, iters)
+        return time.perf_counter() - t
+
+    def parallel() -> float:
+        t = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=threads) as ex:
+            futs = [
+                ex.submit(_run_iters, fn, pristine, read, offset, iters) for _ in range(threads)
+            ]
+            for f in futs:
+                f.result()
+        return time.perf_counter() - t
+
+    s = statistics.median(serial() for _ in range(repeats))
+    p = statistics.median(parallel() for _ in range(repeats))
+    return {
+        "iters": float(iters),
+        "serial_s": s,
+        "parallel_s": p,
+        "speedup": threads * s / p if p > 0 else float("inf"),
+        "per_call_ms": s / iters * 1e3,
+        "mb_s": pristine.nbytes / 1e6 / (s / iters) if s > 0 else float("inf"),
+    }
+
+
+def _gil_enabled() -> bool | None:
+    """True/False on 3.13+ (free-threaded build => False); None when undeterminable (<=3.12)."""
+    probe = getattr(sys, "_is_gil_enabled", None)
+    return bool(probe()) if probe is not None else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="insitubatch-check-transform",
+        description="Develop a chunk_transform against one chunk of your real dataset.",
+    )
+    p.add_argument("url", help="zarr store URL (file://, s3://, gs://, ...)")
+    p.add_argument("--var", required=True, help="variable (array) name in the store")
+    p.add_argument("--transform", required=True, help="'module.path:attr' or './file.py:attr'")
+    p.add_argument("--chunk", type=int, default=0, help="outer (sample-axis) chunk index to probe")
+    p.add_argument("--threads", type=int, default=0, help="GIL-probe threads (0 = min(4, cpus))")
+    p.add_argument("--repeats", type=int, default=3, help="timing runs per point; report median")
+    p.add_argument("--min-seconds", type=float, default=0.3, help="min serial timing window")
+    p.add_argument(
+        "--no-gil-probe",
+        action="store_true",
+        help="skip the GIL/vectorization probe "
+        "(geometry + output_inner checks only -- fast, deterministic)",
+    )
+    a = p.parse_args(argv)
+
+    threads = a.threads or min(4, os.cpu_count() or 1)
+
+    try:
+        fn = load_transform(a.transform)
+    except (ValueError, FileNotFoundError, ImportError, AttributeError, TypeError) as exc:
+        print(f"error: could not load --transform {a.transform!r}: {exc}", file=sys.stderr)
+        return 2
+
+    geoms = open_geometries(a.url, variables=[a.var])
+    geom = geoms[a.var]
+    if not 0 <= a.chunk < geom.n_chunks:
+        print(f"error: --chunk {a.chunk} out of range [0, {geom.n_chunks})", file=sys.stderr)
+        return 2
+
+    n_samples = len(geom.samples_in_chunk(a.chunk))
+    src_mb = int(np.prod(geom.slot_shape(a.chunk))) * geom.dtype.itemsize / 1e6
+    tiles = geom.n_inner_chunks(a.chunk)
+    print(f"dataset: {a.url}  var={a.var}")
+    print(
+        f"  sample axis : {geom.n_samples} samples, {geom.sample_chunk_size}/chunk, "
+        f"{geom.n_chunks} chunks"
+    )
+    print(f"  inner shape : {geom.inner_shape}  dtype={geom.dtype}  inner tiles/chunk={tiles}")
+    print(
+        f"  chunk {a.chunk:<5}: {n_samples} samples -> source shape "
+        f"{geom.slot_shape(a.chunk)} = {src_mb:.1f} MB decoded"
+    )
+
+    base = read_chunk(a.url, a.var, a.chunk, geom)
+    in_shape, in_dtype = base.data.shape, base.data.dtype
+    out = fn(_fresh(base))
+    out_data = out.data
+    print("\ntransform output:")
+    print(f"  {in_shape} {in_dtype}  ->  {out_data.shape} {out_data.dtype}")
+    reshaped = out_data.shape[1:] != in_shape[1:]
+    recast = out_data.dtype != in_dtype
+    tags = [t for t, on in (("reshaped", reshaped), ("recast", recast)) if on]
+    print(f"  {'  '.join(tags) if tags else 'shape- and dtype-preserving'}")
+    if np.issubdtype(out_data.dtype, np.floating):
+        bad = int(np.count_nonzero(~np.isfinite(out_data)))
+        if bad:
+            print(f"  WARNING: output has {bad} non-finite (NaN/inf) values")
+
+    # -- declared-output validation -----------------------------------------
+    ok = True
+    declares = hasattr(fn, "output_inner")
+    print("\ncacheability (declared output geometry):")
+    if declares:
+        declared = output_geometry(geom, [fn])
+        match = declared.inner_shape == out_data.shape[1:] and declared.dtype == out_data.dtype
+        ok = ok and match
+        verdict = "OK" if match else "MISMATCH"
+        print(f"  declares output_inner -> {declared.inner_shape} {declared.dtype}  [{verdict}]")
+        if not match:
+            print(
+                f"  FAIL: declared {declared.inner_shape}/{declared.dtype} != actual "
+                f"{out_data.shape[1:]}/{out_data.dtype} -- ChunkPool._persist would raise."
+            )
+    elif reshaped or recast:
+        ok = False
+        print(
+            "  FAIL: this transform reshapes/recasts but does not declare output_inner. The "
+            "cache cannot size its slot -> add output_inner(geom) -> (inner_shape, dtype) "
+            "(see insitubatch.transforms.ReshapingChunkTransform)."
+        )
+    else:
+        print("  shape/dtype-preserving, no output_inner needed -> cacheable as-is.")
+
+    # -- GIL-release / vectorization probe ----------------------------------
+    if a.no_gil_probe:
+        print("\nGIL-release probe: skipped (--no-gil-probe).")
+        print(
+            f"\n{'PASS' if ok else 'FAIL'}: chunk_transform checks "
+            f"{'all passed' if ok else 'found problems (see above)'}."
+        )
+        return 0 if ok else 1
+
+    print(f"\nGIL-release probe (thread-scaling, {threads} threads):")
+    gil = _gil_enabled()
+    probe = gil_probe(fn, base, threads=threads, min_seconds=a.min_seconds, repeats=a.repeats)
+    print(
+        f"  per-call {probe['per_call_ms']:.2f} ms  (~{probe['mb_s']:.0f} MB/s)  "
+        f"iters={int(probe['iters'])}  "
+        f"serial {probe['serial_s']:.3f}s  parallel {probe['parallel_s']:.3f}s"
+    )
+    if gil is False:
+        print(
+            "  speedup "
+            f"{probe['speedup']:.2f}x -- GIL-release: N/A on a free-threaded build "
+            "(Python loops also scale; check per-call latency for vectorization)."
+        )
+    else:
+        target = 0.6 * min(threads, os.cpu_count() or 1)
+        passed = probe["speedup"] >= target
+        ok = ok and passed
+        if passed:
+            print(
+                f"  speedup {probe['speedup']:.2f}x (>= {target:.2f}) "
+                "-> releases the GIL (vectorized)."
+            )
+        else:
+            print(
+                f"  FAIL: speedup {probe['speedup']:.2f}x (< {target:.2f}) -> appears to HOLD the "
+                "GIL. A pure-Python per-element transform serializes the decode pool and kills "
+                "IO overlap; rewrite as vectorized numpy."
+            )
+
+    print(
+        f"\n{'PASS' if ok else 'FAIL'}: chunk_transform checks "
+        f"{'all passed' if ok else 'found problems (see above)'}."
+    )
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - module entry point
+    raise SystemExit(main())

--- a/src/insitubatch/check_transform.py
+++ b/src/insitubatch/check_transform.py
@@ -60,6 +60,9 @@ def load_transform(target: str) -> ChunkTransform:
         if spec is None or spec.loader is None:
             raise ImportError(f"could not load a module from {path}")
         module = importlib.util.module_from_spec(spec)
+        # Register before exec: a dataclass (or anything resolving sys.modules[__module__],
+        # e.g. typing.get_type_hints) in the loaded file needs its module discoverable.
+        sys.modules[spec.name] = module
         spec.loader.exec_module(module)
     else:
         module = importlib.import_module(mod_part)
@@ -80,12 +83,14 @@ def load_transform(target: str) -> ChunkTransform:
     return fn
 
 
-def read_chunk(url: str, var: str, chunk_index: int, geom: ArrayGeometry) -> DecodedChunk:
+def read_chunk(
+    url: str, var: str, chunk_index: int, geom: ArrayGeometry, **store_kwargs: bool
+) -> DecodedChunk:
     """Decode exactly one outer chunk of ``var`` into a :class:`DecodedChunk`.
 
     Uses a plain zarr slice -- this is a one-off development read, not the training hot path
     (the no-getitem stance is about throughput), so zarr stitching the inner grid is fine."""
-    group = zarr.open_group(store=as_store(url), mode="r")
+    group = zarr.open_group(store=as_store(url, **store_kwargs), mode="r")
     arr = group[var]
     samples = geom.samples_in_chunk(chunk_index)
     data = np.asarray(arr[samples.start : samples.stop])  # type: ignore[index]
@@ -100,12 +105,19 @@ def _fresh(base: DecodedChunk) -> DecodedChunk:
 def _run_iters(
     fn: ChunkTransform, pristine: np.ndarray, read: ChunkRead, offset: int, iters: int
 ) -> None:
-    """Run ``fn`` ``iters`` times, each on a fresh source-shaped copy of ``pristine``.
+    """Run ``fn`` ``iters`` times, resetting the input to ``pristine`` before each call.
 
-    A fresh copy per call is required for correctness: transforms may mutate ``chunk.data``
-    in place, and a reshaping transform cannot be re-run on its own (changed-shape) output."""
+    The input is reset because transforms may mutate ``chunk.data`` in place, and a reshaping
+    transform cannot be re-run on its own (changed-shape) output. The reset writes into a
+    *preallocated* per-worker buffer (``np.copyto``) rather than allocating a fresh copy each
+    iteration: a per-iter allocation would thrash the allocator across the probe's worker
+    threads and mask the transform's own GIL behavior (a per-worker malloc lock, not the GIL)."""
+    buffer = pristine.copy()
+    chunk = DecodedChunk(read=read, data=buffer, sample_offset=offset)
     for _ in range(iters):
-        fn(DecodedChunk(read=read, data=pristine.copy(), sample_offset=offset))
+        np.copyto(buffer, pristine)  # reset the input (a GIL-releasing memcpy, no allocation)
+        chunk.data = buffer
+        fn(chunk)
 
 
 def gil_probe(
@@ -180,9 +192,22 @@ def main(argv: list[str] | None = None) -> int:
         help="skip the GIL/vectorization probe "
         "(geometry + output_inner checks only -- fast, deterministic)",
     )
+    p.add_argument(
+        "--skip-signature",
+        action="store_true",
+        help="anonymous read of a public bucket (e.g. gs://weatherbench2/...)",
+    )
+    p.add_argument("--request-payer", action="store_true", help="Requester-Pays S3 bucket")
     a = p.parse_args(argv)
 
     threads = a.threads or min(4, os.cpu_count() or 1)
+    # Same store-auth surface as the loader (see examples/wb2_dataloader.py) so check_transform
+    # reaches the same public / requester-pays stores. Typed bool so the **kwargs stays mypy-clean.
+    store_kwargs: dict[str, bool] = {}
+    if a.skip_signature:
+        store_kwargs["skip_signature"] = True
+    if a.request_payer:
+        store_kwargs["request_payer"] = True
 
     try:
         fn = load_transform(a.transform)
@@ -190,7 +215,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: could not load --transform {a.transform!r}: {exc}", file=sys.stderr)
         return 2
 
-    geoms = open_geometries(a.url, variables=[a.var])
+    geoms = open_geometries(a.url, variables=[a.var], **store_kwargs)
     geom = geoms[a.var]
     if not 0 <= a.chunk < geom.n_chunks:
         print(f"error: --chunk {a.chunk} out of range [0, {geom.n_chunks})", file=sys.stderr)
@@ -210,7 +235,7 @@ def main(argv: list[str] | None = None) -> int:
         f"{geom.slot_shape(a.chunk)} = {src_mb:.1f} MB decoded"
     )
 
-    base = read_chunk(a.url, a.var, a.chunk, geom)
+    base = read_chunk(a.url, a.var, a.chunk, geom, **store_kwargs)
     in_shape, in_dtype = base.data.shape, base.data.dtype
     out = fn(_fresh(base))
     out_data = out.data

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -687,12 +687,18 @@ class ChunkPool:
     def _load_manifest(self) -> None:
         """Populate the persisted-entry registry from a prior run's manifest, if any.
 
-        No manifest is a cold start (silent -- the expected first run). An unreadable
-        manifest or a format mismatch is a cold start too, but WARNed: persistence was
-        asked for and a prior cache could not be honored. Per-entry validation
-        (existence, shape, dtype) is deferred to :meth:`_revive`, which reads it from the
-        ``.npy`` header -- so a stale/missing file shows up as a per-epoch revive failure
-        the driver can warn on, not a silent drop here.
+        No manifest is a cold start (silent -- the expected first run). The *expected* stale
+        states degrade to a cold start with a WARN: an unreadable manifest, a format-version
+        bump, and a chunk_transform fingerprint change. Per-entry data validation (file
+        existence, shape, dtype) is deferred to :meth:`_revive`, which reads it from the
+        ``.npy`` header -- so a stale/missing file shows up as a per-epoch revive failure.
+
+        A manifest that clears those gates but is then *structurally* corrupt -- an entry with
+        a missing field, a non-integer chunk index, or a ``file`` that is not a bare filename
+        (an absolute or ``..`` path would let :meth:`_revive` ``open_memmap`` escape the cache
+        dir) -- is **not** an expected stale cache; it is corruption or tampering. We fail fast
+        and raise rather than silently start cold (which would hide the problem and re-decode
+        everything). Delete the cache dir to reset.
         """
         assert self._dir is not None
         path = self._dir / self._MANIFEST_NAME
@@ -718,8 +724,38 @@ class ChunkPool:
                 path,
             )
             return
-        for entry in doc.get("entries", []):
-            self._persisted[(entry["array"], int(entry["chunk_index"]))] = entry["file"]
+        entries = doc.get("entries", [])
+        if not isinstance(entries, list):
+            raise ValueError(
+                f"persist: cache manifest {path} is corrupt ('entries' is not a list); "
+                f"delete {self._dir} to reset the cache."
+            )
+        for entry in entries:
+            try:
+                array, chunk_index, fname = entry["array"], int(entry["chunk_index"]), entry["file"]
+            except (TypeError, KeyError, ValueError) as exc:
+                raise ValueError(
+                    f"persist: cache manifest {path} has a malformed entry {entry!r} ({exc}); "
+                    f"this is corruption or tampering, not a stale cache -- delete {self._dir} "
+                    "to reset."
+                ) from exc
+            # The file must be a bare name resolved inside the cache dir. An absolute path, a
+            # ``..`` component, or any separator would escape via ``self._dir / fname`` in
+            # _revive; a manifest only ever stores basenames (see _register_persisted). Check
+            # separators explicitly -- ``Path('..').name`` is ``'..'``, and a Windows-style
+            # separator is an ordinary char to posix ``basename`` -- so neither alone suffices.
+            unsafe = (
+                not isinstance(fname, str)
+                or fname in ("", ".", "..")
+                or "/" in fname
+                or "\\" in fname
+            )
+            if unsafe:
+                raise ValueError(
+                    f"persist: cache manifest {path} entry file {fname!r} is not a bare filename "
+                    f"(possible path-traversal tampering); delete {self._dir} to reset."
+                )
+            self._persisted[(array, chunk_index)] = fname
         self.manifest_entries = len(self._persisted)
 
     def _write_manifest(self) -> None:  # call under the lock

--- a/tests/test_check_transform.py
+++ b/tests/test_check_transform.py
@@ -21,7 +21,19 @@ from insitubatch.types import ChunkRead, DecodedChunk
 FAST = ["--no-gil-probe"]
 
 TRANSFORMS_SRC = """
+from dataclasses import dataclass
+
 import numpy as np
+
+@dataclass
+class Coarsen:  # a dataclass reshaping transform: needs its module registered in sys.modules
+    factor: int = 2
+    def __call__(self, chunk):
+        chunk.data = chunk.data[:, :: self.factor, :: self.factor]
+        return chunk
+    def output_inner(self, geom):
+        lat, lon = geom.inner_shape
+        return (-(-lat // self.factor), -(-lon // self.factor)), geom.dtype
 
 class MeanLastAxis:
     def __call__(self, chunk):
@@ -84,6 +96,15 @@ def test_load_transform_instantiates_zero_arg_class(transforms_file):
     fn = load_transform(f"{transforms_file}:MeanLastAxis")
     assert not isinstance(fn, type) and callable(fn)  # an instance, not the class
     assert hasattr(fn, "output_inner")
+
+
+def test_load_transform_dataclass_from_file(transforms_file):
+    """A @dataclass transform loaded from a file needs its module registered in sys.modules
+    (dataclasses resolves annotations via sys.modules[__module__]); regression for that."""
+    fn = load_transform(f"{transforms_file}:Coarsen")
+    assert callable(fn) and hasattr(fn, "output_inner")
+    chunk = DecodedChunk(read=ChunkRead("v", 0), data=np.ones((2, 6, 8)), sample_offset=0)
+    assert fn(chunk).data.shape == (2, 3, 4)  # strided by factor=2
 
 
 def test_load_transform_from_module(transforms_file, monkeypatch):
@@ -155,6 +176,24 @@ def test_main_bad_transform_returns_2(store, capsys):
     rc = main([store, "--var", "t2m", "--transform", "nope_no_colon", *FAST])
     assert rc == 2
     assert "could not load --transform" in capsys.readouterr().err
+
+
+def test_main_store_auth_flags_pass_through(store, transforms_file, capsys):
+    """--skip-signature / --request-payer thread into the store open (so check_transform
+    reaches the same public / Requester-Pays stores the loader does)."""
+    rc = main(
+        [
+            store,
+            "--var",
+            "t2m",
+            "--transform",
+            f"{transforms_file}:vectorized_scale",
+            "--skip-signature",
+            "--request-payer",
+            *FAST,
+        ]
+    )
+    assert rc == 0
 
 
 def test_main_chunk_out_of_range(store, transforms_file, capsys):

--- a/tests/test_check_transform.py
+++ b/tests/test_check_transform.py
@@ -1,0 +1,195 @@
+"""The transform-development CLI: geometry report, output_inner validation, target
+resolution, and the GIL-release probe plumbing.
+
+The GIL probe is timing-based, so we assert its *plumbing* (fields + a verdict) directly and
+keep the main() integration tests on --no-gil-probe (deterministic exit codes), never a hard
+speedup threshold for the held case (flaky on shared CI / variable core counts).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import zarr
+
+from insitubatch import ensure_local_dir, open_geometries, store_from_url
+from insitubatch.check_transform import gil_probe, load_transform, main, read_chunk
+from insitubatch.types import ChunkRead, DecodedChunk
+
+# Geometry + output_inner validation are deterministic; skip the timing-based GIL probe so
+# the exit code reflects only the validation (the probe is covered by gil_probe() unit tests).
+FAST = ["--no-gil-probe"]
+
+TRANSFORMS_SRC = """
+import numpy as np
+
+class MeanLastAxis:
+    def __call__(self, chunk):
+        chunk.data = chunk.data.mean(axis=-1)
+        return chunk
+    def output_inner(self, geom):
+        return geom.inner_shape[:-1], geom.dtype
+
+class NeedsArgs:
+    def __init__(self, factor):
+        self.factor = factor
+    def __call__(self, chunk):
+        chunk.data = chunk.data * self.factor
+        return chunk
+
+def vectorized_scale(chunk):
+    chunk.data = chunk.data * 2.0
+    return chunk
+
+def reshape_no_declare(chunk):       # reshapes but no output_inner -> not cacheable
+    chunk.data = chunk.data.mean(axis=-1)
+    return chunk
+
+def wrong_declare(chunk):
+    chunk.data = chunk.data.mean(axis=-1)
+    return chunk
+wrong_declare.output_inner = lambda geom: ((999,), geom.dtype)  # lies about the shape
+
+not_callable = 42
+"""
+
+
+@pytest.fixture
+def store(tmp_path):
+    url = f"file://{tmp_path}/syn.zarr"
+    ensure_local_dir(url)
+    g = zarr.open_group(store=store_from_url(url, read_only=False), mode="w")
+    arr = g.create_array("t2m", shape=(24, 6, 8), chunks=(8, 6, 8), dtype="f4")
+    arr[:] = np.random.default_rng(0).standard_normal((24, 6, 8)).astype("f4")
+    return url
+
+
+@pytest.fixture
+def transforms_file(tmp_path):
+    p = tmp_path / "xf.py"
+    p.write_text(TRANSFORMS_SRC)
+    return p
+
+
+# -- target resolution ------------------------------------------------------
+
+
+def test_load_transform_from_file(transforms_file):
+    fn = load_transform(f"{transforms_file}:vectorized_scale")
+    chunk = DecodedChunk(read=ChunkRead("v", 0), data=np.ones((2, 3)), sample_offset=0)
+    assert np.array_equal(fn(chunk).data, np.full((2, 3), 2.0))
+
+
+def test_load_transform_instantiates_zero_arg_class(transforms_file):
+    fn = load_transform(f"{transforms_file}:MeanLastAxis")
+    assert not isinstance(fn, type) and callable(fn)  # an instance, not the class
+    assert hasattr(fn, "output_inner")
+
+
+def test_load_transform_from_module(transforms_file, monkeypatch):
+    monkeypatch.syspath_prepend(str(transforms_file.parent))
+    fn = load_transform(f"{transforms_file.stem}:vectorized_scale")  # dotted module:attr
+    assert callable(fn)
+
+
+def test_load_transform_class_needing_args_is_a_clear_error(transforms_file):
+    with pytest.raises(TypeError, match="constructor needs arguments|configured instance"):
+        load_transform(f"{transforms_file}:NeedsArgs")
+
+
+@pytest.mark.parametrize(
+    "target, exc",
+    [
+        ("no_colon_here", ValueError),
+        ("./missing_file.py:fn", FileNotFoundError),
+        ("os:does_not_exist", AttributeError),
+    ],
+)
+def test_load_transform_bad_targets(target, exc):
+    with pytest.raises(exc):
+        load_transform(target)
+
+
+def test_load_transform_non_callable(transforms_file):
+    with pytest.raises(TypeError, match="not callable"):
+        load_transform(f"{transforms_file}:not_callable")
+
+
+# -- one-chunk read ---------------------------------------------------------
+
+
+def test_read_chunk_matches_source(store):
+    geom = open_geometries(store, variables=["t2m"])["t2m"]
+    chunk = read_chunk(store, "t2m", 1, geom)
+    assert chunk.data.shape == (8, 6, 8) and chunk.sample_offset == 8
+
+
+# -- main() integration: exit codes + report --------------------------------
+
+
+def test_main_passes_for_correct_reshaping_transform(store, transforms_file, capsys):
+    rc = main([store, "--var", "t2m", "--transform", f"{transforms_file}:MeanLastAxis", *FAST])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "8/chunk" in out and "(6, 8)" in out  # geometry line
+    assert "-> (6,)" in out and "[OK]" in out  # declared output validated
+
+
+def test_main_fails_on_wrong_output_inner(store, transforms_file, capsys):
+    rc = main([store, "--var", "t2m", "--transform", f"{transforms_file}:wrong_declare", *FAST])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "MISMATCH" in out and "_persist would raise" in out
+
+
+def test_main_fails_on_undeclared_reshape(store, transforms_file, capsys):
+    rc = main(
+        [store, "--var", "t2m", "--transform", f"{transforms_file}:reshape_no_declare", *FAST]
+    )
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "does not declare output_inner" in out
+
+
+def test_main_bad_transform_returns_2(store, capsys):
+    rc = main([store, "--var", "t2m", "--transform", "nope_no_colon", *FAST])
+    assert rc == 2
+    assert "could not load --transform" in capsys.readouterr().err
+
+
+def test_main_chunk_out_of_range(store, transforms_file, capsys):
+    rc = main(
+        [
+            store,
+            "--var",
+            "t2m",
+            "--transform",
+            f"{transforms_file}:vectorized_scale",
+            "--chunk",
+            "99",
+            *FAST,
+        ]
+    )
+    assert rc == 2
+    assert "out of range" in capsys.readouterr().err
+
+
+# -- GIL probe plumbing -----------------------------------------------------
+
+
+def test_gil_probe_reports_fields_and_classifies_vectorized(store, transforms_file):
+    geom = open_geometries(store, variables=["t2m"])["t2m"]
+    base = read_chunk(store, "t2m", 0, geom)
+    fn = load_transform(f"{transforms_file}:vectorized_scale")
+    out = gil_probe(fn, base, threads=2, min_seconds=0.02, repeats=1)
+    assert {"iters", "serial_s", "parallel_s", "speedup", "per_call_ms", "mb_s"} <= out.keys()
+    assert out["iters"] >= 1 and out["serial_s"] > 0 and out["speedup"] > 0
+
+
+def test_gil_probe_single_thread_speedup_about_one(store, transforms_file):
+    # threads=1: serial and parallel are the same work -> speedup ~1 (no scaling claimed).
+    geom = open_geometries(store, variables=["t2m"])["t2m"]
+    base = read_chunk(store, "t2m", 0, geom)
+    fn = load_transform(f"{transforms_file}:vectorized_scale")
+    out = gil_probe(fn, base, threads=1, min_seconds=0.02, repeats=1)
+    assert out["speedup"] == pytest.approx(1.0, abs=0.6)

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -50,6 +50,9 @@ def test_transforms_example_runs_both_stages(tmp_path) -> None:
     assert summary["windspeed_mean"] > 0.0
     assert summary["windspeed_nonneg"]
     assert summary["samples"] > 0
+    # the reshaping chunk_transform (Coarsen factor=2) halved the spatial grid
+    src_lat, src_lon = summary["source_inner"]
+    assert summary["sample_shape"] == (src_lat // 2, src_lon // 2)
 
 
 def test_fit_scaler_example_partial_fit(tmp_path) -> None:

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import itertools
+import json
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
@@ -655,6 +656,53 @@ def test_pool_persist_without_cloudpickle_warns_and_falls_back(
     same = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[scale])
     assert same.pin_if_ready("single_inner", 0)  # source hash matches -> hit
     same.close()
+
+
+def _persist_one(tiled_store, backing):
+    """Write a one-entry persistent cache and return (geoms, manifest_path)."""
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    pool = ChunkPool(geoms, backing_dir=backing, persist=True)
+    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    pool.close()
+    return geoms, backing / "insitu_cache.json"
+
+
+@pytest.mark.parametrize("bad_file", ["/etc/passwd", "../../etc/passwd", "sub/dir.npy", "..", ""])
+def test_pool_manifest_rejects_non_basename_file(tiled_store, tmp_path, bad_file):
+    """A tampered manifest whose entry ``file`` is not a bare basename is rejected fail-fast
+    (not silently skipped): ``_revive`` would otherwise ``open_memmap`` a path escaping the
+    cache dir (``self._dir / fname``). Absolute paths and ``..`` both escape."""
+    backing = tmp_path / "cache"
+    geoms, mpath = _persist_one(tiled_store, backing)
+    doc = json.loads(mpath.read_text())
+    doc["entries"][0]["file"] = bad_file
+    mpath.write_text(json.dumps(doc))
+    with pytest.raises(ValueError, match="bare filename|path-traversal"):
+        ChunkPool(geoms, backing_dir=backing, persist=True)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda d: d["entries"][0].pop("file"),  # missing field
+        lambda d: d["entries"][0].update(chunk_index="NaN"),  # non-int index
+        lambda d: d.update(entries="not-a-list"),  # wrong container type
+        lambda d: d.update(entries=["a-bare-string"]),  # entry not a mapping
+    ],
+)
+def test_pool_manifest_rejects_malformed_entry(tiled_store, tmp_path, mutate):
+    """A manifest that clears the format/fingerprint gates but is structurally corrupt raises
+    -- corruption/tampering is not an expected stale cache (those degrade to a cold start)."""
+    backing = tmp_path / "cache"
+    geoms, mpath = _persist_one(tiled_store, backing)
+    doc = json.loads(mpath.read_text())
+    mutate(doc)
+    mpath.write_text(json.dumps(doc))
+    with pytest.raises(ValueError, match="malformed entry|corrupt|bare filename"):
+        ChunkPool(geoms, backing_dir=backing, persist=True)
 
 
 def test_pool_spill_unlinks_without_persist(tiled_store, tmp_path):


### PR DESCRIPTION
Stacked on #8 (depends on `pool.output_geometry`). Base will retarget to `main` once #8 merges.

## What

A CLI for developing a `chunk_transform` against your real dataset, before training — it gives feedback on the two contracts that otherwise only fail mid-training:

1. **Vectorized / GIL-releasing** — a pure-Python per-element transform silently serializes the decode thread pool and kills IO overlap.
2. **Correct `output_inner`** — a reshaping transform must declare an output geometry that *agrees* with what `__call__` produces (the cross-run cache sizes its slot from it; a mismatch raises in `ChunkPool._persist`).

```bash
python -m insitubatch.check_transform s3://bucket/era5.zarr --var t2m --transform my_pkg:Regrid
insitubatch-check-transform ./era5.zarr --var t2m --transform ./prep.py:scale   # installed entry point
```

## What it reports (against one real chunk)

- **Chunk geometry** — samples/chunk, inner shape, stored tiles/chunk, dtype, and the **decoded MB** the cache will hold.
- **Transform output** — `input shape/dtype -> output shape/dtype`, flags *reshaped* / *recast*, warns on new NaN/inf.
- **Cacheability** — validates a declared `output_inner` against the *actual* output (catches the exact `_persist` mismatch, or an undeclared reshape) by reusing `pool.output_geometry`.
- **GIL-release probe** — a thread-scaling test (`speedup ~threads` ⇒ releases the GIL; `~1` ⇒ holds it). Memory is bounded by thread count (each worker loops on its own pristine buffer), so even a sub-millisecond transform gets a full timing window. `--no-gil-probe` runs geometry + cacheability only (fast, deterministic). Free-threaded builds are detected and the GIL gate is skipped with a note.

Non-zero exit on any failed check, so it can gate a pre-commit hook.

## Design notes

- **Ships in the package**, not `bench/` — `bench/` isn't installed for users (`pythonpath=["."]` is test-only; the wheel ships `src/insitubatch/`). A transform-dev tool must ship to be useful. Adds a `[project.scripts]` console-script entry point.
- Target resolution handles `module.path:attr` and `./file.py:attr`; a zero-arg transform **class** is instantiated, and a ctor needing args gets a clear "expose a configured instance" error.

## Tests / gates

`tests/test_check_transform.py` — target resolution (file/module/class/bad), one-chunk read, the three validation verdicts via `main()` exit codes (on `--no-gil-probe` for determinism), and `gil_probe()` plumbing (no flaky speedup-threshold assertion).

- `uv run pytest -q` → **115 passed, 5 skipped**
- `ruff check` + `ruff format --check` + `mypy src bench examples` → clean

Docs: a "Developing a transform — check_transform" subsection in architecture.md + `output_inner` on the Regrid example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)