### PR TITLE
feat: incremental crash-recovery cache log + opt-in stale-cache GC

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -208,8 +208,9 @@ Caveats: (1) **mmap isn't free for read-once** — scattering into mmap is NVMe 
 traffic even when never reused, so default the pool to **heap** for streaming and
 use mmap only to spill a working set past RAM or for cross-epoch reuse. (2)
 **cross-*run* persistence is now a flag** (`persist=True`, M-C2 ✅) — intra-run/
-cross-epoch reuse is intrinsic (just don't evict); surviving process exit adds a
-manifest of completed slots + a chunk-transform fingerprint, revived on reopen.
+cross-epoch reuse is intrinsic (just don't evict); surviving process exit adds an
+append-only log of completed slots (written incrementally, so a crash mid-run still
+recovers) + a chunk-transform fingerprint, revived on reopen.
 
 Internals are **validated** (`bench/spike_v2_decode.py`, zarr 3.2): key via
 `chunk_key_encoding.encode_chunk_key`, bytes via `store.get`, decode via
@@ -227,8 +228,8 @@ Internals are **validated** (`bench/spike_v2_decode.py`, zarr 3.2): key via
   still-resident chunk). The pool is dataset-owned (persists across epochs); B1's
   `resident_cap` admission unified into the budget (consumer `unpin` replaces
   `evict`, eviction is unpinned-LRU). **M-C2 ✅** later added cross-*run* persistence
-  (`persist=True`): a manifest of completed slots + a chunk-transform fingerprint
-  survive `close` and revive on reopen.
+  (`persist=True`): an append-only log of completed slots + a chunk-transform fingerprint
+  survive `close` (and a crash), revived on reopen.
 
 Demonstrate: on `era5_fatspatial`, plot throughput **and** peak heap vs concurrency
 — v1 (concurrency = `block_chunks`) rises in both; V2 (`block_chunks` fixed small,
@@ -502,26 +503,32 @@ Engine track (make it real for models — see [docs/architecture.md](docs/archit
   separate intercept, it became "don't evict." Deferred: an L1/L2 (RAM+NVMe) tier and
   cached cross-variable derived variables (cross-*run* persistence is M-C2).
 - **M-C2 — cross-run persistent cache ✅.** `persist=True` (with `cache_dir`) keeps the
-  mmap'd `.npy` slots past `close` and writes a JSON **manifest** of completed entries
-  (`(array, chunk_index) → file`); a new pool over the same dir **revives** them as ready
-  hits on first touch, so decode-once amortizes across *runs* — a relaunched job, a
-  hyperparameter sweep, or several processes on one box read decoded chunks straight from
-  NVMe (no S3, no decode). Invalidation has two automatic guards: a **chunk-transform
-  fingerprint** in the manifest header (explicit `transform.cache_key` → optional
-  cloudpickle hash of closures+globals → best-effort source hash that warns) and a
-  per-entry **shape/dtype** check on revive; either mismatch is a *miss* (re-fetch +
-  overwrite), never an error. Crash-safe (only completed chunks are listed; atomic write).
-  Observability: per-epoch `cache_hits`/`cache_misses` + one WARN when persistence was
-  asked for but served nothing. **Deliberately not in the key:** the store URL —
-  Icechunk/Arraylake session stores have no round-trippable URL, so the `cache_dir` path
-  *is* the dataset identity (bury a version in it); content/etag drift is the user's call.
-  The key's `chunk_index` is the *global* zarr index, so subsets/splits share entries.
-  A **reshaping** `chunk_transform` (`Regrid` / dtype recast) is supported on every tier
-  including persistent mmap: it declares `output_inner -> (inner_shape, dtype)`, the cache
-  slot is sized at the output shape, and tiles assemble in a transient source-shaped scratch
-  buffer (the sample axis is invariant). *Still deferred:* a raw-decoded tier keyed by source
-  only, orphaned-file GC across version bumps, and the kvikio/GDS NVMe→GPU feed off the
-  persistent tier.
+  mmap'd `.npy` slots past `close` and records completed entries (`(array, chunk_index) →
+  file`) in an **append-only `insitu_cache.jsonl` log**, written *incrementally as each
+  chunk lands* — so a killed process (spot preempt / OOM / SIGTERM) leaves a usable cache
+  and the next run re-decodes only what hadn't finished (**crash recovery**, backlog #4).
+  A new pool over the same dir **revives** entries as ready hits on first touch, so
+  decode-once amortizes across *runs* — a relaunched job, a hyperparameter sweep, or
+  several processes on one box read decoded chunks straight from NVMe (no S3, no decode).
+  Invalidation: a **chunk-transform fingerprint** in the log header (explicit
+  `transform.cache_key` → optional cloudpickle hash of closures+globals → best-effort
+  source hash that warns). A fingerprint/format mismatch is a **stale** cache, which
+  **raises by default** (almost never intended); `reset_stale_cache=True` opts into GC'ing
+  the stale files + rebuilding (backlog #3). A per-entry **shape/dtype** check on revive is
+  a *miss* (re-fetch + overwrite), never an error; corruption/tampering (unreadable header,
+  malformed interior entry, non-bare filename) always raises. The log is self-deduplicating
+  and bounded to one line per cached chunk (the `_recorded` gate) — no compaction. Durability
+  is `flush` (process-death), not `fsync` (power-loss out of scope). Observability: per-epoch
+  `cache_hits`/`cache_misses` + one WARN when persistence was asked for but served nothing.
+  **Deliberately not in the key:** the store URL — Icechunk/Arraylake session stores have no
+  round-trippable URL, so the `cache_dir` path *is* the dataset identity (bury a version in
+  it); content/etag drift is the user's call. The key's `chunk_index` is the *global* zarr
+  index, so subsets/splits share entries. A **reshaping** `chunk_transform` (`Regrid` / dtype
+  recast) is supported on every tier including persistent mmap: it declares `output_inner ->
+  (inner_shape, dtype)`, the cache slot is sized at the output shape, and tiles assemble in a
+  transient source-shaped scratch buffer (the sample axis is invariant). *Still deferred:* a
+  raw-decoded tier keyed by source only, and the kvikio/GDS NVMe→GPU feed off the persistent
+  tier.
   Scope: a read-through cache keyed by fingerprint; a shared/networked cache tier and
   the L1/L2 split above are later.
 - **M-W — windowed / multi-offset sampling (sample geometry v2).** The forecasting

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -531,6 +531,19 @@ Engine track (make it real for models — see [docs/architecture.md](docs/archit
   tier.
   Scope: a read-through cache keyed by fingerprint; a shared/networked cache tier and
   the L1/L2 split above are later.
+  - **TODO — per-variable transform fingerprint (scope invalidation per array).** Today
+    `chunk_transforms` is one list applied to every variable (each transform self-gates by
+    name and no-ops on the rest), and the cache fingerprint hashes the **whole list once** →
+    a single `pipeline_hash` on every array's entries. So editing a transform that only
+    affects `t2m` invalidates the *whole* cache (`u10`/`v10` too, whose chunks are
+    byte-identical) — with the raise-on-stale default the user must `reset_stale_cache` and
+    re-decode everything. Fix: let transforms be assigned per variable (or derive, per array,
+    the subset of transforms that actually touch it) and compute the fingerprint **per array**,
+    so a temperature-only edit invalidates only the temperature arrays — and each array runs
+    only through its own transforms (drops the wasted no-op passes). Design question: how a
+    transform declares which variables it applies to (explicit mapping vs the current
+    name-gating convention). Documented as a limitation in docs/architecture.md (cache
+    invalidation section).
 - **M-W — windowed / multi-offset sampling (sample geometry v2).** The forecasting
   unlock, and a prerequisite for the canonical WeatherBench examples and the M4
   "around their models" play. Today a batch draws **one shared time index for all

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -535,6 +535,20 @@ and referenced globals, so a changed closed-over constant invalidates), or a
 best-effort source hash (catches an edited body but not a changed closure/global — it
 warns once so the weaker guarantee is visible).
 
+> **Limitation — the fingerprint is per-*pipeline*, not per-variable (invalidation is
+> all-or-nothing).** `chunk_transforms` is a single ordered list applied to **every**
+> variable; a transform that only concerns one field self-gates by name and no-ops on the
+> rest (e.g. `kelvin_to_celsius` acts on `t2m`, returns `u10`/`v10` untouched). But the
+> fingerprint hashes the **whole list once** and stamps that single `pipeline_hash` on
+> every array's cache entries. So editing a transform that logically affects only `t2m`
+> marks the **entire** cache stale — `u10`/`v10` included — even though their cached chunks
+> are byte-identical (the edited transform no-oped on them); with the default you must then
+> `reset_stale_cache=True` and re-decode everything. The engine also runs every transform
+> on every chunk (the no-op passes are wasted work, though cheap for a name-gated early
+> return). A per-variable transform assignment + per-array fingerprint would scope
+> invalidation (and application) to just the affected arrays — see the roadmap in
+> [DESIGN.md](https://github.com/emfdavid/insitubatch/blob/main/DESIGN.md).
+
 **Observability.** `dataset.cache_hits` / `cache_misses` give per-epoch counts; a plain
 miss is silent, but `persist=True` serving **zero** hits while the cache was
 consulted-and-rejected emits one WARNING per epoch — a cache you configured but that

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -501,24 +501,33 @@ materialized batches with frozen composition. Pick by regime, not by a missing f
 ### Cross-run persistence
 
 `persist=True` (with a `cache_dir`) turns the mmap tier into a cache that **survives
-process exit**: ready slot files are kept on `close`, a JSON manifest records the
-completed entries, and a fresh dataset over the same `cache_dir` revives them as ready
-hits on first touch — the fetch driver's existing hit path skips fetch *and* decode
-*and* transform, so a warm run re-decodes **zero** chunks. Without `persist`,
-`cache_dir` is ephemeral spill (files unlinked on close).
+process exit**: ready slot files are kept on `close`, an append-only
+`insitu_cache.jsonl` log records each completed entry *the moment it lands*, and a fresh
+dataset over the same `cache_dir` revives them as ready hits on first touch — the fetch
+driver's existing hit path skips fetch *and* decode *and* transform, so a warm run
+re-decodes **zero** chunks. Because the log is written incrementally (not at `close`), a
+killed process — spot preemption, OOM, SIGTERM — still leaves a usable cache: the next
+run re-decodes only the chunks that hadn't finished. Without `persist`, `cache_dir` is
+ephemeral spill (files unlinked on close).
 
 ```python
 ds = InSituDataset(store, manifest, cache_dir="/mnt/nvme/era5/v3",
                    persist=True, cache_budget_bytes=...)
 ```
 
-Two automatic guards keep a reopened cache honest, and **either mismatch is a miss
-(re-fetch + overwrite), never an error** — the cache is a transparent optimization:
+Two guards keep a reopened cache honest:
 
-1. a **chunk-transform fingerprint** in the manifest — change your `chunk_transforms`
-   and the whole cache is discarded (cold start), never served stale; and
+1. a **chunk-transform fingerprint** in the log header — change your `chunk_transforms`
+   (or bump the log format) and the cache is **stale**. A stale cache is almost never
+   what you intended, so by default it **raises** at construction rather than silently
+   rebuilding or serving stale data. Pass `reset_stale_cache=True` to opt into deleting
+   the old files and rebuilding cold (or delete the `cache_dir` yourself); and
 2. a per-entry **shape/dtype check** on revive — a chunk whose stored geometry no
-   longer matches the current array is ignored.
+   longer matches the current array is a **miss** (re-fetch + overwrite), never an error.
+
+(Corruption or tampering — an unreadable header, a malformed interior entry, or a `file`
+that isn't a bare basename — always raises, regardless of `reset_stale_cache`; that flag
+governs an *expected* stale cache, not a damaged one.)
 
 The fingerprint resolves each transform by, in order: an explicit `transform.cache_key`
 (authoritative), a `cloudpickle` hash (the optional `cache` extra — captures closures
@@ -538,8 +547,11 @@ isn't working is loud, not silent.
   fuller run **share** entries: chunk 5 is always the same `.npy`.
 - A hit returns the **prepped** chunk (post-`chunk_transform`), no copy — `gather` views
   the slot in place.
-- **Crash-safe:** the manifest lists only *completed* chunks (written atomically on
-  `close`), so a `.npy` left half-written by a crash is ignored on reopen.
+- **Crash-safe:** each *completed* chunk is appended to the log as it finishes (flushed to
+  the OS page cache, which survives process death), so a killed run keeps everything it
+  decoded. The log is self-deduplicating (a re-completed chunk across epochs/runs is not
+  re-appended) and bounded to one line per cached chunk — no compaction needed. A `.npy`
+  left half-written by a crash was never logged, so it's simply overwritten on re-decode.
 
 **What you must ensure (the guarantee boundary):**
 
@@ -550,9 +562,11 @@ isn't working is loud, not silent.
   that you bump when the **source data** changes — content/etag drift is deliberately
   not detected.
 - **`chunk_transforms` must be deterministic** (they are baked into the cached chunk).
-  If you rely on auto-invalidation when you edit one, install the `cache` extra
-  (cloudpickle) or set an explicit `transform.cache_key`; the source-only fallback can
-  miss closure/global changes.
+  When you edit one, its fingerprint changes and the cache goes stale — construction then
+  **raises** until you pass `reset_stale_cache=True` (wipe + rebuild) or delete the dir.
+  For the fingerprint to *notice* a change, install the `cache` extra (cloudpickle) or set
+  an explicit `transform.cache_key`; the source-only fallback can miss closure/global
+  changes (and would then wrongly serve the old cache as a hit).
 
 **Reshaping transforms.** A **reshaping** `chunk_transform` (e.g. `Regrid`, or a dtype
 recast) is a first-class cacheable stage on every backing including the persistent mmap
@@ -564,8 +578,8 @@ from the source, so a chunk_transform can never move it). Shape/dtype-preserving
 omit `output_inner` and keep the zero-copy fast path (the slot is buffer and cache in one).
 
 **Limitations (deferred).** A raw-decoded tier (keyed by source only, for transform
-experimentation), orphaned-file GC across version bumps, and the kvikio/GDS NVMe→GPU feed
-off the persistent `.npy` tier remain on the roadmap
+experimentation) and the kvikio/GDS NVMe→GPU feed off the persistent `.npy` tier remain
+on the roadmap
 ([DESIGN.md](https://github.com/emfdavid/insitubatch/blob/main/DESIGN.md)).
 
 ## Earth2Studio integration

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -19,15 +19,17 @@ Buffer and cache differ only in budget + backing, so they are the same code:
   as reclaimable page cache rather than anon heap.
 
 With ``persist=True`` (requires a ``backing_dir``) the mmap tier becomes a **cross-run
-cache**: slot files survive ``close`` (only budget eviction removes them), a JSON
-manifest records the completed entries, and a new pool over the same dir revives them
-as ready hits -- no fetch/decode. The ``backing_dir`` path *is* the dataset identity
-(bury a version in it; the store URL is not in the key). Two automatic guards: the
-manifest carries a **chunk_transform fingerprint** (changed transforms -> whole cache
-discarded) and revive does a **shape/dtype** check per entry; either mismatch is a miss
-(recompute + overwrite), never an error. The fingerprint uses cloudpickle when present
-(``--extra cache``; captures closures/globals), else a best-effort source hash (warned),
-and always honors an explicit ``transform.cache_key``. Without ``persist`` a
+cache**: slot files survive ``close`` (only budget eviction removes them), an append-only
+``insitu_cache.jsonl`` log records each completed entry *as it lands* (so a killed process
+still leaves a usable cache -- crash recovery, no re-decode of what finished), and a new
+pool over the same dir revives them as ready hits -- no fetch/decode. The ``backing_dir``
+path *is* the dataset identity (bury a version in it; the store URL is not in the key).
+The log header carries a **chunk_transform fingerprint**: a changed transform (or a format
+bump) is a **stale cache**, which by default *raises* (``reset_stale_cache=True`` deletes
+and rebuilds it). Revive additionally does a **shape/dtype** check per entry; that mismatch
+is a miss (recompute + overwrite), never an error. The fingerprint uses cloudpickle when
+present (``--extra cache``; captures closures/globals), else a best-effort source hash
+(warned), and always honors an explicit ``transform.cache_key``. Without ``persist`` a
 ``backing_dir`` is ephemeral spill (unlinked on close).
 
 See [docs/architecture.md] for where this sits in the pipeline.
@@ -66,6 +68,7 @@ from collections import OrderedDict
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
+from typing import TextIO
 
 import numpy as np
 
@@ -192,8 +195,8 @@ class ChunkPool:
     the *assembled* array, so a hit reflects decode + transform.
     """
 
-    _MANIFEST_NAME = "insitu_cache.json"
-    _MANIFEST_FORMAT = 1
+    _MANIFEST_NAME = "insitu_cache.jsonl"
+    _MANIFEST_FORMAT = 2
 
     def __init__(
         self,
@@ -203,6 +206,7 @@ class ChunkPool:
         backing_dir: str | Path | None = None,
         budget_bytes: int | None = None,
         persist: bool = False,
+        reset_stale_cache: bool = False,
     ) -> None:
         self._geom = geometries  # label -> geometry (a label is one (array, offset) view)
         # Slots are keyed by the underlying array *path*, not the variable label, so two
@@ -248,10 +252,21 @@ class ChunkPool:
         # path is the dataset+pipeline identity (the user buries a version in it); we only
         # auto-check shape/dtype on revive (a mismatch is a miss, not an error).
         self._persistent = persist
+        # When the on-disk cache is *stale* (its chunk_transform fingerprint or the log format
+        # differs from this run's), the default is to fail fast -- a stale cache is almost never
+        # what the user intended. Setting this opts into deleting the stale files and rebuilding.
+        self._reset_stale_cache = reset_stale_cache
         if persist and self._dir is None:
             raise ValueError("persist=True requires cache_dir (a backing_dir) to keep files in")
         # key -> on-disk filename for completed entries known to survive a run.
         self._persisted: dict[tuple[str, int], str] = {}
+        # Keys already written to the on-disk log this pool's lifetime (loaded entries + entries
+        # appended on completion). Gates the append so re-completing a chunk across epochs/runs
+        # never duplicates a line -- the log is self-deduplicating and bounded to O(#chunks).
+        self._recorded: set[tuple[str, int]] = set()
+        # The append-only manifest handle (persist mode), held open for the pool's lifetime so a
+        # completion is one write()+flush() -- no per-chunk open(). None in heap/spill mode.
+        self._log: TextIO | None = None
         # Fingerprint of the chunk_transform pipeline (only chunk_transforms are baked into
         # cached chunks; batch_transforms run post-cache). A run whose fingerprint differs
         # from the manifest's discards the cache (changed transforms -> stale). batch
@@ -269,7 +284,8 @@ class ChunkPool:
                     "(source only; closure/global changes may not invalidate). Install "
                     "`insitubatch[cache]` or set a `cache_key` attribute for a stronger guarantee."
                 )
-            self._load_manifest()
+            self._load_log()
+            self._open_log()
         self._budget = budget_bytes  # None => unbounded (never self-evicts)
         self._bytes = 0
         # OrderedDict in recency order (LRU front -> MRU back). Eviction targets only
@@ -503,11 +519,10 @@ class ChunkPool:
         self._pinned.pop(key, None)  # no stale refcount if dropping a (rare) pinned partial
         self._bytes -= slot.nbytes
         # In persist mode a *ready* eviction is a cache demotion, not a deletion: keep the
-        # .npy on disk and register it so a later epoch/run can revive it. A not-ready
-        # partial is garbage either way -> unlink it.
+        # .npy on disk so a later epoch/run can revive it. It was already recorded in the log at
+        # completion (see scatter -> _record_completed), so eviction touches only the backing.
+        # A not-ready partial is garbage either way -> unlink it.
         keep = self._persistent and slot.ready
-        if keep:
-            self._register_persisted(key, slot)
         self._free(slot, keep_file=keep)
 
     def _alloc(
@@ -549,6 +564,10 @@ class ChunkPool:
             slot.data = self._persist(slot.data, prepped)
             slot.scratch = None  # assembly done -- drop the transient source-shaped buffer
             slot.ready = True
+            # Record the completed entry *now* (not at eviction/close) so a crash still leaves a
+            # usable cache. Appending here, under the lock, serializes writes across decode
+            # threads and orders them after the slot's data is durable in its .npy.
+            self._record_completed(key, slot)
             self._cv.notify_all()
 
     def _persist(self, current: np.ndarray, prepped: np.ndarray) -> np.ndarray:
@@ -678,111 +697,160 @@ class ChunkPool:
                 with contextlib.suppress(FileNotFoundError):
                     os.unlink(fname)
 
-    def _register_persisted(self, key: tuple[str, int], slot: _Slot) -> None:  # under the lock
-        """Record a ready mmap slot's file as a surviving cache entry (persist mode)."""
+    @staticmethod
+    def _is_bare_filename(fname: object) -> bool:
+        """True iff ``fname`` is a bare basename safe to resolve inside the cache dir.
+
+        An absolute path, a ``..`` component, or any separator would escape via
+        ``self._dir / fname`` in :meth:`_revive`. ``Path('..').name`` is ``'..'`` and a
+        Windows-style separator is an ordinary char to posix ``basename``, so check the
+        separators explicitly rather than trusting ``Path.name``.
+        """
+        return (
+            isinstance(fname, str)
+            and fname not in ("", ".", "..")
+            and "/" not in fname
+            and "\\" not in fname
+        )
+
+    def _record_completed(self, key: tuple[str, int], slot: _Slot) -> None:  # under the lock
+        """Register a freshly completed slot's ``.npy`` as a surviving cache entry and append
+        it to the log -- exactly once per key.
+
+        Recording at *completion* (not at eviction/close) is what makes the cache crash-safe: a
+        killed process still leaves every finished chunk in the log. Idempotent per key -- a
+        re-completion in a later epoch (after eviction + refetch) refreshes ``_persisted`` but
+        the ``_recorded`` gate skips the duplicate log line, so the log stays bounded.
+        """
+        if not self._persistent:
+            return
         fname = getattr(slot.data, "filename", None)
-        if fname is not None:
-            self._persisted[key] = Path(fname).name
+        if fname is None:
+            return  # heap backing -- nothing on disk to record
+        fname = Path(fname).name
+        self._persisted[key] = fname
+        if self._log is not None and key not in self._recorded:
+            array, chunk_index = key
+            self._append_entry(array, chunk_index, fname)
+            self._recorded.add(key)
 
-    def _load_manifest(self) -> None:
-        """Populate the persisted-entry registry from a prior run's manifest, if any.
+    def _append_entry(self, array: str, chunk_index: int, fname: str) -> None:  # under the lock
+        """Append one completed-entry line to the open log and flush it to the page cache.
 
-        No manifest is a cold start (silent -- the expected first run). The *expected* stale
-        states degrade to a cold start with a WARN: an unreadable manifest, a format-version
-        bump, and a chunk_transform fingerprint change. Per-entry data validation (file
-        existence, shape, dtype) is deferred to :meth:`_revive`, which reads it from the
-        ``.npy`` header -- so a stale/missing file shows up as a per-epoch revive failure.
+        ``flush`` (not ``fsync``) makes the entry durable against *process death* -- the target
+        failure mode (spot preemption / OOM / SIGTERM); the kernel flushes the page cache. Power
+        loss (which would need ``fsync`` per chunk) is out of scope.
+        """
+        assert self._log is not None
+        self._log.write(json.dumps({"array": array, "chunk_index": chunk_index, "file": fname}))
+        self._log.write("\n")
+        self._log.flush()
 
-        A manifest that clears those gates but is then *structurally* corrupt -- an entry with
-        a missing field, a non-integer chunk index, or a ``file`` that is not a bare filename
-        (an absolute or ``..`` path would let :meth:`_revive` ``open_memmap`` escape the cache
-        dir) -- is **not** an expected stale cache; it is corruption or tampering. We fail fast
-        and raise rather than silently start cold (which would hide the problem and re-decode
-        everything). Delete the cache dir to reset.
+    def _open_log(self) -> None:
+        """Open the append-only manifest for the pool's lifetime; write the header on a cold
+        start (or after a stale-cache reset removed the file). A warm reopen appends after the
+        existing entries -- the ``_recorded`` gate (populated by :meth:`_load_log`) keeps those
+        from being re-appended."""
+        assert self._dir is not None
+        path = self._dir / self._MANIFEST_NAME
+        fresh = not path.exists()
+        self._log = path.open("a")
+        if fresh:
+            header = {"format_version": self._MANIFEST_FORMAT, "pipeline_hash": self._pipeline_fp}
+            self._log.write(json.dumps(header))
+            self._log.write("\n")
+            self._log.flush()
+
+    def _load_log(self) -> None:
+        """Populate the persisted-entry registry from a prior run's append-only log, if any.
+
+        No log is a cold start (silent -- the expected first run). A log whose header ``format``
+        or ``pipeline_hash`` differs from this run is a **stale** cache: by default that *raises*
+        (a stale cache is almost never what the user intended), or -- with ``reset_stale_cache``
+        -- it deletes the listed files + the log and rebuilds (see :meth:`_reset_stale`).
+
+        Corruption always raises, regardless of the flag: an unreadable header, a malformed
+        *interior* entry, or a ``file`` that is not a bare filename (an absolute or ``..`` path
+        would let :meth:`_revive` ``open_memmap`` escape the cache dir -- path-traversal
+        tampering). A torn *final* line (a crash mid-append) is expected and dropped silently.
         """
         assert self._dir is not None
         path = self._dir / self._MANIFEST_NAME
         if not path.exists():
             return  # cold start: no prior cache (the expected first run)
+        lines = path.read_text().splitlines()
+        if not lines:
+            return  # header not yet flushed (a crash before the first write) -- treat as cold
         try:
-            doc = json.loads(path.read_text())
-        except (OSError, json.JSONDecodeError) as exc:
-            logger.warning("persist: cache manifest %s unreadable (%s); starting cold", path, exc)
-            return
-        if doc.get("format_version") != self._MANIFEST_FORMAT:
-            logger.warning(
-                "persist: cache manifest %s format %r != %d; starting cold",
-                path,
-                doc.get("format_version"),
-                self._MANIFEST_FORMAT,
-            )
-            return
-        if doc.get("pipeline_hash") != self._pipeline_fp:
-            logger.warning(
-                "persist: chunk_transform fingerprint changed since %s was written; "
-                "ignoring the stale cache (starting cold)",
-                path,
-            )
-            return
-        entries = doc.get("entries", [])
-        if not isinstance(entries, list):
+            header = json.loads(lines[0])
+            fmt, fp = header["format_version"], header["pipeline_hash"]
+        except (json.JSONDecodeError, TypeError, KeyError) as exc:
             raise ValueError(
-                f"persist: cache manifest {path} is corrupt ('entries' is not a list); "
-                f"delete {self._dir} to reset the cache."
-            )
-        for entry in entries:
+                f"persist: cache log {path} has an unreadable header ({exc}); this is corruption "
+                f"or tampering, not a stale cache -- delete {self._dir} to reset."
+            ) from exc
+        entry_lines = lines[1:]
+        if fmt != self._MANIFEST_FORMAT or fp != self._pipeline_fp:
+            why = "log format" if fmt != self._MANIFEST_FORMAT else "chunk_transform fingerprint"
+            self._reset_stale(path, entry_lines, why)
+            return
+        for i, line in enumerate(entry_lines):
             try:
-                array, chunk_index, fname = entry["array"], int(entry["chunk_index"]), entry["file"]
-            except (TypeError, KeyError, ValueError) as exc:
+                rec = json.loads(line)
+                array, chunk_index, fname = rec["array"], int(rec["chunk_index"]), rec["file"]
+            except (json.JSONDecodeError, TypeError, KeyError, ValueError) as exc:
+                if i == len(entry_lines) - 1:
+                    break  # torn tail: the crash landed mid-append on the last line -- drop it
                 raise ValueError(
-                    f"persist: cache manifest {path} has a malformed entry {entry!r} ({exc}); "
+                    f"persist: cache log {path} has a malformed entry on line {i + 2} ({exc}); "
                     f"this is corruption or tampering, not a stale cache -- delete {self._dir} "
                     "to reset."
                 ) from exc
-            # The file must be a bare name resolved inside the cache dir. An absolute path, a
-            # ``..`` component, or any separator would escape via ``self._dir / fname`` in
-            # _revive; a manifest only ever stores basenames (see _register_persisted). Check
-            # separators explicitly -- ``Path('..').name`` is ``'..'``, and a Windows-style
-            # separator is an ordinary char to posix ``basename`` -- so neither alone suffices.
-            unsafe = (
-                not isinstance(fname, str)
-                or fname in ("", ".", "..")
-                or "/" in fname
-                or "\\" in fname
-            )
-            if unsafe:
+            if not self._is_bare_filename(fname):
                 raise ValueError(
-                    f"persist: cache manifest {path} entry file {fname!r} is not a bare filename "
+                    f"persist: cache log {path} entry file {fname!r} is not a bare filename "
                     f"(possible path-traversal tampering); delete {self._dir} to reset."
                 )
-            self._persisted[(array, chunk_index)] = fname
+            key = (array, chunk_index)
+            self._persisted[key] = fname
+            self._recorded.add(key)
         self.manifest_entries = len(self._persisted)
 
-    def _write_manifest(self) -> None:  # call under the lock
-        """Atomically write the registry of completed cache entries (persist mode)."""
+    def _reset_stale(self, path: Path, entry_lines: list[str], why: str) -> None:
+        """A stale cache: raise by default, or (``reset_stale_cache``) GC + rebuild.
+
+        The GC deletes exactly the ``.npy`` files this stale log named -- each re-checked as a
+        bare filename before ``unlink`` (a tampered path is never removed) -- then the log
+        itself. Precise: only files we recorded writing; crash-orphans are already in the log.
+        """
         assert self._dir is not None
-        entries = [
-            {"array": array, "chunk_index": cid, "file": fname}
-            for (array, cid), fname in sorted(self._persisted.items())
-        ]
-        doc = {
-            "format_version": self._MANIFEST_FORMAT,
-            "pipeline_hash": self._pipeline_fp,
-            "entries": entries,
-        }
-        tmp = self._dir / (self._MANIFEST_NAME + ".tmp")
-        tmp.write_text(json.dumps(doc))
-        os.replace(tmp, self._dir / self._MANIFEST_NAME)
+        if not self._reset_stale_cache:
+            raise ValueError(
+                f"persist: cache at {self._dir} is stale ({why} changed since it was written). "
+                "This is not corruption -- pass reset_stale_cache=True to delete and rebuild it, "
+                f"or remove {self._dir} yourself."
+            )
+        for line in entry_lines:
+            try:
+                fname = json.loads(line)["file"]
+            except (json.JSONDecodeError, TypeError, KeyError):
+                continue  # a garbage/torn line in a log we're discarding anyway -- skip
+            if self._is_bare_filename(fname):
+                with contextlib.suppress(FileNotFoundError):
+                    os.unlink(self._dir / fname)
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(path)
+        logger.info("persist: stale cache at %s (%s changed) reset; rebuilding.", self._dir, why)
 
     def close(self) -> None:
-        """Free every remaining slot. Persist mode keeps ready cache files + a manifest;
-        otherwise (heap/spill) mmap files are unlinked -- e.g. on teardown."""
+        """Free every remaining slot. Persist keeps ready cache files (each already recorded in
+        the log at completion, so there is nothing to rewrite -- just flush + close the handle);
+        heap/spill mmap files are unlinked."""
         with self._cv:
-            if self._persistent:
-                for key, slot in self._slots.items():
-                    if slot.ready:
-                        self._register_persisted(key, slot)
-                self._write_manifest()
+            if self._log is not None:
+                self._log.flush()
+                self._log.close()
+                self._log = None
             for k in list(self._slots):
                 slot = self._slots.pop(k)
                 self._free(slot, keep_file=self._persistent and slot.ready)

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -843,9 +843,9 @@ class ChunkPool:
         logger.info("persist: stale cache at %s (%s changed) reset; rebuilding.", self._dir, why)
 
     def close(self) -> None:
-        """Free every remaining slot. Persist keeps ready cache files (each already recorded in
-        the log at completion, so there is nothing to rewrite -- just flush + close the handle);
-        heap/spill mmap files are unlinked."""
+        """Free every remaining slot and release the log handle. Persist keeps ready cache files
+        (each already recorded in the log at completion, so there is nothing to rewrite -- just
+        flush + close the handle); heap/spill mmap files are unlinked. Idempotent."""
         with self._cv:
             if self._log is not None:
                 self._log.flush()
@@ -856,3 +856,11 @@ class ChunkPool:
                 self._free(slot, keep_file=self._persistent and slot.ready)
             self._bytes = 0
             self._pinned.clear()
+
+    def __del__(self) -> None:
+        # Safety net for a pool dropped without an explicit close() -- release the open log
+        # handle (persist mode holds one for its lifetime) and the mmap backings. Best-effort:
+        # __del__ runs at GC / interpreter shutdown where exceptions are unraisable. In normal
+        # use InSituDataset.close()/__del__ closes the pool; this covers a bare ChunkPool.
+        with contextlib.suppress(Exception):
+            self.close()

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -120,6 +120,7 @@ class InSituDataset:
         cache_dir: str | None = None,
         cache_budget_bytes: int | None = None,
         persist: bool = False,
+        reset_stale_cache: bool = False,
         on_bad_chunk: str = "raise",
         chunk_transforms: Sequence[Callable[[DecodedChunk], DecodedChunk]] = (),
         batch_transforms: Sequence[Callable[[Batch], Batch]] = (),
@@ -215,6 +216,7 @@ class InSituDataset:
             backing_dir=cache_dir,
             budget_bytes=self.cache_budget_bytes,
             persist=persist,
+            reset_stale_cache=reset_stale_cache,
         )
 
         # One concurrency dial (max_inflight, network), independent of the shuffle

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -604,6 +604,23 @@ def test_pool_persist_log_dedups_across_epochs_and_runs(tiled_store, tmp_path):
     assert len(logpath.read_text().splitlines()) == 3, "reopen must not duplicate lines"
 
 
+def test_pool_close_is_idempotent(tiled_store, tmp_path):
+    """close() must be safe to call twice: InSituDataset.close() and its __del__ both call it,
+    and ChunkPool.__del__ is a third best-effort call. The second call releases nothing (the log
+    handle is already None, the slots already freed) and must not raise."""
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    backing = tmp_path / "cache"
+
+    pool = ChunkPool(geoms, backing_dir=backing, persist=True)
+    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    pool.close()
+    assert pool._log is None  # handle released
+    pool.close()  # idempotent -- no double-close error on the file handle or slots
+
+
 def test_pool_persist_missing_file_is_miss_not_raise(tiled_store, tmp_path):
     """A log entry whose ``.npy`` is gone from disk (external deletion / disk cleanup -- NOT
     eviction, which keeps the file) is a **miss**: revive fails to open it, drops the entry, and

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -318,7 +318,7 @@ def test_pool_reshaping_transform_mmap_persist_roundtrip(
         _fill_chunk(pool, "single_inner", cid, geom, tiles)
     assert pool.misses == geom.n_chunks and pool.hits == 0
     pool.close()
-    assert list(backing.glob("*.npy")) and (backing / "insitu_cache.json").exists()
+    assert list(backing.glob("*.npy")) and (backing / "insitu_cache.jsonl").exists()
 
     pool2 = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[MeanLastAxis()])
     assert pool2.manifest_entries == geom.n_chunks
@@ -504,7 +504,7 @@ def test_pool_cross_run_persistence(tiled_store, tmp_path):
     assert pool.misses == geom.n_chunks and pool.hits == 0  # cold: every chunk a miss
     pool.close()
     assert list(backing.glob("*.npy")), "persist=True must keep slot files after close()"
-    assert (backing / "insitu_cache.json").exists(), "persist must write a manifest"
+    assert (backing / "insitu_cache.jsonl").exists(), "persist must write a manifest"
 
     # Run 2: same dir -> every chunk a ready hit, no fetch/scatter.
     pool2 = ChunkPool(geoms, backing_dir=backing, persist=True)
@@ -517,6 +517,141 @@ def test_pool_cross_run_persistence(tiled_store, tmp_path):
         assert np.array_equal(got, srcs["single_inner"][cid * spc : cid * spc + n0])
     assert pool2.hits == geom.n_chunks and pool2.misses == 0  # warm: every chunk a hit
     pool2.close()
+
+
+def test_pool_persist_crash_recovery_without_close(tiled_store, tmp_path):
+    """The headline crash-recovery contract: a process that dies WITHOUT calling close() (spot
+    preempt / OOM / SIGTERM) still leaves every completed chunk in the append-only log, so a new
+    pool over the same dir revives them all as hits -- re-decoding ZERO. The close-only manifest
+    could not do this: it wrote nothing on a crash."""
+    url, srcs = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    spc = geom.sample_chunk_size
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    backing = tmp_path / "cache"
+
+    # Run 1: populate every chunk but NEVER close() -- simulate a killed process. The log must
+    # already carry every completed entry (flushed on completion, not at close).
+    pool = ChunkPool(geoms, backing_dir=backing, persist=True)
+    for cid in range(geom.n_chunks):
+        _fill_chunk(pool, "single_inner", cid, geom, tiles)
+    log = (backing / "insitu_cache.jsonl").read_text().splitlines()
+    assert len(log) == geom.n_chunks + 1  # header + one entry per completed chunk
+
+    # Run 2: same dir, fresh pool -> every chunk a ready hit despite the missing close().
+    pool2 = ChunkPool(geoms, backing_dir=backing, persist=True)
+    assert pool2.manifest_entries == geom.n_chunks
+    for cid in range(geom.n_chunks):
+        assert pool2.pin_if_ready("single_inner", cid), "crashed-run chunk must revive as a hit"
+        n0 = len(geom.samples_in_chunk(cid))
+        rows = np.array([[cid, w] for w in range(n0)], dtype=np.int64)
+        got = pool2.gather(rows, ["single_inner"], spc).arrays["single_inner"]
+        assert np.array_equal(got, srcs["single_inner"][cid * spc : cid * spc + n0])
+    assert pool2.hits == geom.n_chunks and pool2.misses == 0
+    pool2.close()
+
+
+def test_pool_persist_partial_iteration_recovers_completed_subset(tiled_store, tmp_path):
+    """A crash partway through the first epoch: only the chunks that *completed* are logged, so
+    a reopen revives exactly that subset -- the rest are misses (re-decoded), not false hits."""
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    backing = tmp_path / "cache"
+
+    pool = ChunkPool(geoms, backing_dir=backing, persist=True)
+    _fill_chunk(pool, "single_inner", 0, geom, tiles)  # only chunk 0 completes before the "crash"
+    # no close()
+
+    pool2 = ChunkPool(geoms, backing_dir=backing, persist=True)
+    assert pool2.manifest_entries == 1
+    assert pool2.pin_if_ready("single_inner", 0), "the completed chunk revives"
+    assert not pool2.pin_if_ready("single_inner", 1), "an un-reached chunk is a miss, not a hit"
+    pool2.close()
+
+
+def test_pool_persist_log_dedups_across_epochs_and_runs(tiled_store, tmp_path):
+    """The log is self-deduplicating and bounded: re-completing a chunk (after an eviction +
+    refetch, and across a close+reopen) never appends a duplicate line -- the count stays equal
+    to the number of distinct cached chunks."""
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    backing = tmp_path / "cache"
+    logpath = backing / "insitu_cache.jsonl"
+
+    # A tiny budget so admitting a second chunk evicts (demotes) the first -> then refetch it,
+    # re-completing the same key. The _recorded gate must prevent a duplicate log line.
+    one_slot = int(np.prod(geom.slot_shape(0)) * geom.dtype.itemsize)
+    pool = ChunkPool(geoms, backing_dir=backing, persist=True, budget_bytes=one_slot)
+    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    pool.unpin_all()  # drop the pin so chunk 0 is evictable
+    _fill_chunk(pool, "single_inner", 1, geom, tiles)  # evicts (demotes) chunk 0
+    pool.unpin_all()
+    _fill_chunk(pool, "single_inner", 0, geom, tiles)  # refetch + re-complete chunk 0
+    pool.close()
+
+    header_plus_entries = logpath.read_text().splitlines()
+    assert len(header_plus_entries) == 1 + 2, "one line per distinct key, no duplicates"
+
+    # Reopen and re-complete an already-logged chunk: still no new line.
+    pool2 = ChunkPool(geoms, backing_dir=backing, persist=True)
+    assert pool2.manifest_entries == 2
+    pool2.close()
+    assert len(logpath.read_text().splitlines()) == 3, "reopen must not duplicate lines"
+
+
+def test_pool_persist_missing_file_is_miss_not_raise(tiled_store, tmp_path):
+    """A log entry whose ``.npy`` is gone from disk (external deletion / disk cleanup -- NOT
+    eviction, which keeps the file) is a **miss**: revive fails to open it, drops the entry, and
+    the chunk is re-fetched. Never a raise -- the cache is a transparent optimization."""
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    backing = tmp_path / "cache"
+
+    pool = ChunkPool(geoms, backing_dir=backing, persist=True)
+    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    pool.close()
+
+    # Delete the data file but leave the log referencing it (a torn cache, not eviction).
+    for f in backing.glob("*.npy"):
+        f.unlink()
+
+    pool2 = ChunkPool(geoms, backing_dir=backing, persist=True)
+    assert pool2.manifest_entries == 1  # the log still lists the (now-missing) entry
+    assert not pool2.pin_if_ready("single_inner", 0), "a missing .npy is a miss, not a hit"
+    assert pool2.revive_missing == 1 and pool2.hits == 0
+    assert ("single_inner", 0) not in pool2._persisted  # the dangling entry is dropped
+    pool2.close()
+
+
+def test_pool_persist_evicted_chunk_revives_from_kept_file(tiled_store, tmp_path):
+    """Eviction in persist mode is a *demotion*, not a delete: a ready chunk pushed out under
+    budget pressure keeps its ``.npy`` on disk, so touching it again revives it as a HIT from
+    NVMe -- no re-fetch. (This is why a missing file is never expected from eviction.)"""
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    backing = tmp_path / "cache"
+
+    one_slot = int(np.prod(geom.slot_shape(0)) * geom.dtype.itemsize)
+    pool = ChunkPool(geoms, backing_dir=backing, persist=True, budget_bytes=one_slot)
+    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    pool.unpin_all()  # make chunk 0 evictable
+    _fill_chunk(pool, "single_inner", 1, geom, tiles)  # admits 1 -> demotes 0 (file KEPT)
+    pool.unpin_all()  # make chunk 1 evictable so reviving 0 can free room
+
+    assert ("single_inner", 0) not in pool._slots  # 0 was evicted from memory
+    assert (backing / pool._persisted[("single_inner", 0)]).exists()  # but its file survives
+    assert pool.pin_if_ready("single_inner", 0), "the demoted chunk revives from its kept file"
+    assert pool.revive_missing == 0  # nothing was lost by the eviction
+    pool.close()
 
 
 def test_pool_persist_invalidates_on_geometry_mismatch(tiled_store, tmp_path):
@@ -542,8 +677,9 @@ def test_pool_persist_invalidates_on_geometry_mismatch(tiled_store, tmp_path):
 
 
 def test_pool_persist_invalidates_on_transform_change(tiled_store, tmp_path):
-    """The manifest carries a chunk_transform fingerprint: the same transform reopens as
-    a hit; a changed transform discards the whole cache (cold start), not a false hit."""
+    """The log header carries a chunk_transform fingerprint: the same transform reopens as a
+    hit; a changed transform is a *stale* cache, which RAISES by default (not a false hit, and
+    not a silent cold-start -- a stale cache is almost never what the user intended)."""
     url, _ = tiled_store
     geoms = open_geometries(url, variables=["single_inner"])
     geom = geoms["single_inner"]
@@ -566,10 +702,40 @@ def test_pool_persist_invalidates_on_transform_change(tiled_store, tmp_path):
         chunk.data = chunk.data * 3.0
         return chunk
 
-    changed = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[scale_b])
-    assert changed.manifest_entries == 0  # stale cache discarded, not loaded
-    assert not changed.pin_if_ready("single_inner", 0)
-    changed.close()
+    with pytest.raises(ValueError, match="stale|reset_stale_cache"):
+        ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[scale_b])
+
+
+def test_pool_persist_reset_stale_cache_gcs_and_rebuilds(tiled_store, tmp_path):
+    """reset_stale_cache=True opts into wiping a stale cache: the old .npy files and log are
+    deleted and the cache rebuilds cold (no raise, no false hit)."""
+    url, _ = tiled_store
+    geoms = open_geometries(url, variables=["single_inner"])
+    geom = geoms["single_inner"]
+    tiles = asyncio.run(_decode_tiles(url, "single_inner"))
+    backing = tmp_path / "cache"
+
+    def scale_a(chunk):
+        chunk.data = chunk.data * 2.0
+        return chunk
+
+    pool = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[scale_a])
+    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    pool.close()
+    stale_file = pool._persisted[("single_inner", 0)]
+    assert (backing / stale_file).exists()
+
+    def scale_b(chunk):
+        chunk.data = chunk.data * 3.0
+        return chunk
+
+    reset = ChunkPool(
+        geoms, backing_dir=backing, persist=True, chunk_transforms=[scale_b], reset_stale_cache=True
+    )
+    assert reset.manifest_entries == 0  # stale cache wiped -> cold start
+    assert not (backing / stale_file).exists(), "the stale .npy must be GC'd"
+    assert not reset.pin_if_ready("single_inner", 0)  # nothing to revive -> a miss
+    reset.close()
 
 
 def test_pool_persist_cache_key_overrides_fingerprint(tiled_store, tmp_path):
@@ -597,10 +763,9 @@ def test_pool_persist_cache_key_overrides_fingerprint(tiled_store, tmp_path):
     assert same.pin_if_ready("single_inner", 0)
     same.close()
 
-    t2.cache_key = "v2"  # type: ignore[attr-defined]  # bump the key -> invalidate
-    changed = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[t2])
-    assert changed.manifest_entries == 0
-    changed.close()
+    t2.cache_key = "v2"  # type: ignore[attr-defined]  # bump the key -> invalidate (stale -> raise)
+    with pytest.raises(ValueError, match="stale|reset_stale_cache"):
+        ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[t2])
 
 
 def test_pool_persist_cloudpickle_catches_closure_change(tiled_store, tmp_path):
@@ -624,11 +789,8 @@ def test_pool_persist_cloudpickle_catches_closure_change(tiled_store, tmp_path):
     _fill_chunk(pool, "single_inner", 0, geom, tiles)
     pool.close()
 
-    changed = ChunkPool(
-        geoms, backing_dir=backing, persist=True, chunk_transforms=[make_scaler(3.0)]
-    )
-    assert changed.manifest_entries == 0  # closure-value change caught -> cache discarded
-    changed.close()
+    with pytest.raises(ValueError, match="stale|reset_stale_cache"):  # closure change -> stale
+        ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[make_scaler(3.0)])
 
 
 def test_pool_persist_without_cloudpickle_warns_and_falls_back(
@@ -658,28 +820,46 @@ def test_pool_persist_without_cloudpickle_warns_and_falls_back(
     same.close()
 
 
-def _persist_one(tiled_store, backing):
-    """Write a one-entry persistent cache and return (geoms, manifest_path)."""
+def _persist_two(tiled_store, backing):
+    """Write a two-entry persistent cache and return (geoms, log_path). Two entries so a
+    tampered/malformed entry can be an *interior* (non-tail) line -- a corrupt tail is treated
+    as a crash artifact and dropped, an interior one is corruption and raises."""
     url, _ = tiled_store
     geoms = open_geometries(url, variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     pool = ChunkPool(geoms, backing_dir=backing, persist=True)
-    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    for cid in (0, 1):
+        _fill_chunk(pool, "single_inner", cid, geom, tiles)
     pool.close()
-    return geoms, backing / "insitu_cache.json"
+    return geoms, backing / "insitu_cache.jsonl"
+
+
+def _read_log(path):
+    lines = path.read_text().splitlines()
+    return json.loads(lines[0]), [json.loads(line) for line in lines[1:]]
+
+
+def _write_log(path, header, entries):
+    """Serialize a header + entry list back to JSONL. An entry given as a ``str`` is written
+    raw (to inject an unparseable / non-mapping line); a dict is json-encoded."""
+    with path.open("w") as f:
+        f.write(json.dumps(header) + "\n")
+        for e in entries:
+            f.write((e if isinstance(e, str) else json.dumps(e)) + "\n")
 
 
 @pytest.mark.parametrize("bad_file", ["/etc/passwd", "../../etc/passwd", "sub/dir.npy", "..", ""])
 def test_pool_manifest_rejects_non_basename_file(tiled_store, tmp_path, bad_file):
-    """A tampered manifest whose entry ``file`` is not a bare basename is rejected fail-fast
-    (not silently skipped): ``_revive`` would otherwise ``open_memmap`` a path escaping the
-    cache dir (``self._dir / fname``). Absolute paths and ``..`` both escape."""
+    """A tampered log whose entry ``file`` is not a bare basename is rejected fail-fast (not
+    silently skipped): ``_revive`` would otherwise ``open_memmap`` a path escaping the cache dir
+    (``self._dir / fname``). Absolute paths and ``..`` both escape. Mutating the *first* (of two)
+    entries keeps it an interior line so it can't be mistaken for a torn tail."""
     backing = tmp_path / "cache"
-    geoms, mpath = _persist_one(tiled_store, backing)
-    doc = json.loads(mpath.read_text())
-    doc["entries"][0]["file"] = bad_file
-    mpath.write_text(json.dumps(doc))
+    geoms, mpath = _persist_two(tiled_store, backing)
+    header, entries = _read_log(mpath)
+    entries[0]["file"] = bad_file
+    _write_log(mpath, header, entries)
     with pytest.raises(ValueError, match="bare filename|path-traversal"):
         ChunkPool(geoms, backing_dir=backing, persist=True)
 
@@ -687,22 +867,50 @@ def test_pool_manifest_rejects_non_basename_file(tiled_store, tmp_path, bad_file
 @pytest.mark.parametrize(
     "mutate",
     [
-        lambda d: d["entries"][0].pop("file"),  # missing field
-        lambda d: d["entries"][0].update(chunk_index="NaN"),  # non-int index
-        lambda d: d.update(entries="not-a-list"),  # wrong container type
-        lambda d: d.update(entries=["a-bare-string"]),  # entry not a mapping
+        lambda entries: entries[0].pop("file"),  # missing field
+        lambda entries: entries[0].update(chunk_index="NaN"),  # non-int index
+        lambda entries: entries.__setitem__(0, "a-bare-string"),  # entry not a mapping
+        lambda entries: entries.__setitem__(0, "{not-json"),  # unparseable interior line
     ],
 )
 def test_pool_manifest_rejects_malformed_entry(tiled_store, tmp_path, mutate):
-    """A manifest that clears the format/fingerprint gates but is structurally corrupt raises
-    -- corruption/tampering is not an expected stale cache (those degrade to a cold start)."""
+    """A log that clears the format/fingerprint gates but has a structurally corrupt *interior*
+    entry raises -- corruption/tampering is not an expected stale cache. (A corrupt *tail* line
+    is a crash artifact, tested separately.)"""
     backing = tmp_path / "cache"
-    geoms, mpath = _persist_one(tiled_store, backing)
-    doc = json.loads(mpath.read_text())
-    mutate(doc)
-    mpath.write_text(json.dumps(doc))
+    geoms, mpath = _persist_two(tiled_store, backing)
+    header, entries = _read_log(mpath)
+    mutate(entries)
+    _write_log(mpath, header, entries)
     with pytest.raises(ValueError, match="malformed entry|corrupt|bare filename"):
         ChunkPool(geoms, backing_dir=backing, persist=True)
+
+
+def test_pool_manifest_tolerates_torn_tail(tiled_store, tmp_path):
+    """A crash mid-append leaves a partial final line: it is dropped (not a raise), and every
+    complete entry before it still revives -- the crash-recovery contract."""
+    backing = tmp_path / "cache"
+    geoms, mpath = _persist_two(tiled_store, backing)
+    with mpath.open("a") as f:
+        f.write('{"array": "single_inner", "chunk_ind')  # torn tail, no newline
+    pool = ChunkPool(geoms, backing_dir=backing, persist=True)
+    assert pool.manifest_entries == 2  # both complete entries survived; the torn tail dropped
+    assert pool.pin_if_ready("single_inner", 0) and pool.pin_if_ready("single_inner", 1)
+    pool.close()
+
+
+def test_pool_manifest_rejects_unreadable_header(tiled_store, tmp_path):
+    """An unparseable header (line 0) is corruption -- we cannot validate the fingerprint -- so
+    it raises regardless of reset_stale_cache; the flag governs a *stale* cache, not a torn one."""
+    backing = tmp_path / "cache"
+    geoms, mpath = _persist_two(tiled_store, backing)
+    _, entries = _read_log(mpath)
+    with mpath.open("w") as f:
+        f.write("{not-json\n")
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+    with pytest.raises(ValueError, match="header|corrupt"):
+        ChunkPool(geoms, backing_dir=backing, persist=True, reset_stale_cache=True)
 
 
 def test_pool_spill_unlinks_without_persist(tiled_store, tmp_path):
@@ -718,4 +926,4 @@ def test_pool_spill_unlinks_without_persist(tiled_store, tmp_path):
     _fill_chunk(pool, "single_inner", 0, geom, tiles)
     pool.close()
     assert not list(backing.glob("*.npy")), "spill must unlink slot files on close()"
-    assert not (backing / "insitu_cache.json").exists(), "no manifest without persist"
+    assert not (backing / "insitu_cache.jsonl").exists(), "no manifest without persist"

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -239,6 +239,57 @@ def test_cache_persists_across_runs(write_zarr, tmp_path) -> None:
         assert np.array_equal(a, b)
 
 
+def test_persist_stale_transform_raises_then_rebuilds_with_flag(write_zarr, tmp_path) -> None:
+    # A changed chunk_transform makes the cache stale. Default: constructing the dataset RAISES
+    # (a stale cache is almost never intended). reset_stale_cache=True instead wipes it and
+    # rebuilds cold -- yielding correct batches again.
+    url, _ = write_zarr(n=80, spc=8)  # 10 chunks
+    geom = open_geometries(url)["t2m"]
+    manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
+    cache = str(tmp_path / "cache")
+
+    def scale_a(chunk):
+        chunk.data = chunk.data * 2.0
+        return chunk
+
+    def scale_b(chunk):
+        chunk.data = chunk.data * 3.0
+        return chunk
+
+    def make(transform, reset=False) -> InSituDataset:
+        return InSituDataset(
+            url,
+            manifest,
+            batch_size=4,
+            block_chunks=4,
+            shuffle=False,
+            chunk_transforms=[transform],
+            cache_dir=cache,
+            persist=True,
+            reset_stale_cache=reset,
+            cache_budget_bytes=10_000_000,
+        )
+
+    ds = make(scale_a)
+    ds.set_epoch(0)
+    _ = [b for b in ds.train]
+    ds.close()
+
+    # Default: a different transform -> stale -> raise at construction (fail fast).
+    with pytest.raises(ValueError, match="stale|reset_stale_cache"):
+        make(scale_b)
+
+    # Opt in: wipe + rebuild, batches correct against the new transform.
+    ds2 = make(scale_b, reset=True)
+    try:
+        ds2.set_epoch(0)
+        got = np.concatenate([b.arrays["t2m"] for b in ds2.train])
+    finally:
+        ds2.close()
+    assert ds2.cache_misses > 0 and ds2.cache_hits == 0  # rebuilt cold, no false hits
+    assert np.isfinite(got).all()
+
+
 def test_persist_warns_when_cache_unusable(write_zarr, tmp_path, caplog) -> None:
     # persist=True but the cache is consulted and serves nothing (here: the .npy files
     # were deleted under a surviving manifest) -> one loud WARNING per epoch, and the


### PR DESCRIPTION
## What & why

The cross-run persist cache wrote its manifest **only in `close()`**, so two gaps remained (backlog #3 + #4):

1. **No crash recovery.** A killed process — spot preemption, OOM, SIGTERM, the target environment — never reached `close()`, so every `.npy` on disk stayed unlisted and the next run cold-started, re-decoding the whole epoch. The expensive first epoch that *builds* the cache was exactly what got lost.
2. **Stale cache silently rebuilt, files leaked.** On a chunk_transform fingerprint (or format) change the cache was discarded cold but its superseded `.npy` files were never deleted.

## Changes

**Append-only `insitu_cache.jsonl`** (format v1→v2) replaces the close-only JSON manifest:
- Header line (`format_version`, `pipeline_hash`) + one entry line per completed chunk, appended + flushed **at completion** in `scatter`'s ready block via a held-open handle.
- A killed process leaves a usable cache; the next run re-decodes only what didn't finish.
- **Self-deduplicating** via a `_recorded` set (repopulated on load) — re-completing a chunk across epochs/runs never duplicates a line, so the log is bounded to one line per cached chunk. **No compaction.** Eviction is a demotion (file + line kept), so it removes nothing.
- Durability is `flush` (process-death recovery), not `fsync` (power-loss out of scope).
- Registration moved to completion → `_register_persisted` and `_write_manifest` removed; `close()` just flushes + closes the handle.

**Stale cache raises by default** (reverses the old WARN + cold-start — a stale cache is almost never intended):
- Fingerprint/format mismatch → `ValueError` at construction. New **`reset_stale_cache: bool = False`** on `ChunkPool` and `InSituDataset` opts into GC'ing the stale `.npy` files (bare-name-checked) + the log, then rebuilding cold.
- Corruption/tampering (unreadable header, malformed *interior* entry, non-bare filename) **always raises**, regardless of the flag. A torn *final* line is a crash artifact → dropped.

## Tests

New (TDD): crash-recovery-without-close, partial-iteration, dedup-across-epochs/runs, stale-raises + reset-GCs, torn-tail-tolerated, unreadable-header-raises, missing-file-is-miss, evicted-chunk-revives-from-kept-file. The manifest-rejection tests were adapted to 2-entry JSONL (so the bad entry is interior, not a droppable tail), plus an end-to-end `reset_stale_cache` test on `InSituDataset`.

**130 passed / 10 skipped; ruff, ruff-format, mypy all clean.**

Docs (`docs/architecture.md`, `DESIGN.md`) updated; backlog #3 + #4 closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)