### PR TITLE
Store-only API + working fsspec/gcsfs backend (M-GCS: obstore wins HTTP; Rapid pending)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           # cache pulls cloudpickle so the cross-run cache fingerprint exercises its
           # cloudpickle path here rather than importorskip-skipping it.
           - python: "3.12"
-            extras: "--extra torch --extra bench --extra icechunk --extra cache"
+            extras: "--extra torch --extra bench --extra icechunk --extra cache --extra gcsfs"
           # JAX alone.
           - python: "3.12"
             extras: "--extra jax"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,8 +57,12 @@ for the thesis and [docs/architecture.md](docs/architecture.md) for the pipeline
 - **Sample geometry v1:** a sample is a slice of the outer (sample) axis that does
   not cross a chunk boundary. No cross-chunk samples; cross-variable derived
   fields are batch-stage only.
-- **One URL, any backend:** `store_from_url` (obstore) gives `file://` locally,
-  `s3://`/`gs://` in the cloud — no hot-path change.
+- **One contract, any backend:** the engine reads a zarr-v3 `Store`; constructors
+  build one per backend (`obstore_store` for `file://`/`s3://`/`gs://`,
+  `fsspec_store` for what obstore can't reach — GCS Rapid/zonal, requester-pays —,
+  `arraylake_store` for Icechunk sessions). No str-vs-Store dispatch, no hot-path
+  change. obstore is the default URL path today; fsspec is under evaluation as a
+  co-equal fast path for GCS.
 
 ## Do not
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -316,7 +316,7 @@ multiple grows with colder S3 or heavier decode; 2.5× is the conservative read.
 |---|---|
 | `types.py` | `ArrayGeometry`, `ChunkRead`, `DecodedChunk`, `Batch` |
 | `split.py` | chunk-aligned `SplitManifest`, `split_by_chunk` (+ `sample_range` subsetting) |
-| `store.py` | `store_from_url` shim (local↔S3 via obstore) + geometry introspection |
+| `store.py` | per-backend `Store` constructors (`obstore_store`, `fsspec_store`, `arraylake_store`) + geometry introspection |
 | `shuffle.py` | chunk permutation + shuffle-block / sequential order + quality metric |
 | `plan.py` | `build_stored_chunk_reads` — a draw order's chunks → deduped stored-chunk (tile) reads for the scheduler |
 | `scheduler.py` | `Scheduler` — one `max_inflight` budget over stored-chunk reads; fetch→decode→scatter; residency admission |
@@ -482,6 +482,15 @@ Perf track (the core thesis):
   fetching (fast cold TTFB), and `max_inflight` goes back to being purely the concurrency
   dial. Applies to both the V2 main engine and the M-W branch (whose residency rework did
   not add a read-ahead cap either).
+- **M-GCS — fsspec/gcsfs store backend (in progress).** The engine now takes a zarr
+  `Store`, built per backend: `obstore_store` (default, pure-Rust URL path),
+  `fsspec_store` (`FsspecStore.from_url`, reaches what obstore can't — GCS Rapid/zonal
+  over gRPC, requester-pays — via `insitubatch[gcsfs]`), and `arraylake_store`
+  (Icechunk sessions). The str-vs-Store / `**store_kwargs` dispatch is gone. **Open
+  question under evaluation on the GCP bench box:** whether fsspec-over-gcsfs on Rapid
+  storage matches or beats obstore's raw-read path — if so, fsspec earns a spot as a
+  core dep and a co-equal fast path (today it is an optional extra). Pending: validate a
+  real Rapid bucket end-to-end, then drop the `ops_gcp.md` VERIFY markers.
 - **M2 — GPU full scale** kvikio/cupy/nvCOMP, dlpack→torch; prove GPU saturation
   with bounded host memory.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -491,6 +491,49 @@ Perf track (the core thesis):
   storage matches or beats obstore's raw-read path — if so, fsspec earns a spot as a
   core dep and a co-equal fast path (today it is an optional extra). Pending: validate a
   real Rapid bucket end-to-end, then drop the `ops_gcp.md` VERIFY markers.
+  - **Event-loop ownership (shipped) + a TODO to simplify it.** A genuinely-async
+    fsspec backend (gcsfs, s3fs) binds its aiohttp session to the *first event loop that
+    awaits it*, permanently — no ctor knob pins it. For a zarr store that first loop is
+    **zarr's** process-wide store-IO loop (`zarr.core.sync._get_loop()`), because any
+    zarr sync call (`open_geometries`, `xr.open_zarr`, user code) touches the store
+    first. That is the correct owner: the session living on zarr's loop is what keeps the
+    store drivable by *any* zarr code — so insitu **conforms** (routes its reads there)
+    rather than hijacking the session onto its own loop (which would crash every other
+    zarr-sync consumer). Today the scheduler keeps its own orchestration loop and bridges
+    each fsspec read to zarr's loop (`run_coroutine_threadsafe`); obstore is loop-agnostic
+    (Rust runtime) and is awaited inline. Teardown closes the session on its own loop
+    (`close_store`) so gcsfs's finalizer — which wrongly targets `fsspec.asyn.get_loop()` —
+    is a no-op.
+
+    ```mermaid
+    flowchart TD
+        subgraph proc["insitubatch process (one training run)"]
+          OG["any zarr sync call<br/>open_geometries / xr.open_zarr"]
+          SL["Scheduler loop<br/>own loop, new thread per pass<br/>orchestration + decode/scatter pool"]
+          ZL["zarr store-IO loop<br/>zarr.core.sync._get_loop()"]
+          SESS[("gcsfs aiohttp session")]
+          OBS["obstore ObjectStore<br/>Rust tokio runtime, loop-agnostic"]
+          FL["fsspec.asyn.get_loop()<br/>NOT where the session lives"]
+        end
+        OG -->|"first await creates the session here"| ZL
+        ZL -->|owns| SESS
+        SL -->|"fsspec read: run_coroutine_threadsafe (bridge)"| ZL
+        SL -->|"obstore read: await inline"| OBS
+        FL -.->|"gcsfs finalizer wrongly targets this;<br/>close_store fixes the mismatch at teardown"| SESS
+    ```
+
+    **TODO — unify on zarr's loop; delete the bridge.** Run the scheduler's orchestration
+    *on* zarr's loop for all backends instead of spinning a private loop+thread per pass.
+    This removes `_fsspec_io_loop` / `_io` / `_foreign_loop` (the bridge) **and** the
+    per-pass `new_event_loop()` + thread churn — collapsing to one loop with one clear
+    owner (obstore rides it fine; the gcsfs session is already there). Not a late edit to
+    the working PR: it rewrites the Scheduler concurrency core, so its **acceptance gate is
+    a stress test** that a consumer-stalled, back-pressured `_drive` sharing zarr's
+    *process-global* loop cannot starve or deadlock other zarr-sync work (it is await-heavy
+    and offloads decode/scatter, so it *should* be fine — verify, don't assume). Must not
+    set that loop's default executor (pass the decode pool explicitly) or stop it on
+    `close()`. `close_store` stays either way (the finalizer mismatch is independent of who
+    drives the reads).
 - **M2 — GPU full scale** kvikio/cupy/nvCOMP, dlpack→torch; prove GPU saturation
   with bounded host memory.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -491,6 +491,23 @@ Perf track (the core thesis):
   storage matches or beats obstore's raw-read path — if so, fsspec earns a spot as a
   core dep and a co-equal fast path (today it is an optional extra). Pending: validate a
   real Rapid bucket end-to-end, then drop the `ops_gcp.md` VERIFY markers.
+  - **Preliminary — standard HTTP GCS (n2-standard-8, 2026-07-03; `ops_gcp.md` §7a).**
+    On plain HTTP GCS, **obstore wins the transfer floor decisively.** Decode-free raw
+    concurrent GET (best of a 4→32 concurrency sweep, MB/s): obstore 1211 / 1581 / 802 at
+    c1 / c4 / c16 vs gcsfs 529 / 606 / 487 — a **~1.6–2.6× obstore lead**. The mechanism is
+    visible in the sweep: obstore *scales* with concurrency (c1 raw: 376→681→1042→1211),
+    while gcsfs `cat_file` **plateaus at ~500–600 MB/s and degrades past 16 threads**
+    (c1: 343→513→529→358) — the per-request Python/aiohttp path on the one fsspec loop is
+    the ceiling. End-to-end (insitu, fetch+decode) the gap **compresses to ~1.15–1.2×**
+    only because this 8-core box is **decode-bound at ~450 MB/s** (the decode-threads sweep
+    saturates 445→456 at 4–8 threads, well under obstore's raw 0.8–1.6 GB/s), so both
+    backends hit the same decode wall. That ~20% is therefore a *floor* on fsspec's HTTP
+    penalty — on more cores / faster decode the fetch gap re-widens toward the ~2× raw
+    number. **Takeaway:** obstore stays the HTTP default; fsspec is *not* a co-equal fast
+    path on HTTP, but it is not a correctness regression. Its case rests entirely on the
+    **Rapid/zonal gRPC** path obstore cannot reach — still the deciding, unrun experiment
+    (blocked on Rapid quota). Not yet on the published `docs/benchmarks.md`: that waits for
+    the complete standard-vs-Rapid story so the numbers aren't read as "fsspec is worse."
   - **Event-loop ownership (shipped) + a TODO to simplify it.** A genuinely-async
     fsspec backend (gcsfs, s3fs) binds its aiohttp session to the *first event loop that
     awaits it*, permanently — no ctor knob pins it. For a zarr store that first loop is

--- a/README.md
+++ b/README.md
@@ -148,16 +148,19 @@ two splits both read decodes once. Handoff to torch / JAX / TF is a thin, option
 adapter layer in `insitubatch.frameworks`; the core imports no framework.
 
 ```python
-from insitubatch import open_geometries, split_by_chunk
+from insitubatch import obstore_store, open_geometries, split_by_chunk
 from insitubatch.source import InSituDataset
 
-url = "file:///data/era5.zarr"  # or "s3://bucket/era5.zarr" — same code
-geoms = open_geometries(url)  # {var: ArrayGeometry} from zarr metadata
+# The engine reads a zarr Store; build one per backend. obstore_store covers
+# file://, s3://, gs://, az://. (fsspec_store reaches GCS Rapid/requester-pays;
+# arraylake_store opens an Icechunk session — same InSituDataset below.)
+store = obstore_store("file:///data/era5.zarr")  # or "s3://bucket/era5.zarr"
+geoms = open_geometries(store)  # {var: ArrayGeometry} from zarr metadata
 # contiguous chunk blocks by default (no time-series leakage);
 # pass contiguous=False for exchangeable samples (independent scenes)
 manifest = split_by_chunk(geoms["t2m"], fractions=(0.8, 0.1, 0.1))
 
-ds = InSituDataset(url, manifest, batch_size=32, block_chunks=16)
+ds = InSituDataset(store, manifest, batch_size=32, block_chunks=16)
 
 for epoch in range(n_epochs):
     ds.set_epoch(epoch)

--- a/bench/backend.py
+++ b/bench/backend.py
@@ -1,0 +1,39 @@
+"""Store-backend switch for the benchmark A/B: obstore (Rust) vs fsspec (gcsfs).
+
+The library keeps per-backend constructors with no str-vs-Store dispatch (PEP 20,
+DESIGN.md "One contract, any backend"). The benchmark is the *one* place that
+deliberately builds *any* of them from a ``--backend`` flag: on the same GCS data,
+obstore-over-HTTP vs fsspec/gcsfs measures how much overhead the Python fsspec
+layer adds -- the deciding experiment for whether fsspec earns a co-equal fast
+path (DESIGN.md M-GCS). fsspec is also the only path to GCS Rapid/zonal (gRPC),
+which obstore cannot reach at all. ``arraylake`` reads an Icechunk repo (its ``url``
+is the ``org/repo`` name; ``branch`` selects the ref).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from zarr.abc.store import Store
+
+from insitubatch import arraylake_store, fsspec_store, obstore_store
+
+BACKENDS = ("obstore", "fsspec", "arraylake")
+
+
+def build_store(backend: str, url: str, *, read_only: bool = True, **kwargs: Any) -> Store:
+    """Build a zarr ``Store`` for ``url`` via the named backend.
+
+    ``kwargs`` pass straight through to the backend constructor, so callers own the
+    (backend-specific) knobs -- obstore's ``request_payer`` / ``s3_express``, gcsfs's
+    ``requester_pays`` / ``token``, or arraylake's ``branch``. ``arraylake`` opens a
+    readonly Icechunk session, so it has no ``read_only`` toggle and ``url`` is the
+    ``org/repo`` name rather than a URL.
+    """
+    if backend == "arraylake":
+        return arraylake_store(url, **kwargs)
+    if backend == "fsspec":
+        return fsspec_store(url, read_only=read_only, **kwargs)
+    if backend == "obstore":
+        return obstore_store(url, read_only=read_only, **kwargs)
+    raise ValueError(f"unknown backend {backend!r}; expected one of {BACKENDS}")

--- a/bench/engines.py
+++ b/bench/engines.py
@@ -121,13 +121,14 @@ def run(
 ) -> list[Result]:
     store_kwargs = store_kwargs or {}
     # Each engine builds its own store from (backend, url, store_kwargs) rather than
-    # being handed this live Store. That's deliberate, not an oversight: the workers /
-    # xbatcher baselines pickle their dataset to child processes (forkserver/spawn --
-    # obstore's Rust runtime and gcsfs sessions aren't fork-safe), so they *must*
-    # reconstruct the store inside each worker; a live Store can't cross that boundary.
-    # Passing a store would serve only the in-process engines and split the interface
-    # in two while still keeping these args on Cfg -- so we keep one construction path.
-    # The store object is cheap (lazy; no IO until first read, and gcsfs caches the fs).
+    # being handed this live Store. Not because stores can't be serialized -- obstore's
+    # ObjectStore and zarr's FsspecStore both pickle fine (fsspec drops the aiohttp
+    # session and recreates it on demand in the child) -- but because the workers /
+    # xbatcher baselines run their dataset in child processes where each worker opens its
+    # *own* fresh connection from the config, and those procs are forkserver/spawn (not
+    # fork: obstore's tokio runtime is not fork-safe). Keeping one construction-from-cfg
+    # path is simpler than passing a live store to the in-process engines and cfg to the
+    # workers. Construction is cheap (lazy; no IO until first read, and gcsfs caches the fs).
     geom = open_geometries(build_store(cfg.backend, cfg.url, **store_kwargs))[cfg.var]
     manifest = split_by_chunk(geom, fractions=(0.8, 0.1, 0.1))
     engines = {

--- a/bench/engines.py
+++ b/bench/engines.py
@@ -27,9 +27,9 @@ import zarr
 from insitubatch import (
     SplitManifest,
     SplitName,
+    obstore_store,
     open_geometries,
     split_by_chunk,
-    store_from_url,
 )
 from insitubatch.source import InSituDataset
 from insitubatch.types import ArrayGeometry
@@ -118,7 +118,7 @@ def run(
     cfg: Cfg, *, cache_dir: str | None = None, store_kwargs: dict | None = None
 ) -> list[Result]:
     store_kwargs = store_kwargs or {}
-    geom = open_geometries(cfg.url, **store_kwargs)[cfg.var]
+    geom = open_geometries(obstore_store(cfg.url, **store_kwargs))[cfg.var]
     manifest = split_by_chunk(geom, fractions=(0.8, 0.1, 0.1))
     engines = {
         "insitu": _run_insitu,
@@ -153,7 +153,7 @@ def _run_insitu(
         budget = (n_train + 2) * per_chunk  # hold every train chunk + a margin
         cdir = cache_dir
     ds = InSituDataset(
-        cfg.url,
+        obstore_store(cfg.url, **store_kwargs),
         manifest,
         geometries={cfg.var: geom},
         batch_size=cfg.batch_size,
@@ -164,7 +164,6 @@ def _run_insitu(
         seed=cfg.seed,
         cache_dir=cdir,
         cache_budget_bytes=budget,
-        **store_kwargs,
     )
     out = []
     for epoch in range(cfg.epochs):
@@ -183,7 +182,7 @@ def _run_naive(
     cache_dir: str | None,
     store_kwargs: dict,
 ) -> list[Result]:
-    arr = zarr.open_array(store=store_from_url(cfg.url, **store_kwargs), path=cfg.var, mode="r")
+    arr = zarr.open_array(store=obstore_store(cfg.url, **store_kwargs), path=cfg.var, mode="r")
     spc = geom.sample_chunk_size
 
     def batches() -> Iterator[np.ndarray]:
@@ -205,7 +204,7 @@ def _run_memory(
     cache_dir: str | None,
     store_kwargs: dict,
 ) -> list[Result]:
-    arr = zarr.open_array(store=store_from_url(cfg.url, **store_kwargs), path=cfg.var, mode="r")
+    arr = zarr.open_array(store=obstore_store(cfg.url, **store_kwargs), path=cfg.var, mode="r")
     full = np.asarray(arr[:])
     idx0 = manifest.sample_indices(SplitName.TRAIN, geom)
     out = []
@@ -241,7 +240,7 @@ class _SampleReader:
     def __getitem__(self, i: int) -> np.ndarray:
         if self._arr is None:
             self._arr = zarr.open_array(
-                store=store_from_url(self.url, **self.store_kwargs), path=self.var, mode="r"
+                store=obstore_store(self.url, **self.store_kwargs), path=self.var, mode="r"
             )
         return np.asarray(self._arr[int(self.idx[i])])
 
@@ -310,7 +309,7 @@ def _run_xbatcher(
     from torch.utils.data import DataLoader
     from xbatcher.loaders.torch import MapDataset
 
-    da = xr.open_zarr(store_from_url(cfg.url, **store_kwargs), consolidated=False)[cfg.var]
+    da = xr.open_zarr(obstore_store(cfg.url, **store_kwargs), consolidated=False)[cfg.var]
     da = da.isel({da.dims[0]: manifest.sample_indices(SplitName.TRAIN, geom)})
     # one timestep per sample (full inner dims); the DataLoader collates batch_size.
     input_dims = {da.dims[0]: 1, **{d: int(da.sizes[d]) for d in da.dims[1:]}}

--- a/bench/engines.py
+++ b/bench/engines.py
@@ -27,13 +27,13 @@ import zarr
 from insitubatch import (
     SplitManifest,
     SplitName,
-    obstore_store,
     open_geometries,
     split_by_chunk,
 )
 from insitubatch.source import InSituDataset
 from insitubatch.types import ArrayGeometry
 
+from .backend import build_store
 from .result import Result, peak_rss_mb, rss_breakdown_mb
 
 
@@ -41,8 +41,9 @@ from .result import Result, peak_rss_mb, rss_breakdown_mb
 class Cfg:
     engine: str
     url: str
-    storage: str  # file | s3
+    storage: str  # file | s3 | gs
     sample_chunk: int  # for the JSONL row (the dataset's chunk size)
+    backend: str = "obstore"  # obstore | fsspec | arraylake -- the store to read through
     var: str = "t2m"
     batch_size: int = 32
     block_chunks: int = 16
@@ -96,6 +97,7 @@ def _result(
         engine=cfg.engine,
         cache=cfg.cache,
         storage=cfg.storage,
+        backend=cfg.backend,
         sample_chunk=cfg.sample_chunk,
         n_samples=n,
         epoch=epoch,
@@ -118,7 +120,15 @@ def run(
     cfg: Cfg, *, cache_dir: str | None = None, store_kwargs: dict | None = None
 ) -> list[Result]:
     store_kwargs = store_kwargs or {}
-    geom = open_geometries(obstore_store(cfg.url, **store_kwargs))[cfg.var]
+    # Each engine builds its own store from (backend, url, store_kwargs) rather than
+    # being handed this live Store. That's deliberate, not an oversight: the workers /
+    # xbatcher baselines pickle their dataset to child processes (forkserver/spawn --
+    # obstore's Rust runtime and gcsfs sessions aren't fork-safe), so they *must*
+    # reconstruct the store inside each worker; a live Store can't cross that boundary.
+    # Passing a store would serve only the in-process engines and split the interface
+    # in two while still keeping these args on Cfg -- so we keep one construction path.
+    # The store object is cheap (lazy; no IO until first read, and gcsfs caches the fs).
+    geom = open_geometries(build_store(cfg.backend, cfg.url, **store_kwargs))[cfg.var]
     manifest = split_by_chunk(geom, fractions=(0.8, 0.1, 0.1))
     engines = {
         "insitu": _run_insitu,
@@ -153,7 +163,7 @@ def _run_insitu(
         budget = (n_train + 2) * per_chunk  # hold every train chunk + a margin
         cdir = cache_dir
     ds = InSituDataset(
-        obstore_store(cfg.url, **store_kwargs),
+        build_store(cfg.backend, cfg.url, **store_kwargs),
         manifest,
         geometries={cfg.var: geom},
         batch_size=cfg.batch_size,
@@ -182,7 +192,9 @@ def _run_naive(
     cache_dir: str | None,
     store_kwargs: dict,
 ) -> list[Result]:
-    arr = zarr.open_array(store=obstore_store(cfg.url, **store_kwargs), path=cfg.var, mode="r")
+    arr = zarr.open_array(
+        store=build_store(cfg.backend, cfg.url, **store_kwargs), path=cfg.var, mode="r"
+    )
     spc = geom.sample_chunk_size
 
     def batches() -> Iterator[np.ndarray]:
@@ -204,7 +216,9 @@ def _run_memory(
     cache_dir: str | None,
     store_kwargs: dict,
 ) -> list[Result]:
-    arr = zarr.open_array(store=obstore_store(cfg.url, **store_kwargs), path=cfg.var, mode="r")
+    arr = zarr.open_array(
+        store=build_store(cfg.backend, cfg.url, **store_kwargs), path=cfg.var, mode="r"
+    )
     full = np.asarray(arr[:])
     idx0 = manifest.sample_indices(SplitName.TRAIN, geom)
     out = []
@@ -227,7 +241,10 @@ class _SampleReader:
     opening its own zarr handle per worker. Must be top-level (not a closure) so
     it pickles to DataLoader worker processes under the `spawn` start method."""
 
-    def __init__(self, url: str, var: str, idx: np.ndarray, store_kwargs: dict) -> None:
+    def __init__(
+        self, backend: str, url: str, var: str, idx: np.ndarray, store_kwargs: dict
+    ) -> None:
+        self.backend = backend
         self.url = url
         self.var = var
         self.idx = idx
@@ -240,7 +257,9 @@ class _SampleReader:
     def __getitem__(self, i: int) -> np.ndarray:
         if self._arr is None:
             self._arr = zarr.open_array(
-                store=obstore_store(self.url, **self.store_kwargs), path=self.var, mode="r"
+                store=build_store(self.backend, self.url, **self.store_kwargs),
+                path=self.var,
+                mode="r",
             )
         return np.asarray(self._arr[int(self.idx[i])])
 
@@ -281,7 +300,7 @@ def _run_workers(
     # DataLoader accepts it at runtime; cast(Any) satisfies the stub (which wants a Dataset)
     # without a `type: ignore` that flips to "unused" when torch (its stub) isn't installed.
     loader: DataLoader = DataLoader(
-        cast(Any, _SampleReader(cfg.url, cfg.var, idx, store_kwargs)),
+        cast(Any, _SampleReader(cfg.backend, cfg.url, cfg.var, idx, store_kwargs)),
         batch_size=cfg.batch_size,
         num_workers=cfg.num_workers,
         shuffle=cfg.shuffle,
@@ -309,7 +328,8 @@ def _run_xbatcher(
     from torch.utils.data import DataLoader
     from xbatcher.loaders.torch import MapDataset
 
-    da = xr.open_zarr(obstore_store(cfg.url, **store_kwargs), consolidated=False)[cfg.var]
+    store = build_store(cfg.backend, cfg.url, **store_kwargs)
+    da = xr.open_zarr(store, consolidated=False)[cfg.var]
     da = da.isel({da.dims[0]: manifest.sample_indices(SplitName.TRAIN, geom)})
     # one timestep per sample (full inner dims); the DataLoader collates batch_size.
     input_dims = {da.dims[0]: 1, **{d: int(da.sizes[d]) for d in da.dims[1:]}}

--- a/bench/make_dataset.py
+++ b/bench/make_dataset.py
@@ -20,7 +20,7 @@ from typing import Literal
 import numpy as np
 import zarr
 
-from insitubatch.store import ensure_local_dir, obstore_store
+from insitubatch.store import ensure_local_dir, fsspec_store, obstore_store
 
 
 def make_dataset(
@@ -36,6 +36,7 @@ def make_dataset(
     write_batch_mb: int = 1024,
     write_concurrency: int = 32,
     s3_express: bool = False,
+    backend: str = "obstore",
 ) -> None:
     """Write a ``(n_samples, *inner)`` array per variable, chunked along axis 0.
 
@@ -56,10 +57,14 @@ def make_dataset(
     if len(inner_chunks) != len(inner):
         raise ValueError(f"inner_chunks {inner_chunks} must match inner dims {inner}")
     ensure_local_dir(url)
-    # S3 Express One Zone (directory buckets, --x-s3): obstore needs s3_express=True;
-    # it is NOT inferred from the bucket name. (env equivalent: AWS_S3_EXPRESS=true)
-    store_kwargs = {"s3_express": True} if s3_express else {}
-    store = obstore_store(url, read_only=False, **store_kwargs)
+    # fsspec/gcsfs is the only writer that reaches GCS Rapid/zonal (gRPC); obstore is the
+    # default and the S3 writer. (arraylake sessions are read-only, so it can't write here.)
+    if backend == "fsspec":
+        store = fsspec_store(url, read_only=False)
+    else:
+        # S3 Express One Zone (directory buckets, --x-s3): obstore needs s3_express=True;
+        # it is NOT inferred from the bucket name. (env equivalent: AWS_S3_EXPRESS=true)
+        store = obstore_store(url, read_only=False, **({"s3_express": True} if s3_express else {}))
     group = zarr.open_group(store=store, mode="w")
     rng = np.random.default_rng(seed)
     chunks = (sample_chunk, *inner_chunks)
@@ -155,6 +160,12 @@ def main() -> None:
     p.add_argument(
         "--s3-express", action="store_true", help="target an S3 Express One Zone directory bucket"
     )
+    p.add_argument(
+        "--backend",
+        default="obstore",
+        choices=["obstore", "fsspec"],
+        help="write store: obstore (default, S3/standard-GCS) or fsspec/gcsfs (GCS Rapid/zonal)",
+    )
     a = p.parse_args()
 
     sample_chunk = (
@@ -172,6 +183,7 @@ def main() -> None:
         write_batch_mb=a.write_batch_mb,
         write_concurrency=a.write_concurrency,
         s3_express=a.s3_express,
+        backend=a.backend,
     )
 
 

--- a/bench/make_dataset.py
+++ b/bench/make_dataset.py
@@ -20,7 +20,7 @@ from typing import Literal
 import numpy as np
 import zarr
 
-from insitubatch.store import ensure_local_dir, store_from_url
+from insitubatch.store import ensure_local_dir, obstore_store
 
 
 def make_dataset(
@@ -59,7 +59,7 @@ def make_dataset(
     # S3 Express One Zone (directory buckets, --x-s3): obstore needs s3_express=True;
     # it is NOT inferred from the bucket name. (env equivalent: AWS_S3_EXPRESS=true)
     store_kwargs = {"s3_express": True} if s3_express else {}
-    store = store_from_url(url, read_only=False, **store_kwargs)
+    store = obstore_store(url, read_only=False, **store_kwargs)
     group = zarr.open_group(store=store, mode="w")
     rng = np.random.default_rng(seed)
     chunks = (sample_chunk, *inner_chunks)

--- a/bench/ops_aws.md
+++ b/bench/ops_aws.md
@@ -36,10 +36,10 @@ reproduce the benchmark paying only their own egress.
   Requester-Pays bucket. "Public" here means **any authenticated AWS account** can
   read, and **the reader pays** their own GET + egress; the bucket owner pays
   storage only. Reproducers need an AWS account (which they need for EC2 anyway).
-- **obstore supports it.** External readers pass `request_payer=True`, which flows
-  through `store_from_url(...)` / `InSituDataset(..., request_payer=True)`. The
-  bucket **owner** is *not* charged and does not need the flag for their own
-  reads/writes on their own bucket.
+- **obstore supports it.** External readers pass `request_payer=True` to the store
+  constructor: `obstore_store("s3://…", request_payer=True)`, then hand the store to
+  `InSituDataset(store, ...)`. The bucket **owner** is *not* charged and does not need
+  the flag for their own reads/writes on their own bucket.
 - **Co-locate** bucket and instance in `us-east-1`. Cross-region egress is slow
   and billed.
 

--- a/bench/ops_gcp.md
+++ b/bench/ops_gcp.md
@@ -261,6 +261,91 @@ faster floor.
 > Rapid `storage_options`, and the measured numbers all need checking on the live box before
 > they mean anything. Treat provisioning below as an experiment plan, not a settled runbook.
 
+### 7a — Standard-GCS A/B (obstore vs fsspec): run this first
+
+Before Rapid, establish that fsspec is **not a regression on standard GCS** — the
+prerequisite for co-equal status, and the same harness you re-point at the Rapid bucket
+below. Runnable on any box (recipe validated on an `n2-standard-8` with a 375 GB local SSD
+at `/mnt/nvme`). The one box limit that matters here is **decode saturation** (few cores →
+the full pipeline goes decode-bound, which is backend-invariant and *hides* the fetch
+difference), so the sharpest backend signal is the **decode-free raw GET** (`probe_decode`
+section 2). The **ChunkPool cache is post-decode and backend-invariant** — obstore and
+fsspec share the same decoded bytes — so it does *not* discriminate the backends; the NVMe
+is used to (a) run the end-to-end suite as designed (mmap tier, not a RAM-only degraded
+mode) and (b) measure the decode-once ceiling (cold vs warm, `probe_decode` §1c), which
+tells you whether you are fetch-bound enough for the backend to matter at all. **Gotcha:**
+a cache is keyed by chunk, not by backend, so never point both backends at the *same*
+`--cache-dir` — the second run would hit the first's decoded chunks and measure the cache,
+not its own reads. The discriminating A/B (Step 1) is therefore cache-free; cached runs use
+a fresh per-backend dir.
+
+`probe_decode` prints human-readable tables → capture as `.log`; the `bench` suite writes
+JSONL natively → `--out …jsonl`. All logs land in `bench/results/`.
+
+```bash
+export PREFIX="gs://$BUCKET/era5"          # the _c{spc}.zarr family from §6
+export NVME=/mnt/nvme                      # the local SSD (fixed at 1 drive for this class)
+mkdir -p bench/results "$NVME/insitu-cache"
+{ hostname; nproc; date -u; } | tee bench/results/BOX.txt   # stamp the hardware
+
+# Step 0 — characterize THIS box (don't trust the spec sheet). One obstore run gives:
+#   section 1  = where decode saturates on your cores;
+#   section 1c = the decode-once ceiling (cold vs warm epoch off NVMe) -> if warm >> cold
+#                you're fetch/decode-bound (backend can matter); if warm ~= cold, delivery-bound;
+#   section 2  = the NIC ceiling (where raw-GET MB/s stops rising).
+uv run python -m bench.probe_decode --url "${PREFIX}_c8.zarr" --backend obstore \
+  --max-chunks 64 --repeats 3 --decode-threads 1,2,4,8,0 \
+  --concurrency 4,8,16,32,64 --max-inflight 32 --cache-dir "$NVME/insitu-cache/calib" \
+  2>&1 | tee bench/results/probe_calib_obstore_c8.log
+
+# Step 1 — the A/B: raw transfer floor (section 2) + bridge scaling (section 1b), both
+#   backends, grib->mid->fat. The grib end (c1) is the discriminating case (per-request Python cost).
+for BK in obstore fsspec; do
+  for SPC in 1 4 16; do
+    uv run python -m bench.probe_decode --url "${PREFIX}_c${SPC}.zarr" --backend "$BK" \
+      --max-chunks 128 --repeats 3 --no-decode-sweep \
+      --max-inflight 8,16,32 --concurrency 4,8,16,32 \
+      2>&1 | tee "bench/results/probe_${BK}_c${SPC}.log"
+  done
+done
+
+# Step 1b (optional sharpener) — pure request-rate: tiny objects, all per-call overhead,
+#   no bandwidth. Where obstore's Rust path would win most, if anywhere.
+uv run python bench/make_dataset.py --url "gs://$BUCKET/tiny_c1.zarr" \
+  --n-samples 4000 --inner 64,64 --sample-chunk 1 --variables t2m
+for BK in obstore fsspec; do
+  uv run python -m bench.probe_decode --url "gs://$BUCKET/tiny_c1.zarr" --backend "$BK" \
+    --max-chunks 256 --repeats 3 --no-decode-sweep --max-inflight 16,32 --concurrency 8,16,32 \
+    2>&1 | tee "bench/results/probe_${BK}_tiny.log"
+done
+
+# Step 2 — end-to-end confirmation, mmap cache tier on NVMe. Fresh per-backend cache dir
+#   (never shared — see the gotcha above) so each backend's reads are its own.
+for BK in obstore fsspec; do
+  uv run python -m bench --url-prefix "$PREFIX" --backend "$BK" \
+    --chunk-sizes 1,2,4,8,16,32 --engines insitu,naive --repeats 3 --max-batches 100 \
+    --cache-dir "$NVME/insitu-cache/e2e_${BK}" \
+    --out "bench/results/gcs_e2e_${BK}.jsonl"
+done
+```
+
+**Read it:** fsspec earns co-equal *on standard GCS* if raw-GET (Step 1 section 2, read
+*below* your Step-0 NIC ceiling — especially c1/tiny) is within ~10–15 % of obstore, the
+section-1b curves don't flatten fsspec early (the cross-loop bridge isn't throttling), and
+end-to-end insitu tracks obstore. A large c1/tiny raw-GET gap is the one red flag (the
+per-request Python tax). This proves *not a regression* — **not** the Rapid win, which
+needs the gRPC bucket below (DESIGN.md M-GCS).
+
+> **Sustained-rate caveat — big-chunk raw-GET reads low, for *both* backends.** `--max-chunks`
+> fixes the *object count*, so a larger `sample-chunk` moves proportionally more bytes per
+> point (single-inner-chunk: c16 ≈ 16× the bytes of c1). Those points therefore measure
+> **sustained** throughput after GCP/GCS burst credits deplete, not the **burst** rate the
+> small-chunk points catch — so a dip in MB/s at c16/c32 is this byte-volume artifact, *not*
+> a backend effect (it hits obstore and fsspec equally). The verdict is the **gap between
+> backends at a fixed chunk size**, which is invariant to it. To make per-chunk-size points
+> directly comparable, hold bytes ~constant by scaling `--max-chunks` *down* as chunk size
+> rises (e.g. 128 at c1 → 8 at c16).
+
 Open questions to resolve first:
 
 - **gcsfs Rapid `storage_options`.** How gcsfs is told to use the zonal gRPC endpoint (an

--- a/bench/ops_gcp.md
+++ b/bench/ops_gcp.md
@@ -89,13 +89,15 @@ gcloud storage buckets add-iam-policy-binding "gs://$BUCKET" \
 gcloud storage buckets update "gs://$BUCKET" --requester-pays
 ```
 
-> **Do not run this on the bench bucket yet.** obstore 0.10.1 has no GCS billing-project
-> config (verified: `GCSConfig` carries auth options like `skip_signature` / `service_account`
-> but no `user_project`), and GCS — unlike S3 — grants the owner **no** Requester-Pays exemption.
-> So enabling it breaks *your own* GCE bench reads too, not just external reproducers, with
-> `... is a requester pays bucket but no user project provided`. There is no `request_payer`
-> equivalent to pass through `store_from_url` for `gs://`. Until obstore gains a GCS
-> user-project knob, anonymous-public (above) is the one working path.
+> **obstore cannot read Requester-Pays GCS; use `fsspec_store` instead.** obstore 0.10.1 has
+> no GCS billing-project config (verified: `GCSConfig` carries auth options like
+> `skip_signature` / `service_account` but no `user_project`), and GCS — unlike S3 — grants
+> the owner **no** Requester-Pays exemption, so enabling it breaks *your own* GCE bench reads
+> too (`... is a requester pays bucket but no user project provided`). The path is
+> `insitubatch.fsspec_store` (gcsfs), which forwards a billing project via `storage_options`:
+> `fsspec_store("gs://bucket/ds.zarr", project="my-billing-project", requester_pays=True)`.
+> obstore stays the default for non-Requester-Pays reads; anonymous-public (above) needs no
+> billing project on either backend.
 
 ## 3. Service account + bucket access
 
@@ -234,31 +236,38 @@ uv run python -m bench --full --url-prefix "gs://$BUCKET/era5" \
   --cache-dir /mnt/nvme/cache
 ```
 
-obstore reads `gs://` through the same `store_from_url` shim; credentials come from the
-instance service account (Application Default Credentials) automatically. A public reader on
-another account passes `skip_signature=True` instead — **VERIFY** the kwarg name flows
-through `make_dataset`/`open_geometries` for `gs://` as it does for the WB2 example.
+obstore reads `gs://` through `obstore_store`; credentials come from the instance service
+account (Application Default Credentials) automatically. A public reader on another account
+passes `skip_signature=True` instead — **VERIFY** the kwarg name flows through
+`make_dataset`/`open_geometries` for `gs://` as it does for the WB2 example. For Rapid/zonal or
+Requester-Pays buckets, build the store with `fsspec_store` (gcsfs) instead — see §7 and §2.
 
-## 7. Rapid Storage (gRPC) — the obstore high-performance experiment
+## 7. Rapid Storage (gRPC) — the fsspec/gcsfs high-performance experiment
 
-**Goal:** test obstore against **Google Cloud Rapid Storage** — a *zonal* GCS bucket served
-over the high-throughput **gRPC** Cloud Storage API (the GCS analogue of S3 Express One Zone).
-The open question is whether obstore (via Rust `object_store`) can drive the gRPC endpoint at
-all, and if so how close it gets to the raw-GET ceiling — exactly the story-4 efficiency
-measurement, on a faster floor.
+**Goal:** test **Google Cloud Rapid Storage** — a *zonal* GCS bucket served over the
+high-throughput **gRPC** Cloud Storage API (the GCS analogue of S3 Express One Zone) — as an
+insitubatch read path. The measurement is the story-4 raw-GET-vs-decoded efficiency, on a
+faster floor.
 
-> **All of this section is UNVERIFIED.** Rapid Storage is new and the exact `gcloud` flags,
-> the gRPC endpoint wiring, and obstore's gRPC support all need checking before the numbers
-> mean anything. Treat it as an experiment plan, not a runbook.
+> **Backend: gcsfs, not obstore.** Rust `object_store` (obstore) speaks GCS over HTTPS/JSON
+> only — it has no gRPC path — so it cannot drive the Rapid endpoint. gcsfs *does* (it has
+> dedicated Rapid/zonal support: True Appends over gRPC BidiWriteObject, streaming I/O). The
+> read path is therefore `insitubatch.fsspec_store("gs://…", …)` (zarr `FsspecStore` over
+> gcsfs), which is exactly why fsspec_store exists. The headline experiment is **fsspec-over-
+> gcsfs on Rapid vs obstore-over-HTTP on standard GCS** — does zonal gRPC beat the raw-GET
+> ceiling enough to justify fsspec as a co-equal fast path (see DESIGN.md M-GCS)?
+
+> **Still UNVERIFIED end-to-end.** Rapid Storage is new; the exact `gcloud` flags, the gcsfs
+> Rapid `storage_options`, and the measured numbers all need checking on the live box before
+> they mean anything. Treat provisioning below as an experiment plan, not a settled runbook.
 
 Open questions to resolve first:
 
-- **Does obstore/`object_store` speak the GCS gRPC API?** The S3-Express win came for free
-  because it is still the S3 HTTP API; GCS gRPC is a *different protocol*. If `object_store`
-  is HTTPS/JSON-only for GCS, this needs an obstore feature or a different client — confirm
-  before provisioning.
-- **Endpoint selection.** How obstore is told to use the gRPC endpoint (a URL scheme, a store
-  kwarg, or an env var) is **VERIFY** — there may be no hook yet.
+- **gcsfs Rapid `storage_options`.** How gcsfs is told to use the zonal gRPC endpoint (an
+  endpoint override, a bucket-type flag, or automatic on a Rapid bucket) is **VERIFY** —
+  confirm against the gcsfs Rapid docs, then thread it through `fsspec_store(...)`.
+- **Write path.** `bench/make_dataset.py` writes via `obstore_store` (HTTP); confirm whether it
+  must switch to gcsfs to *populate* a Rapid bucket, or whether HTTP writes + gRPC reads work.
 
 Provisioning sketch (**VERIFY** every flag against current docs — Rapid Storage requires a
 zonal location and hierarchical namespace):

--- a/bench/probe_decode.py
+++ b/bench/probe_decode.py
@@ -44,16 +44,26 @@ import zarr
 
 from insitubatch import SplitManifest, SplitName, open_geometries, split_by_chunk
 from insitubatch.source import InSituDataset
-from insitubatch.store import obstore_store
 
 from ._profile import record_pyspy
+from .backend import build_store
 from .make_dataset import make_dataset
 
 
-def _store_kwargs(url: str, anon: bool, request_payer: bool, s3_express: bool) -> dict:
+def _store_kwargs(
+    url: str, backend: str, anon: bool, request_payer: bool, s3_express: bool
+) -> dict:
+    """Backend-specific store kwargs. ``--anon`` must be explicit: an owned (private)
+    GCS bucket reads with ambient credentials, so gs:// is not forced anonymous."""
     kw: dict = {}
-    if anon or url.startswith("gs://"):
-        kw["skip_signature"] = True
+    if backend == "fsspec":
+        if anon:
+            kw["token"] = "anon"  # gcsfs anonymous read of a public bucket
+        if request_payer:
+            kw["requester_pays"] = True
+        return kw
+    if anon:
+        kw["skip_signature"] = True  # obstore anonymous read
     if request_payer:
         kw["request_payer"] = True
     if s3_express:  # S3 Express One Zone directory bucket (--x-s3); not inferred from the name
@@ -78,6 +88,7 @@ def _insitu(
     block_chunks: int = 2,
     max_inflight: int = 32,
     window: int = 0,
+    backend: str = "obstore",
 ) -> tuple[float, int]:
     """One insitu pass over the first ``max_chunks`` chunks; (MB/s, peak resident chunks).
 
@@ -91,8 +102,12 @@ def _insitu(
     most exposed at the GRIB end (one sample/chunk = max chunk-rate = max pin/unpin/lock
     churn) and under free-threading. MB/s counts the anchor-input bytes either way, so
     the windowing machinery's overhead shows as a drop at equal anchor rate.
+
+    ``backend`` selects the store (obstore | fsspec) so the max_inflight sweep can be
+    run on either -- fsspec routes its reads through zarr's loop (the cross-loop fix),
+    so this is where any bridge overhead at high concurrency would surface.
     """
-    store = obstore_store(url, **kw)
+    store = build_store(backend, url, **kw)
     geom = open_geometries(store, variables=[var])[var]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     geoms = {var: geom}
@@ -120,10 +135,12 @@ def _insitu(
     return n * bps / 1e6 / dt, ds.resident_peak
 
 
-def _insitu_mb(url: str, var: str, kw: dict[str, Any], **opts: int) -> float:
+def _insitu_mb(
+    url: str, var: str, kw: dict[str, Any], *, backend: str = "obstore", **opts: int
+) -> float:
     """Just the MB/s of an :func:`_insitu` pass -- a typed target for ``partial`` in
     the ``show`` sweeps (a ``lambda x=x:`` loop-capture defeats mypy inference)."""
-    return _insitu(url, var, kw, **opts)[0]
+    return _insitu(url, var, kw, backend=backend, **opts)[0]
 
 
 def _insitu_cache(
@@ -134,6 +151,7 @@ def _insitu_cache(
     max_chunks: int,
     block_chunks: int,
     cache_dir: str,
+    backend: str = "obstore",
 ) -> tuple[float, float]:
     """Two epochs over the first ``max_chunks`` chunks with a budget that holds them
     all; returns (cold MB/s, warm MB/s). The manifest is restricted to exactly those
@@ -141,7 +159,7 @@ def _insitu_cache(
     then served entirely from the cache (no S3, no decode). ``cache_dir`` spills the
     slots to NVMe (mmap); pass it to keep heap bounded on fat data.
     """
-    store = obstore_store(url, **kw)
+    store = build_store(backend, url, **kw)
     geom = open_geometries(store, variables=[var])[var]
     full = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     train = full.chunks[SplitName.TRAIN.value][:max_chunks]
@@ -180,17 +198,18 @@ def _insitu_cache(
 
 
 def _raw_get_mb_s(
-    url: str, var: str, kw: dict[str, Any], concurrency: int, max_chunks: int
+    url: str, var: str, kw: dict[str, Any], concurrency: int, max_chunks: int, backend: str
 ) -> float:
-    """Fetch raw (still-encoded) chunk objects via obstore — no decode.
+    """Fetch raw (still-encoded) chunk objects — no decode, no engine — as the pure
+    transfer-stack floor. ``backend`` picks the fetcher: obstore's Rust GET or a
+    concurrent gcsfs ``cat_file``. Comparing the two is the cleanest "what does the
+    Python fsspec layer cost" number, isolated from decode/gather/loop.
 
-    Enumerates the *real* stored-chunk grid (outer x inner) from the array's
-    chunks, so it's correct for spatially-chunked arrays (not just single inner
-    chunk). max_chunks bounds the number of OUTER chunks; every inner chunk under
-    them is fetched.
+    Enumerates the *real* stored-chunk grid (outer x inner) from the array's chunks, so
+    it's correct for spatially-chunked arrays. max_chunks bounds the number of OUTER
+    chunks; every inner chunk under them is fetched, concurrency threads at a time.
     """
-    arr = zarr.open_array(store=obstore_store(url, **kw), path=var, mode="r")  # sync; for chunks
-    obs = obstore.store.from_url(url, **kw)
+    arr = zarr.open_array(store=build_store(backend, url, **kw), path=var, mode="r")  # for chunks
     n_outer = min(max_chunks, math.ceil(arr.shape[0] / arr.chunks[0]))
     inner_ranges = [
         range(math.ceil(s / c)) for s, c in zip(arr.shape[1:], arr.chunks[1:], strict=True)
@@ -201,8 +220,23 @@ def _raw_get_mb_s(
         for inner in itertools.product(*inner_ranges)
     ]
 
-    def fetch(key: str) -> int:
-        return len(bytes(obstore.get(obs, key).bytes()))
+    if backend == "fsspec":
+        import fsspec
+
+        proto, _, rest = url.partition("://")
+        root = rest.rstrip("/")
+        # A dedicated *sync* fs (own session on fsspec's loop), separate from the async
+        # zarr store above -- so the thread pool drives concurrent cat_file without the
+        # cross-loop session sharing that trips the engine path.
+        raw_fs = fsspec.filesystem(proto, **kw)
+
+        def fetch(key: str) -> int:
+            return len(raw_fs.cat_file(f"{root}/{key}"))
+    else:
+        obs = obstore.store.from_url(url, **kw)
+
+        def fetch(key: str) -> int:
+            return len(bytes(obstore.get(obs, key).bytes()))
 
     t = time.perf_counter()
     with ThreadPoolExecutor(max_workers=concurrency) as ex:
@@ -216,6 +250,12 @@ def main() -> None:
     )
     p.add_argument("--url", default=None, help="zarr URL; default = synthetic file://")
     p.add_argument("--var", default="t2m")
+    p.add_argument(
+        "--backend",
+        default="obstore",
+        choices=["obstore", "fsspec"],
+        help="store backend for the fetch-sensitive sections (1b, 2): obstore or fsspec/gcsfs",
+    )
     p.add_argument("--max-chunks", type=int, default=64, help="chunks to probe (bounds the cost)")
     p.add_argument("--repeats", type=int, default=3, help="runs per point; report median (min-max)")
     p.add_argument("--decode-threads", default="1,2,4,8,0", help="sec 1 sweep (0=auto)")
@@ -276,8 +316,8 @@ def main() -> None:
         a.url = f"file://{tmp}/era5.zarr"
         a.var = "t2m"
         make_dataset(a.url, n_samples=512, inner=(721, 1440), sample_chunk=8, variables=["t2m"])
-    kw = _store_kwargs(a.url, a.anon, a.request_payer, a.s3_express)
-    print(f"probe {a.url}  var={a.var}  first {a.max_chunks} chunks\n")
+    kw = _store_kwargs(a.url, a.backend, a.anon, a.request_payer, a.s3_express)
+    print(f"probe {a.url}  var={a.var}  backend={a.backend}  first {a.max_chunks} chunks\n")
 
     def show(label: str, fn: Callable[[], float]) -> None:
         med, lo, hi = _stats(fn, a.repeats)
@@ -302,6 +342,7 @@ def main() -> None:
                 block_chunks=bc,
                 max_inflight=mi_warm,
                 window=a.window,
+                backend=a.backend,
             )
         except Exception as exc:  # noqa: BLE001 - prewarm is best-effort
             print(f"   prewarm failed: {type(exc).__name__}: {exc}")
@@ -324,6 +365,7 @@ def main() -> None:
                     max_chunks=a.max_chunks,
                     block_chunks=bc,
                     window=a.window,
+                    backend=a.backend,
                 ),
             )
 
@@ -342,6 +384,7 @@ def main() -> None:
                     block_chunks=bc,
                     max_inflight=mi,
                     window=a.window,
+                    backend=a.backend,
                 )
                 for _ in range(a.repeats)
             )
@@ -355,15 +398,25 @@ def main() -> None:
     if a.cache_dir:
         print(f"\n1c) cross-epoch cache ({a.max_chunks} chunks, budget holds all, mmap):")
         cold, warm = _insitu_cache(
-            a.url, a.var, kw, max_chunks=a.max_chunks, block_chunks=bc, cache_dir=a.cache_dir
+            a.url,
+            a.var,
+            kw,
+            max_chunks=a.max_chunks,
+            block_chunks=bc,
+            cache_dir=a.cache_dir,
+            backend=a.backend,
         )
         print(f"   epoch 0 (cold):   {cold:8.1f} MB/s")
         print(f"   epoch 1 (cached): {warm:8.1f} MB/s   ({warm / cold:.1f}x cold)")
 
     if not a.no_raw:
-        print("\n2) raw obstore concurrent GET MB/s (no decode):")
+        fetcher = "gcsfs cat_file" if a.backend == "fsspec" else "obstore GET"
+        print(f"\n2) raw concurrent {fetcher} MB/s (no decode):")
         for c in (int(x) for x in a.concurrency.split(",")):
-            show(f"concurrency={c:>2}", partial(_raw_get_mb_s, a.url, a.var, kw, c, a.max_chunks))
+            show(
+                f"concurrency={c:>2}",
+                partial(_raw_get_mb_s, a.url, a.var, kw, c, a.max_chunks, a.backend),
+            )
 
     if tmp:
         none_url = f"file://{tmp}/era5_none.zarr"

--- a/bench/probe_decode.py
+++ b/bench/probe_decode.py
@@ -92,20 +92,20 @@ def _insitu(
     churn) and under free-threading. MB/s counts the anchor-input bytes either way, so
     the windowing machinery's overhead shows as a drop at equal anchor rate.
     """
-    geom = open_geometries(obstore_store(url), variables=[var], **kw)[var]
+    store = obstore_store(url, **kw)
+    geom = open_geometries(store, variables=[var])[var]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     geoms = {var: geom}
     for k in range(1, window + 1):
         geoms[f"{var}_t{k}"] = geom.shift(k)
     ds = InSituDataset(
-        obstore_store(url),
+        store,
         manifest,
         geometries=geoms,
         batch_size=16,
         block_chunks=block_chunks,
         max_inflight=max_inflight,
         shuffle=False,
-        **kw,
     )
     ds.scheduler_config.decode_threads = decode_threads  # read by the scheduler at iteration time
     bps = int(np.prod(geom.inner_shape)) * 4
@@ -141,7 +141,8 @@ def _insitu_cache(
     then served entirely from the cache (no S3, no decode). ``cache_dir`` spills the
     slots to NVMe (mmap); pass it to keep heap bounded on fat data.
     """
-    geom = open_geometries(obstore_store(url), variables=[var], **kw)[var]
+    store = obstore_store(url, **kw)
+    geom = open_geometries(store, variables=[var])[var]
     full = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     train = full.chunks[SplitName.TRAIN.value][:max_chunks]
     manifest = SplitManifest(
@@ -154,7 +155,7 @@ def _insitu_cache(
     outer_nbytes = geom.sample_chunk_size * int(np.prod(geom.inner_shape)) * geom.dtype.itemsize
     budget = (len(train) + 2) * outer_nbytes  # hold every probed chunk + a margin
     ds = InSituDataset(
-        obstore_store(url),
+        store,
         manifest,
         geometries={var: geom},
         batch_size=16,
@@ -162,7 +163,6 @@ def _insitu_cache(
         shuffle=False,
         cache_dir=cache_dir,
         cache_budget_bytes=budget,
-        **kw,
     )
     bps = int(np.prod(geom.inner_shape)) * 4
 

--- a/bench/probe_decode.py
+++ b/bench/probe_decode.py
@@ -44,7 +44,7 @@ import zarr
 
 from insitubatch import SplitManifest, SplitName, open_geometries, split_by_chunk
 from insitubatch.source import InSituDataset
-from insitubatch.store import store_from_url
+from insitubatch.store import obstore_store
 
 from ._profile import record_pyspy
 from .make_dataset import make_dataset
@@ -92,13 +92,13 @@ def _insitu(
     churn) and under free-threading. MB/s counts the anchor-input bytes either way, so
     the windowing machinery's overhead shows as a drop at equal anchor rate.
     """
-    geom = open_geometries(url, variables=[var], **kw)[var]
+    geom = open_geometries(obstore_store(url), variables=[var], **kw)[var]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     geoms = {var: geom}
     for k in range(1, window + 1):
         geoms[f"{var}_t{k}"] = geom.shift(k)
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         geometries=geoms,
         batch_size=16,
@@ -141,7 +141,7 @@ def _insitu_cache(
     then served entirely from the cache (no S3, no decode). ``cache_dir`` spills the
     slots to NVMe (mmap); pass it to keep heap bounded on fat data.
     """
-    geom = open_geometries(url, variables=[var], **kw)[var]
+    geom = open_geometries(obstore_store(url), variables=[var], **kw)[var]
     full = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     train = full.chunks[SplitName.TRAIN.value][:max_chunks]
     manifest = SplitManifest(
@@ -154,7 +154,7 @@ def _insitu_cache(
     outer_nbytes = geom.sample_chunk_size * int(np.prod(geom.inner_shape)) * geom.dtype.itemsize
     budget = (len(train) + 2) * outer_nbytes  # hold every probed chunk + a margin
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         geometries={var: geom},
         batch_size=16,
@@ -189,7 +189,7 @@ def _raw_get_mb_s(
     chunk). max_chunks bounds the number of OUTER chunks; every inner chunk under
     them is fetched.
     """
-    arr = zarr.open_array(store=store_from_url(url, **kw), path=var, mode="r")  # sync; for chunks
+    arr = zarr.open_array(store=obstore_store(url, **kw), path=var, mode="r")  # sync; for chunks
     obs = obstore.store.from_url(url, **kw)
     n_outer = min(max_chunks, math.ceil(arr.shape[0] / arr.chunks[0]))
     inner_ranges = [

--- a/bench/probe_decode.py
+++ b/bench/probe_decode.py
@@ -25,6 +25,7 @@ it's the network/endpoint (more/bigger parallel streams, in-region S3, the gatew
 from __future__ import annotations
 
 import argparse
+import asyncio
 import atexit
 import contextlib
 import itertools
@@ -42,7 +43,7 @@ import numpy as np
 import obstore
 import zarr
 
-from insitubatch import SplitManifest, SplitName, open_geometries, split_by_chunk
+from insitubatch import SplitManifest, SplitName, close_store, open_geometries, split_by_chunk
 from insitubatch.source import InSituDataset
 
 from ._profile import record_pyspy
@@ -69,6 +70,21 @@ def _store_kwargs(
     if s3_express:  # S3 Express One Zone directory bucket (--x-s3); not inferred from the name
         kw["s3_express"] = True
     return kw
+
+
+def _close_fsspec_session(fs: Any) -> None:
+    """Close a gcsfs aiohttp session on the loop it lives on, so gcsfs's finalizer --
+    which captures ``self.loop`` (None here) and otherwise closes on the wrong loop at
+    GC -- becomes a no-op. Silences the "Task was destroyed / different loop" teardown
+    traceback. Best-effort: guarded for non-gcsfs backends and already-closed sessions.
+    """
+    sess = getattr(fs, "_session", None)
+    loop = getattr(sess, "_loop", None)
+    if sess is None or loop is None or sess.closed or not loop.is_running():
+        return
+    with contextlib.suppress(Exception):
+        asyncio.run_coroutine_threadsafe(sess.close(), loop).result(timeout=5)
+        fs._session = None
 
 
 def _stats(fn: Callable[[], float], repeats: int) -> tuple[float, float, float]:
@@ -209,7 +225,8 @@ def _raw_get_mb_s(
     it's correct for spatially-chunked arrays. max_chunks bounds the number of OUTER
     chunks; every inner chunk under them is fetched, concurrency threads at a time.
     """
-    arr = zarr.open_array(store=build_store(backend, url, **kw), path=var, mode="r")  # for chunks
+    meta_store = build_store(backend, url, **kw)
+    arr = zarr.open_array(store=meta_store, path=var, mode="r")  # for the chunk grid
     n_outer = min(max_chunks, math.ceil(arr.shape[0] / arr.chunks[0]))
     inner_ranges = [
         range(math.ceil(s / c)) for s, c in zip(arr.shape[1:], arr.chunks[1:], strict=True)
@@ -241,7 +258,11 @@ def _raw_get_mb_s(
     t = time.perf_counter()
     with ThreadPoolExecutor(max_workers=concurrency) as ex:
         total = sum(ex.map(fetch, keys))
-    return total / 1e6 / (time.perf_counter() - t)
+    mb = total / 1e6 / (time.perf_counter() - t)
+    if backend == "fsspec":
+        _close_fsspec_session(raw_fs)  # the bare raw-fetch fs (no Store wrapper)
+        close_store(meta_store)  # the async grid-metadata store's session
+    return mb
 
 
 def main() -> None:

--- a/bench/result.py
+++ b/bench/result.py
@@ -52,7 +52,8 @@ def rss_breakdown_mb() -> tuple[float, float]:
 class Result:
     engine: str  # insitu | naive | memory | workers | xbatcher
     cache: str  # none | memory | disk
-    storage: str  # file | s3
+    storage: str  # file | s3 | gs
+    backend: str  # obstore | fsspec | arraylake -- which store built the reads (M-GCS A/B)
     sample_chunk: int
     n_samples: int
     epoch: int

--- a/bench/run.py
+++ b/bench/run.py
@@ -33,6 +33,7 @@ def run_suite(
     data_dir: str | Path | None = None,
     url_prefix: str | None = None,
     storage: str = "file",
+    backend: str = "obstore",
     chunk_sizes: Sequence[int] = (1, 8),
     engines: Sequence[str] = ("naive", "workers", "xbatcher", "insitu", "memory"),
     caches: Sequence[str] = ("none",),  # insitu only: "none" (read-once) | "resident" (hold split)
@@ -51,13 +52,20 @@ def run_suite(
     s3_express: bool = False,
     verbose: bool = True,
 ) -> list[Result]:
+    # Auth knobs are named per backend: obstore uses request_payer / s3_express (S3),
+    # gcsfs uses requester_pays. For an owned standard bucket both are empty and the
+    # backend falls back to ambient credentials -- which is the M-GCS A/B case.
     store_kwargs: dict[str, bool] = {}
-    if request_payer:
-        store_kwargs["request_payer"] = True
-    # S3 Express One Zone (directory buckets, --x-s3): obstore needs s3_express=True;
-    # it is NOT inferred from the bucket name. (env equivalent: AWS_S3_EXPRESS=true)
-    if s3_express:
-        store_kwargs["s3_express"] = True
+    if backend == "fsspec":
+        if request_payer:
+            store_kwargs["requester_pays"] = True
+    else:  # obstore
+        if request_payer:
+            store_kwargs["request_payer"] = True
+        # S3 Express One Zone (directory buckets, --x-s3): obstore needs s3_express=True;
+        # it is NOT inferred from the bucket name. (env equivalent: AWS_S3_EXPRESS=true)
+        if s3_express:
+            store_kwargs["s3_express"] = True
     if url_prefix:
         urls = {spc: f"{url_prefix}_c{spc}.zarr" for spc in chunk_sizes}
     else:
@@ -82,6 +90,7 @@ def run_suite(
             engine="insitu",
             url=url,
             storage=storage,
+            backend=backend,
             sample_chunk=spc,
             batch_size=batch_size,
             block_chunks=bc_warm,
@@ -133,6 +142,7 @@ def run_suite(
                                     engine=engine,
                                     url=url,
                                     storage=storage,
+                                    backend=backend,
                                     sample_chunk=spc,
                                     batch_size=batch_size,
                                     block_chunks=bc,
@@ -184,7 +194,13 @@ def main() -> None:
     p.add_argument("--out", default=str(DEFAULT_OUT))
     p.add_argument("--data-dir", default=None, help="where to write local datasets (default: temp)")
     p.add_argument("--url-prefix", default=None, help="pre-generated data: <prefix>_c<spc>.zarr")
-    p.add_argument("--storage", default="file", choices=["file", "s3"])
+    p.add_argument("--storage", default="file", choices=["file", "s3", "gs"])
+    p.add_argument(
+        "--backend",
+        default="obstore",
+        choices=["obstore", "fsspec", "arraylake"],
+        help="store backend to read through: obstore (Rust), fsspec (gcsfs), or arraylake",
+    )
     p.add_argument("--full", action="store_true", help="chunk-size spectrum + sweeps")
     p.add_argument("--engines", default=None, help="comma list of engines to run")
     p.add_argument(
@@ -216,6 +232,7 @@ def main() -> None:
         data_dir=a.data_dir,
         url_prefix=a.url_prefix,
         storage=a.storage,
+        backend=a.backend,
         epochs=a.epochs,
         repeats=a.repeats,
         cache_dir=a.cache_dir,

--- a/bench/run.py
+++ b/bench/run.py
@@ -18,6 +18,7 @@ import tempfile
 import time
 from collections.abc import Sequence
 from pathlib import Path
+from urllib.parse import urlparse
 
 from .engines import Cfg, run
 from .make_dataset import make_family
@@ -32,7 +33,6 @@ def run_suite(
     out: str | Path = DEFAULT_OUT,
     data_dir: str | Path | None = None,
     url_prefix: str | None = None,
-    storage: str = "file",
     backend: str = "obstore",
     chunk_sizes: Sequence[int] = (1, 8),
     engines: Sequence[str] = ("naive", "workers", "xbatcher", "insitu", "memory"),
@@ -73,6 +73,9 @@ def run_suite(
         urls = make_family(
             f"file://{ddir}/era5", tuple(chunk_sizes), n_samples=n_samples, inner=inner
         )
+    # The JSONL row's storage label is just the URL scheme (file | s3 | gs) -- no need
+    # for a separate flag to restate what the prefix already says.
+    storage = urlparse(next(iter(urls.values()))).scheme or "file"
 
     scratch = (
         Path(cache_dir) if cache_dir else Path(tempfile.mkdtemp(prefix="insitubatch-bench-cache-"))
@@ -194,7 +197,6 @@ def main() -> None:
     p.add_argument("--out", default=str(DEFAULT_OUT))
     p.add_argument("--data-dir", default=None, help="where to write local datasets (default: temp)")
     p.add_argument("--url-prefix", default=None, help="pre-generated data: <prefix>_c<spc>.zarr")
-    p.add_argument("--storage", default="file", choices=["file", "s3", "gs"])
     p.add_argument(
         "--backend",
         default="obstore",
@@ -231,7 +233,6 @@ def main() -> None:
         out=a.out,
         data_dir=a.data_dir,
         url_prefix=a.url_prefix,
-        storage=a.storage,
         backend=a.backend,
         epochs=a.epochs,
         repeats=a.repeats,

--- a/bench/spike_v2_decode.py
+++ b/bench/spike_v2_decode.py
@@ -22,13 +22,13 @@ import zarr
 from zarr.core.array_spec import ArraySpec
 from zarr.core.buffer import default_buffer_prototype
 
-from insitubatch.store import ensure_local_dir, store_from_url
+from insitubatch.store import ensure_local_dir, obstore_store
 
 
 async def fetch_decode_scatter(url: str, var: str, max_inflight: int) -> np.ndarray:
     """Reconstruct the whole array by fetching every stored chunk under one flat
     ``max_inflight`` budget, decoding it, and scattering it into place."""
-    aa = zarr.open_array(store=store_from_url(url), path=var, mode="r")._async_array
+    aa = zarr.open_array(store=obstore_store(url), path=var, mode="r")._async_array
     proto = default_buffer_prototype()
     spec = ArraySpec(
         shape=aa.metadata.chunks,
@@ -71,7 +71,7 @@ def main() -> None:
     tmp = tempfile.mkdtemp(prefix="spike-v2-")
     url = f"file://{tmp}/s.zarr"
     ensure_local_dir(url)
-    g = zarr.open_group(store=store_from_url(url, read_only=False), mode="w")
+    g = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
     rng = np.random.default_rng(0)
     # partial edge chunks on every axis, both single-inner and spatially chunked
     shape = (5, 9, 7)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -352,7 +352,7 @@ def fill_nan(chunk):                      # your policy: climatology, interpolat
     np.nan_to_num(chunk.data, copy=False, nan=0.0)
     return chunk
 
-ds = InSituDataset(url, manifest, on_bad_chunk="nan", chunk_transforms=[fill_nan])
+ds = InSituDataset(store, manifest, on_bad_chunk="nan", chunk_transforms=[fill_nan])
 for batch in ds.train:
     ...
 print(ds.bad_chunks)   # the (array, chunk_index, inner_coord) reads that were bad this epoch
@@ -386,9 +386,10 @@ two train chunks shares its neighbours' weather). Set `contiguous=False` only wh
 **exchangeable** (independent scenes); it shuffles chunks before partitioning.
 
 ```python
-from insitubatch import open_geometries, split_by_chunk
+from insitubatch import obstore_store, open_geometries, split_by_chunk
 
-geom = open_geometries(url)[var]
+store = obstore_store(url)                 # or fsspec_store / arraylake_store
+geom = open_geometries(store)[var]
 # time series (default): contiguous blocks, no cross-boundary leakage
 manifest = split_by_chunk(geom, fractions=(0.8, 0.1, 0.1))
 # independent scenes: shuffle chunks before splitting
@@ -410,20 +411,22 @@ used only for this off-hot-path planning step; the engine itself never touches x
 
 ```python
 import xarray as xr
-from insitubatch import open_geometries, split_by_chunk, store_from_url
+from insitubatch import obstore_store, open_geometries, split_by_chunk
 from insitubatch.source import InSituDataset
 
+store = obstore_store(url)                 # one Store, reused for planning + the engine
+
 # define the window in xarray
-xds = xr.open_zarr(store_from_url(url))
+xds = xr.open_zarr(store)
 sel = xds.sel(time=slice("2020-01-01", "2021-01-01"))
 times = xds.indexes["time"]
 i0 = times.get_loc(sel.time.values[0])
 i1 = times.get_loc(sel.time.values[-1]) + 1  # half-open
 
 # pure zarr/numpy from here
-geom = open_geometries(url)[var]
+geom = open_geometries(store)[var]
 manifest = split_by_chunk(geom, fractions=(0.8, 0.1, 0.1), sample_range=(i0, i1))
-ds = InSituDataset(url, manifest, ...)
+ds = InSituDataset(store, manifest, ...)
 ```
 
 **Limitation — chunk-aligned and contiguous.** The selection snaps *outward* to chunk

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,16 +39,18 @@ The core `InSituDataset` is a framework-neutral iterable of numpy `Batch` object
 torch / JAX / TF handoff is a thin optional DLPack adapter in `insitubatch.frameworks`.
 
 ```python
-from insitubatch import open_geometries, split_by_chunk
+from insitubatch import obstore_store, open_geometries, split_by_chunk
 from insitubatch.source import InSituDataset
 from insitubatch.frameworks import as_torch, to_jax, as_tf_dataset
 from torch.utils.data import DataLoader
 
-url = "file:///data/era5.zarr"           # or "s3://bucket/era5.zarr" — same code
-geoms = open_geometries(url)             # {var: ArrayGeometry} from zarr metadata
+# The engine reads a zarr Store; obstore_store builds one for file://, s3://, gs://.
+# (fsspec_store for GCS Rapid/requester-pays; arraylake_store for Icechunk sessions.)
+store = obstore_store("file:///data/era5.zarr")  # or "s3://bucket/era5.zarr"
+geoms = open_geometries(store)           # {var: ArrayGeometry} from zarr metadata
 manifest = split_by_chunk(geoms["t2m"], fractions=(0.8, 0.1, 0.1))
 
-ds = InSituDataset(url, manifest, batch_size=32, block_chunks=16)
+ds = InSituDataset(store, manifest, batch_size=32, block_chunks=16)
 
 for epoch in range(n_epochs):
     ds.set_epoch(epoch)

--- a/examples/README.md
+++ b/examples/README.md
@@ -74,6 +74,8 @@ The same task two ways — complementary engines for the same ndim-batch problem
 can see the cold-start trade-off and pick what fits your workload:
 
 - [`wb2_dataloader.py`](wb2_dataloader.py) — the insitu single-event-loop loader.
+  `--backend fsspec` (needs `--extra gcsfs`) reads the same store through `fsspec_store`
+  (gcsfs) instead of obstore — the A/B for GCS Rapid/zonal + Requester-Pays.
 - [`wb2_xbatcher.py`](wb2_xbatcher.py) — the xbatcher + torch `DataLoader` worker stack
   (xbatcher defines the batches, the `DataLoader` runs them), the pattern from Earthmover's
   `dataloader-demo`, with a focus on cold-start latency and how `forkserver-preload` cuts it

--- a/examples/advection/data.py
+++ b/examples/advection/data.py
@@ -21,17 +21,17 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Callable, Iterable
-from typing import Any
 
 import numpy as np
 import zarr
+from zarr.abc.store import Store
 
 from insitubatch import (
-    StoreLike,
+    arraylake_store,
     ensure_local_dir,
+    obstore_store,
     open_geometries,
     split_by_chunk,
-    store_from_url,
 )
 from insitubatch.source import InSituDataset
 from insitubatch.types import Batch
@@ -51,14 +51,6 @@ SYNTH_VARS = ("t2m", "u10", "v10")
 SYNTH_HORIZON = 24  # 24 steps x 1 h = 24 h
 
 LABELS = ("t2m", "u10", "v10")  # canonical input labels (store-independent)
-
-
-def open_arraylake_store(repo: str, *, branch: str = "main") -> StoreLike:
-    """Read-only Icechunk session store for an Arraylake repo (needs ``--extra arraylake``
-    + ``al auth login`` / ``ARRAYLAKE_TOKEN``). Passed straight to ``InSituDataset``."""
-    from arraylake import Client
-
-    return Client().get_repo(repo).readonly_session(branch).store
 
 
 def _advect(field: np.ndarray, u: np.ndarray, v: np.ndarray) -> np.ndarray:
@@ -125,7 +117,7 @@ def make_advection_store(url: str, *, n_steps: int = 768, size: int = 48, seed: 
     wind_v = np.broadcast_to(v.astype("f4"), (n_steps, size, size))
 
     ensure_local_dir(url)
-    group = zarr.open_group(store=store_from_url(url, read_only=False), mode="w")
+    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
     for name, data in (("t2m", t2m), ("u10", wind_u), ("v10", wind_v)):
         arr = group.create_array(
             name,
@@ -138,7 +130,7 @@ def make_advection_store(url: str, *, n_steps: int = 768, size: int = 48, seed: 
 
 
 def forecast_dataset(
-    store: StoreLike,
+    store: Store,
     *,
     variables: tuple[str, str, str] = SYNTH_VARS,
     horizon: int = SYNTH_HORIZON,
@@ -147,11 +139,11 @@ def forecast_dataset(
     shuffle: bool = True,
     cache_dir: str | None = None,
     max_inflight: int | None = None,
-    **store_kwargs: Any,
 ) -> InSituDataset:
     """One windowed dataset: inputs ``{t2m, u10, v10}@t`` + ``target = t2m@(t+horizon)``.
 
-    ``store`` is a URL or a prebuilt zarr Store (e.g. an Arraylake/Icechunk session store).
+    ``store`` is a zarr Store -- build it with :func:`~insitubatch.obstore_store` /
+    :func:`~insitubatch.fsspec_store` / :func:`~insitubatch.arraylake_store`.
     ``variables`` names the three input arrays in the store (synthetic short names, the
     WeatherBench2 long names, or group-qualified paths); the dataset's labels are always
     ``t2m, u10, v10, target`` so the model code is store-agnostic. The target is the first
@@ -161,7 +153,7 @@ def forecast_dataset(
     high-latency network); ``max_inflight`` throttles read-ahead. Iterate the returned
     dataset's ``.train`` / ``.val`` views.
     """
-    opened = open_geometries(store, variables=list(variables), **store_kwargs)
+    opened = open_geometries(store, variables=list(variables))
     geoms = {label: opened[var] for label, var in zip(LABELS, variables, strict=True)}
     geoms["target"] = opened[variables[0]].shift(horizon)
     manifest = split_by_chunk(
@@ -175,7 +167,6 @@ def forecast_dataset(
         shuffle=shuffle,
         cache_dir=cache_dir,
         max_inflight=max_inflight,
-        **store_kwargs,
     )
 
 
@@ -266,18 +257,20 @@ def build_datasets(args: argparse.Namespace) -> InSituDataset:
     """One forecast dataset from CLI args -- iterate ``ds.train`` / ``ds.val``. ``--source``
     picks offline synthetic (written fresh), the public WeatherBench2 ``gs://`` store, or the
     Arraylake/Icechunk repo (real ERA5; pass ``--sample-range`` to subset the archive)."""
-    store: StoreLike
+    store: Store
     if args.source == "arraylake":
-        store = open_arraylake_store(args.repo)
+        store = arraylake_store(args.repo)
         a, b, c = WB2_VARS
         variables = (f"{args.group}/{a}", f"{args.group}/{b}", f"{args.group}/{c}")
-        horizon, kw = WB2_HORIZON, {}
+        horizon = WB2_HORIZON
     elif args.source == "wb2":
-        store, variables, horizon, kw = WB2_URL, WB2_VARS, WB2_HORIZON, {"skip_signature": True}
+        store = obstore_store(WB2_URL, skip_signature=True)  # anonymous read of the public bucket
+        variables, horizon = WB2_VARS, WB2_HORIZON
     else:
-        store = args.url or "file:///tmp/insitu_advection.zarr"
-        make_advection_store(store, n_steps=args.n_steps)
-        variables, horizon, kw = SYNTH_VARS, SYNTH_HORIZON, {}
+        url = args.url or "file:///tmp/insitu_advection.zarr"
+        make_advection_store(url, n_steps=args.n_steps)
+        store = obstore_store(url)
+        variables, horizon = SYNTH_VARS, SYNTH_HORIZON
     return forecast_dataset(
         store,
         variables=variables,
@@ -287,5 +280,4 @@ def build_datasets(args: argparse.Namespace) -> InSituDataset:
         shuffle=True,
         cache_dir=args.cache_dir,
         max_inflight=args.max_inflight,
-        **kw,
     )

--- a/examples/fit_scaler.py
+++ b/examples/fit_scaler.py
@@ -35,9 +35,9 @@ import zarr
 from insitubatch import (
     Batch,
     ensure_local_dir,
+    obstore_store,
     open_geometries,
     split_by_chunk,
-    store_from_url,
 )
 from insitubatch.source import InSituDataset
 
@@ -55,7 +55,7 @@ def _synthetic(tmp: str, *, n: int = 256, inner: tuple[int, int] = (32, 32), spc
     """Two variables with deliberately different mean/scale, so standardization shows."""
     url = f"file://{tmp}/era5.zarr"
     ensure_local_dir(url)
-    g = zarr.open_group(store=store_from_url(url, read_only=False), mode="w")
+    g = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
     rng = np.random.default_rng(0)
     for i, var in enumerate(("t2m", "u10")):
         a = g.create_array(var, shape=(n, *inner), chunks=(spc, *inner), dtype="f4")
@@ -109,13 +109,13 @@ def run_demo(
     # A real store (WeatherBench2) has many variables on *different* sample axes (coords,
     # pressure levels); InSituDataset requires one shared sample axis, so select a
     # compatible set. None = every variable (fine for the synthetic two-var store).
-    geoms = open_geometries(url, variables=variables, **store_kwargs)
+    geoms = open_geometries(obstore_store(url), variables=variables, **store_kwargs)
     var0 = next(iter(geoms))
     manifest = split_by_chunk(geoms[var0], fractions=(1.0, 0.0, 0.0))
 
     # A cache big enough to hold the split: the fit pass warms it, training reuses it.
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         geometries=geoms,
         batch_size=16,
@@ -130,7 +130,7 @@ def run_demo(
     scalers, fit_s, n = fit_over_loader(ds)
 
     # verify the streamed partial_fit matches the true global mean/std
-    grp = zarr.open_group(store=store_from_url(url, **store_kwargs), mode="r")
+    grp = zarr.open_group(store=obstore_store(url, **store_kwargs), mode="r")
     max_err = 0.0
     for v, s in scalers.items():
         arr = grp[v]

--- a/examples/fit_scaler.py
+++ b/examples/fit_scaler.py
@@ -106,16 +106,18 @@ def run_demo(
     if url.startswith("gs://"):
         store_kwargs["skip_signature"] = True  # public bucket, anonymous read
 
+    store = obstore_store(url, **store_kwargs)  # one Store, reused throughout
+
     # A real store (WeatherBench2) has many variables on *different* sample axes (coords,
     # pressure levels); InSituDataset requires one shared sample axis, so select a
     # compatible set. None = every variable (fine for the synthetic two-var store).
-    geoms = open_geometries(obstore_store(url), variables=variables, **store_kwargs)
+    geoms = open_geometries(store, variables=variables)
     var0 = next(iter(geoms))
     manifest = split_by_chunk(geoms[var0], fractions=(1.0, 0.0, 0.0))
 
     # A cache big enough to hold the split: the fit pass warms it, training reuses it.
     ds = InSituDataset(
-        obstore_store(url),
+        store,
         manifest,
         geometries=geoms,
         batch_size=16,
@@ -123,14 +125,13 @@ def run_demo(
         shuffle=False,
         cache_dir=cache_dir or (f"{tmp}/cache" if tmp else None),
         cache_budget_bytes=4 << 30,
-        **store_kwargs,
     )
 
     # 1) fit over the loader (cold: decode + cache) -----------------------------------
     scalers, fit_s, n = fit_over_loader(ds)
 
     # verify the streamed partial_fit matches the true global mean/std
-    grp = zarr.open_group(store=obstore_store(url, **store_kwargs), mode="r")
+    grp = zarr.open_group(store=store, mode="r")
     max_err = 0.0
     for v, s in scalers.items():
         arr = grp[v]

--- a/examples/transforms.py
+++ b/examples/transforms.py
@@ -34,7 +34,7 @@ from dataclasses import dataclass
 import numpy as np
 import zarr
 
-from insitubatch import ensure_local_dir, open_geometries, split_by_chunk, store_from_url
+from insitubatch import ensure_local_dir, obstore_store, open_geometries, split_by_chunk
 from insitubatch.source import InSituDataset
 from insitubatch.types import ArrayGeometry, Batch, DecodedChunk
 
@@ -45,7 +45,7 @@ def build_store(tmp: str, *, n: int = 64, lat: int = 16, lon: int = 32, spc: int
     """Write a tiny 3-variable zarr: temperature in Kelvin and the two wind components."""
     url = f"file://{tmp}/synthetic.zarr"
     ensure_local_dir(url)
-    group = zarr.open_group(store=store_from_url(url, read_only=False), mode="w")
+    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
     rng = np.random.default_rng(0)
     fields = {
         "t2m": 273.15 + 10.0 * rng.standard_normal((n, lat, lon)).astype("f4"),
@@ -139,14 +139,14 @@ def run_demo(
         tmp = tempfile.mkdtemp(prefix="insitu-transforms-")
         url = build_store(tmp)
     try:
-        geoms = open_geometries(url, variables=list(VARIABLES))
+        geoms = open_geometries(obstore_store(url), variables=list(VARIABLES))
         manifest = split_by_chunk(geoms["t2m"], fractions=(0.8, 0.1, 0.1))
         source_inner = geoms["t2m"].inner_shape
 
         # Two chunk stages: K->C (shape-preserving) then a reshaping Coarsen (halves the grid).
         # The cache slot is sized at the *coarsened* shape via Coarsen.output_inner.
         ds = InSituDataset(
-            url,
+            obstore_store(url),
             manifest,
             geometries=geoms,
             batch_size=batch_size,

--- a/examples/transforms.py
+++ b/examples/transforms.py
@@ -139,14 +139,15 @@ def run_demo(
         tmp = tempfile.mkdtemp(prefix="insitu-transforms-")
         url = build_store(tmp)
     try:
-        geoms = open_geometries(obstore_store(url), variables=list(VARIABLES))
+        store = obstore_store(url)
+        geoms = open_geometries(store, variables=list(VARIABLES))
         manifest = split_by_chunk(geoms["t2m"], fractions=(0.8, 0.1, 0.1))
         source_inner = geoms["t2m"].inner_shape
 
         # Two chunk stages: K->C (shape-preserving) then a reshaping Coarsen (halves the grid).
         # The cache slot is sized at the *coarsened* shape via Coarsen.output_inner.
         ds = InSituDataset(
-            obstore_store(url),
+            store,
             manifest,
             geometries=geoms,
             batch_size=batch_size,

--- a/examples/wb2_arraylake.py
+++ b/examples/wb2_arraylake.py
@@ -44,7 +44,7 @@ from collections.abc import Callable
 import numpy as np
 from zarr.abc.store import Store
 
-from insitubatch import SplitName, open_geometries, split_by_chunk
+from insitubatch import SplitName, arraylake_store, open_geometries, split_by_chunk
 from insitubatch.source import InSituDataset
 from insitubatch.types import Batch
 
@@ -55,19 +55,6 @@ WB2_GROUP = "era5/6h_240x121"
 # Surface field, dims (time, lon, lat). Single-variable keeps the sample geometry
 # v1-friendly (specific_humidity carries a `level` axis; add it explicitly if wanted).
 DEFAULT_VAR = "2m_temperature"
-
-
-def open_arraylake_store(repo: str, *, branch: str = "main") -> Store:
-    """Open an Arraylake repo and return its read-only Icechunk session store.
-
-    Auth comes from a cached ``al auth login`` or ``ARRAYLAKE_TOKEN``; the client
-    vends the bucket credentials for the (public) repo. The returned store is a
-    zarr-v3 Store -- exactly what ``InSituDataset`` accepts directly.
-    """
-    from arraylake import Client
-
-    ic_repo = Client().get_repo(repo)
-    return ic_repo.readonly_session(branch).store
 
 
 def _crop(patch: tuple[int, int], seed: int) -> Callable[[Batch], Batch]:
@@ -244,7 +231,7 @@ def main() -> None:
     p.add_argument("--cache-dir", default=None, help="spill cached slots to this NVMe dir (mmap)")
     a = p.parse_args()
 
-    store = open_arraylake_store(a.repo, branch=a.branch)
+    store = arraylake_store(a.repo, branch=a.branch)
     run(
         store,
         var=a.var,

--- a/examples/wb2_dataloader.py
+++ b/examples/wb2_dataloader.py
@@ -4,8 +4,11 @@ Mirrors https://github.com/earth-mover/dataloader-demo: load an ERA5-style zarr
 from the cloud, feed a simulated training loop, and report per-batch wait time.
 What differs:
 
-- **Storage is obstore.** Pass any zarr ``--url`` (e.g. an S3 ERA5 store); reads
-  go through ``obstore_store`` (so ``--request-payer`` works for Requester-Pays).
+- **Storage is a zarr Store, obstore by default.** Pass any zarr ``--url`` (e.g. an
+  S3 ERA5 store); reads go through ``obstore_store`` (so ``--request-payer`` works for
+  Requester-Pays). ``--backend fsspec`` reads the same URL through ``fsspec_store``
+  (gcsfs) instead — the path to GCS Rapid/zonal + Requester-Pays, and the A/B for
+  whether fsspec matches obstore on GCS (DESIGN.md M-GCS).
 - **Parallelism is in the event loop, not workers.** There is no ``num_workers``
   knob — insitubatch fans out IO on its async loop and prefetches; a different
   parallelism model for the same batches.
@@ -36,6 +39,7 @@ import shutil
 import tempfile
 import time
 from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 import zarr
@@ -43,6 +47,7 @@ import zarr
 from insitubatch import (
     SplitName,
     ensure_local_dir,
+    fsspec_store,
     obstore_store,
     open_geometries,
     split_by_chunk,
@@ -109,6 +114,7 @@ def run_demo(
     shuffle: bool = True,
     seed: int = 0,
     request_payer: bool = False,
+    backend: str = "obstore",
     verbose: bool = True,
 ) -> dict:
     tmp = None
@@ -116,13 +122,22 @@ def run_demo(
         tmp = tempfile.mkdtemp(prefix="wb2-demo-")
         url, var = _synthetic(tmp)
 
-    store_kwargs: dict = {}
-    if url.startswith("gs://"):
-        store_kwargs["skip_signature"] = True  # public bucket, anonymous read
-    if request_payer:
-        store_kwargs["request_payer"] = True
-
-    geom = open_geometries(obstore_store(url), variables=[var], **store_kwargs)[var]
+    # obstore (default, pure-Rust) vs fsspec/gcsfs (the GCS Rapid/requester-pays path) over
+    # the *same* engine -- the A/B for "does fsspec earn a co-equal fast path" (DESIGN M-GCS).
+    anon = url.startswith("gs://")  # the public WeatherBench2 bucket needs no credentials
+    if backend == "fsspec":
+        fs_kwargs: dict[str, Any] = {"token": "anon"} if anon else {}  # gcsfs anonymous read
+        if request_payer:
+            fs_kwargs["requester_pays"] = True
+        store = fsspec_store(url, **fs_kwargs)
+    else:
+        obs_kwargs: dict = {}
+        if anon:
+            obs_kwargs["skip_signature"] = True
+        if request_payer:
+            obs_kwargs["request_payer"] = True
+        store = obstore_store(url, **obs_kwargs)
+    geom = open_geometries(store, variables=[var])[var]
     manifest = split_by_chunk(geom, fractions=(0.8, 0.1, 0.1))
     # Caching is the pool's policy (V2: "don't evict"). --cache-resident sizes the budget
     # to hold the whole train split, so epoch 2+ is served from the pool (decode-once);
@@ -133,7 +148,7 @@ def run_demo(
         cache_budget_bytes = (len(manifest.chunks[SplitName.TRAIN.value]) + 2) * per_chunk
 
     ds = InSituDataset(
-        obstore_store(url),
+        store,
         manifest,
         geometries={var: geom},
         batch_size=batch_size,
@@ -144,7 +159,6 @@ def run_demo(
         shuffle=shuffle,
         seed=seed,
         batch_transforms=[_subregion_crop(var, subregion, seed)],
-        **store_kwargs,
     )
 
     waits: list[float] = []
@@ -218,6 +232,12 @@ def main() -> None:
     p.add_argument("--max-batches", type=int, default=0, help="cap batches per epoch (0 = all)")
     p.add_argument("--no-shuffle", action="store_true")
     p.add_argument("--request-payer", action="store_true")
+    p.add_argument(
+        "--backend",
+        choices=("obstore", "fsspec"),
+        default="obstore",
+        help="store backend: obstore (default, Rust) or fsspec/gcsfs (GCS Rapid/requester-pays)",
+    )
     a = p.parse_args()
     url, var = (WB2_URL, WB2_VAR) if a.wb2 else (a.url, a.var)
     run_demo(
@@ -234,6 +254,7 @@ def main() -> None:
         max_batches=a.max_batches,
         shuffle=not a.no_shuffle,
         request_payer=a.request_payer,
+        backend=a.backend,
     )
 
 

--- a/examples/wb2_dataloader.py
+++ b/examples/wb2_dataloader.py
@@ -5,7 +5,7 @@ from the cloud, feed a simulated training loop, and report per-batch wait time.
 What differs:
 
 - **Storage is obstore.** Pass any zarr ``--url`` (e.g. an S3 ERA5 store); reads
-  go through ``store_from_url`` (so ``--request-payer`` works for Requester-Pays).
+  go through ``obstore_store`` (so ``--request-payer`` works for Requester-Pays).
 - **Parallelism is in the event loop, not workers.** There is no ``num_workers``
   knob — insitubatch fans out IO on its async loop and prefetches; a different
   parallelism model for the same batches.
@@ -43,9 +43,9 @@ import zarr
 from insitubatch import (
     SplitName,
     ensure_local_dir,
+    obstore_store,
     open_geometries,
     split_by_chunk,
-    store_from_url,
 )
 from insitubatch.source import InSituDataset
 from insitubatch.types import Batch
@@ -62,7 +62,7 @@ def _synthetic(
 ) -> tuple[str, str]:
     url = f"file://{tmp}/era5.zarr"
     ensure_local_dir(url)
-    group = zarr.open_group(store=store_from_url(url, read_only=False), mode="w")
+    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
     arr = group.create_array(
         "t2m",
         shape=(n, lat, lon),
@@ -122,7 +122,7 @@ def run_demo(
     if request_payer:
         store_kwargs["request_payer"] = True
 
-    geom = open_geometries(url, variables=[var], **store_kwargs)[var]
+    geom = open_geometries(obstore_store(url), variables=[var], **store_kwargs)[var]
     manifest = split_by_chunk(geom, fractions=(0.8, 0.1, 0.1))
     # Caching is the pool's policy (V2: "don't evict"). --cache-resident sizes the budget
     # to hold the whole train split, so epoch 2+ is served from the pool (decode-once);
@@ -133,7 +133,7 @@ def run_demo(
         cache_budget_bytes = (len(manifest.chunks[SplitName.TRAIN.value]) + 2) * per_chunk
 
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         geometries={var: geom},
         batch_size=batch_size,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,12 @@ docs = [
 icechunk = [
     "icechunk>=0.2",
 ]
+# fsspec-backed stores (insitubatch.fsspec_store) reach backends via fsspec: GCS
+# Rapid/zonal (gRPC) and requester-pays, which obstore does not currently support.
+# gcsfs pulls fsspec transitively; bring your own s3fs/etc. for other schemes.
+gcsfs = [
+    "gcsfs>=2024.6",
+]
 # Arraylake catalog access for examples/wb2_arraylake.py: the client vends
 # credentials for the public earthmover-public/weatherbench2 Icechunk repo (and
 # pulls icechunk in).

--- a/src/insitubatch/__init__.py
+++ b/src/insitubatch/__init__.py
@@ -22,7 +22,15 @@ from .shuffle import (
     shuffle_quality,
 )
 from .split import SplitManifest, split_by_chunk, valid_anchor_range
-from .store import StoreLike, as_store, ensure_local_dir, open_geometries, store_from_url
+from .store import (
+    StoreLike,
+    arraylake_store,
+    as_store,
+    ensure_local_dir,
+    fsspec_store,
+    open_geometries,
+    store_from_url,
+)
 from .transforms import (
     BatchTransform,
     ChunkTransform,
@@ -53,11 +61,13 @@ __all__ = [
     "StandardScaler",
     "StoreLike",
     "StoredChunkRead",
+    "arraylake_store",
     "as_store",
     "block_shuffled_order",
     "build_stored_chunk_reads",
     "chunk_permutation",
     "ensure_local_dir",
+    "fsspec_store",
     "open_geometries",
     "sequential_order",
     "shuffle_quality",

--- a/src/insitubatch/__init__.py
+++ b/src/insitubatch/__init__.py
@@ -23,13 +23,11 @@ from .shuffle import (
 )
 from .split import SplitManifest, split_by_chunk, valid_anchor_range
 from .store import (
-    StoreLike,
     arraylake_store,
-    as_store,
     ensure_local_dir,
     fsspec_store,
+    obstore_store,
     open_geometries,
-    store_from_url,
 )
 from .transforms import (
     BatchTransform,
@@ -59,19 +57,17 @@ __all__ = [
     "SplitManifest",
     "SplitName",
     "StandardScaler",
-    "StoreLike",
     "StoredChunkRead",
     "arraylake_store",
-    "as_store",
     "block_shuffled_order",
     "build_stored_chunk_reads",
     "chunk_permutation",
     "ensure_local_dir",
     "fsspec_store",
+    "obstore_store",
     "open_geometries",
     "sequential_order",
     "shuffle_quality",
     "split_by_chunk",
-    "store_from_url",
     "valid_anchor_range",
 ]

--- a/src/insitubatch/__init__.py
+++ b/src/insitubatch/__init__.py
@@ -24,6 +24,7 @@ from .shuffle import (
 from .split import SplitManifest, split_by_chunk, valid_anchor_range
 from .store import (
     arraylake_store,
+    close_store,
     ensure_local_dir,
     fsspec_store,
     obstore_store,
@@ -59,6 +60,7 @@ __all__ = [
     "StandardScaler",
     "StoredChunkRead",
     "arraylake_store",
+    "close_store",
     "block_shuffled_order",
     "build_stored_chunk_reads",
     "chunk_permutation",

--- a/src/insitubatch/check_transform.py
+++ b/src/insitubatch/check_transform.py
@@ -37,9 +37,10 @@ from pathlib import Path
 
 import numpy as np
 import zarr
+from zarr.abc.store import Store
 
 from .pool import output_geometry
-from .store import as_store, open_geometries
+from .store import obstore_store, open_geometries
 from .types import ArrayGeometry, ChunkRead, DecodedChunk
 
 ChunkTransform = Callable[[DecodedChunk], DecodedChunk]
@@ -83,14 +84,12 @@ def load_transform(target: str) -> ChunkTransform:
     return fn
 
 
-def read_chunk(
-    url: str, var: str, chunk_index: int, geom: ArrayGeometry, **store_kwargs: bool
-) -> DecodedChunk:
+def read_chunk(store: Store, var: str, chunk_index: int, geom: ArrayGeometry) -> DecodedChunk:
     """Decode exactly one outer chunk of ``var`` into a :class:`DecodedChunk`.
 
     Uses a plain zarr slice -- this is a one-off development read, not the training hot path
     (the no-getitem stance is about throughput), so zarr stitching the inner grid is fine."""
-    group = zarr.open_group(store=as_store(url, **store_kwargs), mode="r")
+    group = zarr.open_group(store=store, mode="r")
     arr = group[var]
     samples = geom.samples_in_chunk(chunk_index)
     data = np.asarray(arr[samples.start : samples.stop])  # type: ignore[index]
@@ -203,11 +202,13 @@ def main(argv: list[str] | None = None) -> int:
     threads = a.threads or min(4, os.cpu_count() or 1)
     # Same store-auth surface as the loader (see examples/wb2_dataloader.py) so check_transform
     # reaches the same public / requester-pays stores. Typed bool so the **kwargs stays mypy-clean.
+    # TODO: a --backend fsspec flag for gs:// Rapid/requester-pays via insitubatch.fsspec_store.
     store_kwargs: dict[str, bool] = {}
     if a.skip_signature:
         store_kwargs["skip_signature"] = True
     if a.request_payer:
         store_kwargs["request_payer"] = True
+    store = obstore_store(a.url, **store_kwargs)
 
     try:
         fn = load_transform(a.transform)
@@ -215,7 +216,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: could not load --transform {a.transform!r}: {exc}", file=sys.stderr)
         return 2
 
-    geoms = open_geometries(a.url, variables=[a.var], **store_kwargs)
+    geoms = open_geometries(store, variables=[a.var])
     geom = geoms[a.var]
     if not 0 <= a.chunk < geom.n_chunks:
         print(f"error: --chunk {a.chunk} out of range [0, {geom.n_chunks})", file=sys.stderr)
@@ -235,7 +236,7 @@ def main(argv: list[str] | None = None) -> int:
         f"{geom.slot_shape(a.chunk)} = {src_mb:.1f} MB decoded"
     )
 
-    base = read_chunk(a.url, a.var, a.chunk, geom, **store_kwargs)
+    base = read_chunk(store, a.var, a.chunk, geom)
     in_shape, in_dtype = base.data.shape, base.data.dtype
     out = fn(_fresh(base))
     out_data = out.data

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -314,9 +314,7 @@ class Scheduler:
         """
         if self._foreign_loop is None:
             return await coro
-        return await asyncio.wrap_future(
-            asyncio.run_coroutine_threadsafe(coro, self._foreign_loop)
-        )
+        return await asyncio.wrap_future(asyncio.run_coroutine_threadsafe(coro, self._foreign_loop))
 
     async def _ensure_arrays(self) -> None:
         if self._arrays:

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -50,12 +50,12 @@ from dataclasses import dataclass
 
 import numpy as np
 import zarr.api.asynchronous as za
+from zarr.abc.store import Store
 from zarr.core.array_spec import ArraySpec
 from zarr.core.buffer import default_buffer_prototype
 
 from .plan import build_stored_chunk_reads
 from .pool import ChunkPool
-from .store import StoreLike, as_store
 from .types import ArrayGeometry, StoredChunkRead
 
 
@@ -119,14 +119,12 @@ class Scheduler:
 
     def __init__(
         self,
-        store: StoreLike,
+        store: Store,
         geometries: dict[str, ArrayGeometry],
         pool: ChunkPool,
         config: SchedulerConfig | None = None,
-        **store_kwargs: object,
     ) -> None:
         self._store = store
-        self._store_kwargs = store_kwargs
         self._geometries = geometries
         self._config = config or SchedulerConfig()
         if self._config.on_bad_chunk not in ("raise", "nan"):
@@ -280,7 +278,7 @@ class Scheduler:
         async with self._open_lock:
             if self._arrays:
                 return
-            store = as_store(self._store, **self._store_kwargs)  # type: ignore[arg-type]
+            store = self._store
             # Open each distinct array once, keyed by its zarr path: several windowed
             # views (same path, different offset) share one open + one decode path.
             for geom in self._geometries.values():

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -44,9 +44,10 @@ import asyncio
 import contextlib
 import os
 import threading
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Coroutine, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
+from typing import Any, TypeVar
 
 import numpy as np
 import zarr.api.asynchronous as za
@@ -57,6 +58,35 @@ from zarr.core.buffer import default_buffer_prototype
 from .plan import build_stored_chunk_reads
 from .pool import ChunkPool
 from .types import ArrayGeometry, StoredChunkRead
+
+_T = TypeVar("_T")
+
+
+def _fsspec_io_loop(store: Store) -> asyncio.AbstractEventLoop | None:
+    """The event loop an fsspec-backed store's IO must run on, if not the caller's.
+
+    A genuinely-async fsspec backend (gcsfs, s3fs) binds its aiohttp session to
+    whichever event loop *first awaits* one of its coroutines, and can never be used
+    from another loop ("Future attached to a different loop"). Neither zarr's
+    ``FsspecStore`` nor gcsfs exposes a knob to pin that loop -- the ``loop=``
+    constructor arg does not bind the session -- and zarr's ``FsspecStore.get``
+    awaits ``fs._cat_file`` on the *calling* loop with no routing of its own.
+
+    zarr drives all of *its* store IO on one process-wide background loop
+    (``zarr.core.sync._get_loop()``); because insitu reads a zarr store opened through
+    zarr (``open_geometries``/``open_array``), the session is created there. So the
+    correct, self-consistent choice is to route insitu's fsspec reads to that same
+    loop: the session lives there, and driving every read there keeps one loop for the
+    store even if nothing opened it first. ``None`` for stores needing no routing --
+    obstore's ``ObjectStore`` bridges its Rust runtime to whatever loop awaits it
+    (no ``.fs``), so the scheduler awaits it inline.
+    """
+    fs = getattr(store, "fs", None)
+    if fs is None or not getattr(fs, "asynchronous", False):
+        return None
+    from zarr.core.sync import _get_loop
+
+    return _get_loop()
 
 
 @dataclass(slots=True)
@@ -143,6 +173,9 @@ class Scheduler:
         workers = self._config.decode_threads or min(32, (os.cpu_count() or 4) + 4)
         self._decode_pool = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="insitu-dec")
         self._loop = asyncio.new_event_loop()
+        # Set once reads begin: the foreign loop an fsspec store pins its IO to (gcsfs/
+        # s3fs), or None for a loop-agnostic store (obstore). See _fsspec_io_loop / _io.
+        self._foreign_loop: asyncio.AbstractEventLoop | None = None
         self._inflight: asyncio.Semaphore | None = None
         self._capacity: asyncio.Event | None = None  # set on unpin -> wakes a parked admit
         self._open_lock: asyncio.Lock | None = None
@@ -271,6 +304,20 @@ class Scheduler:
                 return
             await self._capacity.wait()
 
+    async def _io(self, coro: Coroutine[Any, Any, _T]) -> _T:
+        """Await a store coroutine on the loop that store's IO belongs to.
+
+        obstore is loop-agnostic -> await inline on our loop. An fsspec store's IO must
+        run on its own loop (see :func:`_fsspec_io_loop`); schedule it there and bridge
+        the result back to ours, without blocking either loop -- so read concurrency is
+        preserved across the boundary.
+        """
+        if self._foreign_loop is None:
+            return await coro
+        return await asyncio.wrap_future(
+            asyncio.run_coroutine_threadsafe(coro, self._foreign_loop)
+        )
+
     async def _ensure_arrays(self) -> None:
         if self._arrays:
             return
@@ -278,13 +325,16 @@ class Scheduler:
         async with self._open_lock:
             if self._arrays:
                 return
+            # Resolve the store's IO loop once, before the first store touch (open reads
+            # metadata) -- an fsspec store crashes if that touch runs on our loop.
+            self._foreign_loop = _fsspec_io_loop(self._store)
             store = self._store
             # Open each distinct array once, keyed by its zarr path: several windowed
             # views (same path, different offset) share one open + one decode path.
             for geom in self._geometries.values():
                 if geom.path in self._arrays:
                     continue
-                aa = await za.open_array(store=store, path=geom.path, mode="r")
+                aa = await self._io(za.open_array(store=store, path=geom.path, mode="r"))
                 # Format-agnostic: zarr-v2 metadata exposes `dtype`/`encode_chunk_key`
                 # where v3 has `data_type`/`chunk_key_encoding.encode_chunk_key` -- so the
                 # engine reads public v2 stores (WeatherBench2 ARCO) as well as v3.
@@ -347,7 +397,7 @@ class Scheduler:
 
     async def _fetch_decode(self, read: StoredChunkRead, ctx: _ArrayCtx) -> np.ndarray:
         key = ctx.path + "/" + ctx.encode(read.coords)
-        buf = await ctx.store.get(key, prototype=self._proto)  # type: ignore[attr-defined]
+        buf = await self._io(ctx.store.get(key, prototype=self._proto))  # type: ignore[attr-defined]
         if buf is None:  # absent chunk == all fill_value (zarr's getitem semantics)
             return np.full(ctx.chunk_shape, ctx.fill_value, dtype=ctx.dtype)
         [decoded] = list(await ctx.codec.decode([(buf, ctx.spec)]))  # type: ignore[attr-defined]

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -39,7 +39,7 @@ from .pool import ChunkPool, output_geometry
 from .scheduler import Scheduler, SchedulerConfig
 from .shuffle import block_shuffled_order, sequential_order
 from .split import SplitManifest, valid_anchor_range
-from .store import open_geometries
+from .store import close_store, open_geometries
 from .types import ArrayGeometry, Batch, DecodedChunk, SplitName, StoredChunkRead
 
 logger = logging.getLogger(__name__)
@@ -417,18 +417,23 @@ class InSituDataset:
                     )
 
     def close(self) -> None:
-        """Release the cache pool's backing (mmap handles, cached chunks).
+        """Release the cache pool's backing (mmap handles, cached chunks) and any async
+        store session.
 
         The pool persists across epochs, so close it when done training -- not per
         epoch. With ``persist=True`` the cache files + manifest are kept on disk for a
         future run (only the in-memory handles are released); otherwise the mmap spill
-        files are unlinked. Idempotent; also called on GC.
+        files are unlinked. An fsspec/gcsfs store's aiohttp session is closed on its own
+        loop here (a no-op for obstore) so it does not leak or spew a teardown traceback
+        at GC; gcsfs recreates it lazily if the store is reused. Idempotent; also called
+        on GC.
         """
         self._pool.close()
+        close_store(self.store)
 
     def __del__(self) -> None:
         with contextlib.suppress(Exception):  # best-effort on GC
-            self._pool.close()
+            self.close()
 
 
 class _SplitView:

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -31,15 +31,15 @@ import logging
 import queue
 import threading
 from collections.abc import Callable, Iterator, Sequence
-from typing import Any
 
 import numpy as np
+from zarr.abc.store import Store
 
 from .pool import ChunkPool, output_geometry
 from .scheduler import Scheduler, SchedulerConfig
 from .shuffle import block_shuffled_order, sequential_order
 from .split import SplitManifest, valid_anchor_range
-from .store import StoreLike, open_geometries
+from .store import open_geometries
 from .types import ArrayGeometry, Batch, DecodedChunk, SplitName, StoredChunkRead
 
 logger = logging.getLogger(__name__)
@@ -107,7 +107,7 @@ class InSituDataset:
 
     def __init__(
         self,
-        store: StoreLike,
+        store: Store,
         manifest: SplitManifest,
         geometries: dict[str, ArrayGeometry] | None = None,
         *,
@@ -124,13 +124,9 @@ class InSituDataset:
         on_bad_chunk: str = "raise",
         chunk_transforms: Sequence[Callable[[DecodedChunk], DecodedChunk]] = (),
         batch_transforms: Sequence[Callable[[Batch], Batch]] = (),
-        **store_kwargs: Any,
     ) -> None:
         self.store = store
-        self.store_kwargs = store_kwargs
-        self.geometries = (
-            geometries if geometries is not None else open_geometries(store, **store_kwargs)
-        )
+        self.geometries = geometries if geometries is not None else open_geometries(store)
         self.manifest = manifest
         self.variables = list(self.geometries)
 
@@ -379,7 +375,6 @@ class InSituDataset:
             self.geometries,
             self._pool,
             self.scheduler_config,
-            **self.store_kwargs,
         ) as sched:
             producer = threading.Thread(
                 target=produce, args=(sched,), name="insitu-prefetch", daemon=True

--- a/src/insitubatch/store.py
+++ b/src/insitubatch/store.py
@@ -70,6 +70,37 @@ def as_store(store: StoreLike, *, read_only: bool = True, **kwargs: Any) -> Stor
     return store
 
 
+def fsspec_store(url: str, *, read_only: bool = True, **storage_options: Any) -> Store:
+    """Return a zarr ``FsspecStore`` for ``url`` (any fsspec-supported backend).
+
+    Reaches stores via a backend fsspec filesystem -- notably GCS Rapid/zonal
+    buckets (gRPC) and GCS requester-pays, which obstore does not currently
+    support. ``**storage_options`` pass straight through to
+    ``FsspecStore.from_url`` (credentials, project, endpoint, Rapid config, ...).
+
+    Requires an fsspec backend for the URL scheme: ``insitubatch[gcsfs]`` for
+    ``gs://``, or bring your own (``s3fs``, ...). A sync backend (e.g. local
+    ``file://``) is auto-wrapped as async by zarr; ``gs://`` via gcsfs is
+    natively async. See :func:`store_from_url` for the obstore-backed constructor.
+    """
+    return zarr.storage.FsspecStore.from_url(
+        url, storage_options=storage_options or None, read_only=read_only
+    )
+
+
+def arraylake_store(repo: str, *, branch: str = "main") -> Store:
+    """Open an Arraylake repo and return its read-only Icechunk session store.
+
+    Auth comes from a cached ``al auth login`` or ``ARRAYLAKE_TOKEN``; the client
+    vends the bucket credentials for the repo. The returned object is a zarr-v3
+    ``Store`` bound to the branch snapshot -- exactly what the engine accepts.
+    Requires ``insitubatch[arraylake]``.
+    """
+    from arraylake import Client
+
+    return Client().get_repo(repo).readonly_session(branch).store
+
+
 def ensure_local_dir(url: str) -> str:
     """For a ``file://`` URL, create the target directory so writes can land.
 

--- a/src/insitubatch/store.py
+++ b/src/insitubatch/store.py
@@ -1,21 +1,20 @@
-"""Storage shim: one URL, any backend.
+"""Storage: the engine reads a zarr ``Store``; constructors build one per backend.
 
-The whole local-now / cloud-later story is a single function. ``obstore`` already
-dispatches on URL scheme (``file://``, ``s3://``, ``gs://``, ``az://``,
-``memory://``) and ``zarr.storage.ObjectStore`` wraps it for the async zarr path.
-So Phase 0 (local ``file://``) and Phase 1 (``s3://...``) differ only in the URL --
-no hot-path code change, and the read path stays pure Rust (no fsspec layer).
+The engine's whole contract is "a zarr-v3 ``Store``" -- the hot path only ever
+speaks that interface, so any backend works. There is no URL-vs-object dispatch:
+callers pick a constructor for their backend and hand the resulting ``Store`` to
+:class:`~insitubatch.source.InSituDataset` and :func:`open_geometries`.
 
-We deliberately do *not* route through fsspec / universal_pathlib on the read
-hot path: the entire thesis is that obstore wins by bypassing the fsspec/s3fs
-Python layer. (obstore.fsspec exists if path-style ergonomics are ever wanted
-off the hot path -- but not here.)
+- :func:`obstore_store` -- URL-addressable stores via ``obstore`` (``file://``,
+  ``s3://``, ``gs://``, ``az://``, ``memory://``). Pure-Rust read path, no fsspec
+  layer; the local-now / cloud-later story is just a different URL.
+- :func:`fsspec_store` -- fsspec-backed, for what obstore does not reach (GCS
+  Rapid/zonal over gRPC, requester-pays).
+- :func:`arraylake_store` -- an Arraylake/Icechunk session store, bound to a
+  repository snapshot/branch (no URL round-trips to it, so it must be an object).
 
-A URL is one way to name a store, not the only one. The engine's actual contract
-is "a zarr-v3 ``Store``", so callers may hand in a prebuilt store instead of a
-URL (:data:`StoreLike`, normalized by :func:`as_store`). This is required for
-Icechunk: a session store is bound to a repository snapshot/branch and has no URL
-that round-trips to it -- but it is a zarr Store, so the hot path is unchanged.
+Anything that is already a zarr ``Store`` (a custom store, an Icechunk session)
+is passed straight to the engine -- no constructor needed.
 """
 
 from __future__ import annotations
@@ -32,42 +31,17 @@ from zarr.abc.store import Store
 
 from .types import ArrayGeometry
 
-# What the engine reads from: a URL (we build an obstore-backed store) or an
-# already-built zarr-v3 Store. The hot path only ever speaks the zarr Store
-# interface, so any backend works -- Icechunk session stores in particular have
-# no URL that round-trips to them, so they must be passed as objects.
-StoreLike = str | Store
-"""A store argument: either a URL string (resolved by :func:`as_store` /
-:func:`store_from_url`) or an already-constructed obstore ``Store``."""
 
-
-def store_from_url(url: str, *, read_only: bool = True, **kwargs: Any) -> zarr.storage.ObjectStore:
-    """Return a zarr ObjectStore for ``url`` (any obstore-supported scheme).
+def obstore_store(url: str, *, read_only: bool = True, **kwargs: Any) -> Store:
+    """Return an obstore-backed zarr ``Store`` for ``url`` (any obstore scheme).
 
     ``file:///abs/path.zarr`` for local; ``s3://bucket/path.zarr`` for cloud.
     Extra ``kwargs`` pass through to ``obstore.store.from_url`` (region,
-    credentials, client options, ...).
+    credentials, client options, ...). The read path stays pure Rust -- no fsspec
+    Python layer.
     """
     obs = obstore.store.from_url(url, **kwargs)
     return zarr.storage.ObjectStore(obs, read_only=read_only)
-
-
-def as_store(store: StoreLike, *, read_only: bool = True, **kwargs: Any) -> Store:
-    """Normalize a URL *or* an already-built zarr Store into a zarr Store.
-
-    A ``str`` is opened via :func:`store_from_url` (obstore-backed); an existing
-    Store (e.g. an Icechunk session store) is returned unchanged. ``kwargs`` and
-    ``read_only`` configure URL construction only -- passing them alongside a
-    prebuilt store is a usage error (the store already carries that state).
-    """
-    if isinstance(store, str):
-        return store_from_url(store, read_only=read_only, **kwargs)
-    if kwargs:
-        raise TypeError(
-            f"store_kwargs {sorted(kwargs)} apply only to URL stores; a prebuilt "
-            f"{type(store).__name__} was passed and already carries its configuration."
-        )
-    return store
 
 
 def fsspec_store(url: str, *, read_only: bool = True, **storage_options: Any) -> Store:
@@ -81,7 +55,7 @@ def fsspec_store(url: str, *, read_only: bool = True, **storage_options: Any) ->
     Requires an fsspec backend for the URL scheme: ``insitubatch[gcsfs]`` for
     ``gs://``, or bring your own (``s3fs``, ...). A sync backend (e.g. local
     ``file://``) is auto-wrapped as async by zarr; ``gs://`` via gcsfs is
-    natively async. See :func:`store_from_url` for the obstore-backed constructor.
+    natively async. See :func:`obstore_store` for the obstore-backed constructor.
     """
     return zarr.storage.FsspecStore.from_url(
         url, storage_options=storage_options or None, read_only=read_only
@@ -114,16 +88,17 @@ def ensure_local_dir(url: str) -> str:
 
 
 def open_geometries(
-    store: StoreLike,
+    store: Store,
     variables: list[str] | None = None,
-    **kwargs: Any,
 ) -> dict[str, ArrayGeometry]:
-    """Introspect a zarr group (URL or Store) into ``{name: ArrayGeometry}``.
+    """Introspect a zarr group ``Store`` into ``{name: ArrayGeometry}``.
 
-    Lets ``InSituDataset`` be built from a store spec alone -- geometry (shape,
+    Lets ``InSituDataset`` be built from a store alone -- geometry (shape,
     chunks, dtype) is read from the array metadata rather than hand-specified.
+    Build the ``store`` with :func:`obstore_store` / :func:`fsspec_store` /
+    :func:`arraylake_store`, or pass any prebuilt zarr ``Store``.
     """
-    group = zarr.open_group(store=as_store(store, **kwargs), mode="r")
+    group = zarr.open_group(store=store, mode="r")
     names = variables if variables is not None else [k for k, _ in group.arrays()]
     out: dict[str, ArrayGeometry] = {}
     for name in names:

--- a/src/insitubatch/store.py
+++ b/src/insitubatch/store.py
@@ -57,6 +57,12 @@ def fsspec_store(url: str, *, read_only: bool = True, **storage_options: Any) ->
     ``file://``) is auto-wrapped as async by zarr; ``gs://`` via gcsfs is
     natively async. See :func:`obstore_store` for the obstore-backed constructor.
     """
+    # LocalFileSystem does not create parent dirs on write (unlike obstore's LocalStore
+    # and every object store, where prefixes are implicit), so writing a zarr's nested
+    # chunk paths 404s. Default auto_mkdir for file:// so local writes behave like the
+    # other backends; harmless on reads, and never sent to object stores.
+    if urlparse(url).scheme in ("", "file"):
+        storage_options.setdefault("auto_mkdir", True)
     return zarr.storage.FsspecStore.from_url(
         url, storage_options=storage_options or None, read_only=read_only
     )

--- a/src/insitubatch/store.py
+++ b/src/insitubatch/store.py
@@ -19,6 +19,8 @@ is passed straight to the engine -- no constructor needed.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import os
 from typing import Any
 from urllib.parse import urlparse
@@ -79,6 +81,30 @@ def arraylake_store(repo: str, *, branch: str = "main") -> Store:
     from arraylake import Client
 
     return Client().get_repo(repo).readonly_session(branch).store
+
+
+def close_store(store: Store) -> None:
+    """Best-effort teardown for a store that holds an async fsspec session (gcsfs, s3fs).
+
+    Such a backend creates an aiohttp session on the first event loop that awaits it --
+    for a zarr store, that is zarr's loop, not fsspec's -- but gcsfs's finalizer captures
+    ``fs.loop`` (which is ``None`` here) and closes the session on the *wrong* loop at GC,
+    spewing a harmless-looking "Task was destroyed / attached to a different loop"
+    traceback and leaking the connection. Closing the session here on the loop it actually
+    lives on makes that finalizer a no-op.
+
+    A no-op for stores with no such session (obstore's ``ObjectStore`` has no ``.fs``) and
+    for already-closed or not-running loops. gcsfs recreates the session lazily, so a
+    store closed here still works if reused -- but call this only when done with it.
+    """
+    fs: Any = getattr(store, "fs", None)
+    session = getattr(fs, "_session", None)
+    loop = getattr(session, "_loop", None)
+    if session is None or loop is None or session.closed or not loop.is_running():
+        return
+    with contextlib.suppress(Exception):  # teardown is best-effort; never raise from close
+        asyncio.run_coroutine_threadsafe(session.close(), loop).result(timeout=5)
+        fs._session = None
 
 
 def ensure_local_dir(url: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 import zarr
 
-from insitubatch import ensure_local_dir, store_from_url
+from insitubatch import ensure_local_dir, obstore_store
 
 
 @pytest.fixture
@@ -16,7 +16,7 @@ def write_zarr(tmp_path):
     def _write(*, n=80, spc=8, inner=(2, 2), variables=("t2m",), seed=0):
         url = f"file://{tmp_path}/d.zarr"
         ensure_local_dir(url)
-        group = zarr.open_group(store=store_from_url(url, read_only=False), mode="w")
+        group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
         rng = np.random.default_rng(seed)
         srcs: dict[str, np.ndarray] = {}
         for var in variables:

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -95,3 +95,15 @@ def test_workers_engine_spawns(tmp_path) -> None:
     )
     rows = run(cfg)
     assert rows and rows[0].n_samples > 0
+
+
+def test_run_forwards_store_kwargs(tmp_path) -> None:
+    # Regression: engines build the store from store_kwargs and hand a Store to
+    # open_geometries/InSituDataset -- the kwargs must NOT be splatted into those (the
+    # Store-only migration break). The suite smoke tests use empty store_kwargs, so only
+    # a non-empty dict exercises the path (obstore ignores skip_signature on file://).
+    url = f"file://{tmp_path}/k.zarr"
+    make_dataset(url, n_samples=40, inner=(3, 3), sample_chunk=8, variables=["t2m"])
+    cfg = Cfg(engine="insitu", url=url, storage="file", sample_chunk=8, batch_size=8, epochs=1)
+    rows = run(cfg, store_kwargs={"skip_signature": True})
+    assert rows and rows[0].n_samples > 0

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -97,6 +97,52 @@ def test_workers_engine_spawns(tmp_path) -> None:
     assert rows and rows[0].n_samples > 0
 
 
+def test_run_fsspec_backend_threads_to_row(tmp_path) -> None:
+    # The M-GCS A/B: an engine must read through the fsspec backend and stamp it on the
+    # JSONL row so obstore vs fsspec rows are distinguishable. file:// exercises the whole
+    # dispatch without cloud (FsspecStore auto-wraps the sync LocalFileSystem).
+    pytest.importorskip("fsspec")
+    url = f"file://{tmp_path}/f.zarr"
+    make_dataset(url, n_samples=40, inner=(3, 3), sample_chunk=8, variables=["t2m"])
+    cfg = Cfg(
+        engine="insitu",
+        url=url,
+        storage="file",
+        backend="fsspec",
+        sample_chunk=8,
+        batch_size=8,
+        epochs=1,
+    )
+    rows = run(cfg)
+    assert rows and rows[0].n_samples > 0
+    assert rows[0].backend == "fsspec"
+
+
+def test_make_dataset_fsspec_backend_round_trips(tmp_path) -> None:
+    # make_dataset --backend fsspec is the only writer that reaches GCS Rapid (gRPC).
+    # Prove a full write->read round-trip through fsspec; file:// exercises it locally,
+    # which requires fsspec_store's auto_mkdir default (LocalFileSystem won't create the
+    # nested chunk dirs zarr writes, unlike obstore's LocalStore).
+    pytest.importorskip("fsspec")
+    url = f"file://{tmp_path}/w.zarr"
+    make_dataset(
+        url, n_samples=32, inner=(3, 3), sample_chunk=8, variables=["t2m"], backend="fsspec"
+    )
+    cfg = Cfg(
+        engine="naive",
+        url=url,
+        storage="file",
+        backend="fsspec",
+        sample_chunk=8,
+        batch_size=8,
+        epochs=1,
+    )
+    # 32 samples / chunk 8 = 4 chunks; run() splits (0.8, 0.1, 0.1) -> train = 3 chunks,
+    # and naive reads only the train split, so exactly 24 samples come back.
+    rows = run(cfg)
+    assert rows and rows[0].n_samples == 24
+
+
 def test_run_forwards_store_kwargs(tmp_path) -> None:
     # Regression: engines build the store from store_kwargs and hand a Store to
     # open_geometries/InSituDataset -- the kwargs must NOT be splatted into those (the

--- a/tests/test_check_transform.py
+++ b/tests/test_check_transform.py
@@ -12,7 +12,7 @@ import numpy as np
 import pytest
 import zarr
 
-from insitubatch import ensure_local_dir, open_geometries, store_from_url
+from insitubatch import ensure_local_dir, obstore_store, open_geometries
 from insitubatch.check_transform import gil_probe, load_transform, main, read_chunk
 from insitubatch.types import ChunkRead, DecodedChunk
 
@@ -67,10 +67,10 @@ not_callable = 42
 
 
 @pytest.fixture
-def store(tmp_path):
+def url(tmp_path):
     url = f"file://{tmp_path}/syn.zarr"
     ensure_local_dir(url)
-    g = zarr.open_group(store=store_from_url(url, read_only=False), mode="w")
+    g = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
     arr = g.create_array("t2m", shape=(24, 6, 8), chunks=(8, 6, 8), dtype="f4")
     arr[:] = np.random.default_rng(0).standard_normal((24, 6, 8)).astype("f4")
     return url
@@ -139,51 +139,49 @@ def test_load_transform_non_callable(transforms_file):
 # -- one-chunk read ---------------------------------------------------------
 
 
-def test_read_chunk_matches_source(store):
-    geom = open_geometries(store, variables=["t2m"])["t2m"]
-    chunk = read_chunk(store, "t2m", 1, geom)
+def test_read_chunk_matches_source(url):
+    geom = open_geometries(obstore_store(url), variables=["t2m"])["t2m"]
+    chunk = read_chunk(obstore_store(url), "t2m", 1, geom)
     assert chunk.data.shape == (8, 6, 8) and chunk.sample_offset == 8
 
 
 # -- main() integration: exit codes + report --------------------------------
 
 
-def test_main_passes_for_correct_reshaping_transform(store, transforms_file, capsys):
-    rc = main([store, "--var", "t2m", "--transform", f"{transforms_file}:MeanLastAxis", *FAST])
+def test_main_passes_for_correct_reshaping_transform(url, transforms_file, capsys):
+    rc = main([url, "--var", "t2m", "--transform", f"{transforms_file}:MeanLastAxis", *FAST])
     out = capsys.readouterr().out
     assert rc == 0
     assert "8/chunk" in out and "(6, 8)" in out  # geometry line
     assert "-> (6,)" in out and "[OK]" in out  # declared output validated
 
 
-def test_main_fails_on_wrong_output_inner(store, transforms_file, capsys):
-    rc = main([store, "--var", "t2m", "--transform", f"{transforms_file}:wrong_declare", *FAST])
+def test_main_fails_on_wrong_output_inner(url, transforms_file, capsys):
+    rc = main([url, "--var", "t2m", "--transform", f"{transforms_file}:wrong_declare", *FAST])
     out = capsys.readouterr().out
     assert rc == 1
     assert "MISMATCH" in out and "_persist would raise" in out
 
 
-def test_main_fails_on_undeclared_reshape(store, transforms_file, capsys):
-    rc = main(
-        [store, "--var", "t2m", "--transform", f"{transforms_file}:reshape_no_declare", *FAST]
-    )
+def test_main_fails_on_undeclared_reshape(url, transforms_file, capsys):
+    rc = main([url, "--var", "t2m", "--transform", f"{transforms_file}:reshape_no_declare", *FAST])
     out = capsys.readouterr().out
     assert rc == 1
     assert "does not declare output_inner" in out
 
 
-def test_main_bad_transform_returns_2(store, capsys):
-    rc = main([store, "--var", "t2m", "--transform", "nope_no_colon", *FAST])
+def test_main_bad_transform_returns_2(url, capsys):
+    rc = main([url, "--var", "t2m", "--transform", "nope_no_colon", *FAST])
     assert rc == 2
     assert "could not load --transform" in capsys.readouterr().err
 
 
-def test_main_store_auth_flags_pass_through(store, transforms_file, capsys):
-    """--skip-signature / --request-payer thread into the store open (so check_transform
+def test_main_store_auth_flags_pass_through(url, transforms_file, capsys):
+    """--skip-signature / --request-payer thread into the url open (so check_transform
     reaches the same public / Requester-Pays stores the loader does)."""
     rc = main(
         [
-            store,
+            url,
             "--var",
             "t2m",
             "--transform",
@@ -196,10 +194,10 @@ def test_main_store_auth_flags_pass_through(store, transforms_file, capsys):
     assert rc == 0
 
 
-def test_main_chunk_out_of_range(store, transforms_file, capsys):
+def test_main_chunk_out_of_range(url, transforms_file, capsys):
     rc = main(
         [
-            store,
+            url,
             "--var",
             "t2m",
             "--transform",
@@ -216,19 +214,19 @@ def test_main_chunk_out_of_range(store, transforms_file, capsys):
 # -- GIL probe plumbing -----------------------------------------------------
 
 
-def test_gil_probe_reports_fields_and_classifies_vectorized(store, transforms_file):
-    geom = open_geometries(store, variables=["t2m"])["t2m"]
-    base = read_chunk(store, "t2m", 0, geom)
+def test_gil_probe_reports_fields_and_classifies_vectorized(url, transforms_file):
+    geom = open_geometries(obstore_store(url), variables=["t2m"])["t2m"]
+    base = read_chunk(obstore_store(url), "t2m", 0, geom)
     fn = load_transform(f"{transforms_file}:vectorized_scale")
     out = gil_probe(fn, base, threads=2, min_seconds=0.02, repeats=1)
     assert {"iters", "serial_s", "parallel_s", "speedup", "per_call_ms", "mb_s"} <= out.keys()
     assert out["iters"] >= 1 and out["serial_s"] > 0 and out["speedup"] > 0
 
 
-def test_gil_probe_single_thread_speedup_about_one(store, transforms_file):
+def test_gil_probe_single_thread_speedup_about_one(url, transforms_file):
     # threads=1: serial and parallel are the same work -> speedup ~1 (no scaling claimed).
-    geom = open_geometries(store, variables=["t2m"])["t2m"]
-    base = read_chunk(store, "t2m", 0, geom)
+    geom = open_geometries(obstore_store(url), variables=["t2m"])["t2m"]
+    base = read_chunk(obstore_store(url), "t2m", 0, geom)
     fn = load_transform(f"{transforms_file}:vectorized_scale")
     out = gil_probe(fn, base, threads=1, min_seconds=0.02, repeats=1)
     assert out["speedup"] == pytest.approx(1.0, abs=0.6)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 import numpy as np
 import pytest
 
-from insitubatch import open_geometries, split_by_chunk
+from insitubatch import obstore_store, open_geometries, split_by_chunk
 from insitubatch.source import InSituDataset
 from insitubatch.types import DecodedChunk
 
@@ -24,9 +24,9 @@ def _boom(chunk: DecodedChunk) -> DecodedChunk:
 
 def test_error_propagates_through_prefetch(write_zarr) -> None:
     url, _ = write_zarr(n=40, spc=8)
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
-    ds = InSituDataset(url, manifest, chunk_transforms=[_boom])
+    ds = InSituDataset(obstore_store(url), manifest, chunk_transforms=[_boom])
     ds.set_epoch(0)
     with pytest.raises(ValueError, match="boom"):
         list(ds.train)
@@ -37,7 +37,7 @@ def test_bad_chunk_raises_by_default_then_nan_fills(write_zarr) -> None:
     fills it with NaN and carries on (the rest of the data intact)."""
     url, srcs = write_zarr(n=40, spc=8, inner=(2, 2))  # 5 chunks of 8
     src = srcs["t2m"]
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
 
     # Corrupt chunk 1's stored bytes so decode fails (not a valid compressed stream).
@@ -45,12 +45,14 @@ def test_bad_chunk_raises_by_default_then_nan_fills(write_zarr) -> None:
     assert chunk.exists(), f"chunk file not found: {chunk}"
     chunk.write_bytes(b"\x00\x01\x02\x03")
 
-    ds = InSituDataset(url, manifest, shuffle=False, batch_size=8)
+    ds = InSituDataset(obstore_store(url), manifest, shuffle=False, batch_size=8)
     ds.set_epoch(0)
     with pytest.raises(Exception):  # noqa: B017 - decode raises a codec-specific type
         list(ds.train)
 
-    ds = InSituDataset(url, manifest, shuffle=False, batch_size=8, on_bad_chunk="nan")
+    ds = InSituDataset(
+        obstore_store(url), manifest, shuffle=False, batch_size=8, on_bad_chunk="nan"
+    )
     ds.set_epoch(0)
     batches = list(ds.train)
     idx = np.concatenate([b.sample_indices for b in batches])

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -21,6 +21,21 @@ def test_wb2_example_crops_subregion(tmp_path) -> None:
     assert summary["ttfb_ms"] >= 0.0
 
 
+def test_wb2_example_forwards_store_kwargs(tmp_path) -> None:
+    # Regression: run_demo forwards auth kwargs (skip_signature/request_payer) to the
+    # *store constructor*, not to open_geometries/InSituDataset. The synthetic path has
+    # empty store_kwargs, so only a non-empty kwarg exercises the forwarding -- exactly
+    # the path the Store-only migration broke (obstore ignores request_payer on file://).
+    summary = run_demo(url=None, request_payer=True, batch_size=8, verbose=False)
+    assert summary["samples"] > 0
+
+
+def test_wb2_example_fsspec_backend(tmp_path) -> None:
+    pytest.importorskip("fsspec")  # gcsfs extra; fsspec_store reads file:// via zarr's wrapper
+    summary = run_demo(url=None, backend="fsspec", batch_size=8, verbose=False)
+    assert summary["samples"] > 0
+
+
 def test_wb2_xbatcher_example_spawns(tmp_path) -> None:
     pytest.importorskip("torch")
     pytest.importorskip("xbatcher")
@@ -59,7 +74,11 @@ def test_fit_scaler_example_partial_fit(tmp_path) -> None:
     pytest.importorskip("sklearn")  # bench extra
     from examples.fit_scaler import run_demo
 
-    summary = run_demo(url=None, cache_dir=str(tmp_path / "cache"), verbose=False)
+    # skip_signature is a store-constructor kwarg forwarded via **store_kwargs; passing it
+    # here traverses the forwarding the migration broke (obstore ignores it on file://).
+    summary = run_demo(
+        url=None, cache_dir=str(tmp_path / "cache"), verbose=False, skip_signature=True
+    )
     assert summary["samples"] > 0
     assert summary["stat_max_err"] < 1e-3  # partial_fit over the loader == true global stats
     assert abs(summary["scaled_mean"]) < 1e-2  # batch-stage scaling -> standardized output

--- a/tests/test_fsspec_store.py
+++ b/tests/test_fsspec_store.py
@@ -39,6 +39,23 @@ def test_fsspec_store_round_trips_an_epoch(write_zarr) -> None:
     np.testing.assert_array_equal(got, srcs["t2m"])
 
 
+def test_fsspec_store_io_routes_to_zarr_loop(tmp_path) -> None:
+    # Regression for the cross-loop crash: a genuinely-async fsspec store (gcsfs, or
+    # the local async wrapper here) binds its session to the loop that first awaits it
+    # -- zarr's -- so the scheduler must drive its IO there, not on its own loop. An
+    # obstore store is loop-agnostic and needs no routing. (The round-trip above already
+    # exercises the routed read end to end; this pins the selection directly.)
+    from zarr.core.sync import _get_loop
+
+    from insitubatch import obstore_store
+    from insitubatch.scheduler import _fsspec_io_loop
+
+    fss = fsspec_store(f"file://{tmp_path}")  # async fsspec wrapper -> route to zarr's loop
+    assert _fsspec_io_loop(fss) is _get_loop()
+    obs = obstore_store(f"file://{tmp_path}")  # loop-agnostic -> await inline
+    assert _fsspec_io_loop(obs) is None
+
+
 def test_fsspec_store_writes_local_zarr(tmp_path) -> None:
     # Regression: a local fsspec write must create the nested chunk dirs zarr emits.
     # LocalFileSystem won't (unlike obstore's LocalStore), so fsspec_store defaults

--- a/tests/test_fsspec_store.py
+++ b/tests/test_fsspec_store.py
@@ -1,0 +1,33 @@
+"""fsspec-backed store path (insitubatch.fsspec_store).
+
+Exercises the fsspec store path without needing a real cloud bucket: fsspec's
+local ``file://`` backend, which zarr auto-wraps as async. gcsfs/Rapid ride the
+same ``FsspecStore.from_url`` path, so a green local round-trip proves the
+wiring; the GCS-specific validation lives on the bench box, not in unit tests.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+# fsspec is not a core dep; it arrives via a backend extra
+# (insitubatch[gcsfs] -> gcsfs -> fsspec). Skip where absent.
+pytest.importorskip("fsspec")
+
+from insitubatch import fsspec_store, open_geometries, split_by_chunk  # noqa: E402
+from insitubatch.source import InSituDataset  # noqa: E402
+
+
+def test_fsspec_store_round_trips_an_epoch(write_zarr) -> None:
+    url, srcs = write_zarr(n=40, spc=8)
+    store = fsspec_store(url)  # read-only zarr FsspecStore over the local fs
+
+    geom = open_geometries(store)["t2m"]
+    manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(store, manifest, shuffle=False, batch_size=5, block_chunks=2)
+    ds.set_epoch(0)
+
+    got = np.concatenate([b.arrays["t2m"] for b in ds.train])
+    # shuffle=False -> samples arrive in order, so they equal the written source.
+    np.testing.assert_array_equal(got, srcs["t2m"])

--- a/tests/test_fsspec_store.py
+++ b/tests/test_fsspec_store.py
@@ -10,12 +10,18 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+import zarr
 
 # fsspec is not a core dep; it arrives via a backend extra
 # (insitubatch[gcsfs] -> gcsfs -> fsspec). Skip where absent.
 pytest.importorskip("fsspec")
 
-from insitubatch import fsspec_store, open_geometries, split_by_chunk  # noqa: E402
+from insitubatch import (  # noqa: E402
+    ensure_local_dir,
+    fsspec_store,
+    open_geometries,
+    split_by_chunk,
+)
 from insitubatch.source import InSituDataset  # noqa: E402
 
 
@@ -31,3 +37,21 @@ def test_fsspec_store_round_trips_an_epoch(write_zarr) -> None:
     got = np.concatenate([b.arrays["t2m"] for b in ds.train])
     # shuffle=False -> samples arrive in order, so they equal the written source.
     np.testing.assert_array_equal(got, srcs["t2m"])
+
+
+def test_fsspec_store_writes_local_zarr(tmp_path) -> None:
+    # Regression: a local fsspec write must create the nested chunk dirs zarr emits.
+    # LocalFileSystem won't (unlike obstore's LocalStore), so fsspec_store defaults
+    # auto_mkdir for file:// -- without it this 404s on the first chunk write.
+    url = f"file://{tmp_path}/w.zarr"
+    ensure_local_dir(url)
+    src = np.arange(8 * 3 * 3, dtype="f4").reshape(8, 3, 3)
+
+    group = zarr.open_group(store=fsspec_store(url, read_only=False), mode="w")
+    arr = group.create_array(
+        "t2m", shape=src.shape, chunks=(4, 3, 3), dtype="f4", dimension_names=("time", "y", "x")
+    )
+    arr[:] = src
+
+    back = zarr.open_array(store=fsspec_store(url), path="t2m", mode="r")
+    np.testing.assert_array_equal(np.asarray(back[:]), src)

--- a/tests/test_icechunk.py
+++ b/tests/test_icechunk.py
@@ -14,10 +14,9 @@ import pytest
 import zarr
 
 from insitubatch import (
-    as_store,
+    obstore_store,
     open_geometries,
     split_by_chunk,
-    store_from_url,
 )
 from insitubatch.source import InSituDataset
 
@@ -96,22 +95,4 @@ def test_icechunk_matches_url_path(icechunk_store, write_zarr) -> None:
         return np.concatenate([b.arrays["t2m"] for b in ds.train], axis=0)
 
     np.testing.assert_array_equal(collect(store), src)
-    np.testing.assert_array_equal(collect(url), src)
-
-
-def test_as_store_passthrough(icechunk_store) -> None:
-    store, _ = icechunk_store(n=8, spc=8)
-    assert as_store(store) is store  # an existing Store is returned unchanged
-
-
-def test_as_store_builds_url(tmp_path) -> None:
-    url = f"file://{tmp_path}"  # an existing dir; obstore canonicalizes the root
-    built = as_store(url)
-    assert isinstance(built, zarr.abc.store.Store)
-    assert type(built) is type(store_from_url(url))
-
-
-def test_as_store_rejects_kwargs_with_prebuilt_store(icechunk_store) -> None:
-    store, _ = icechunk_store(n=8, spc=8)
-    with pytest.raises(TypeError, match="apply only to URL stores"):
-        as_store(store, region="us-east-1")
+    np.testing.assert_array_equal(collect(obstore_store(url)), src)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from insitubatch import (
     StandardScaler,
+    obstore_store,
     open_geometries,
     split_by_chunk,
 )
@@ -21,13 +22,13 @@ from insitubatch.source import InSituDataset
 def test_transforms_prefetch_reconstruct(write_zarr) -> None:
     url, srcs = write_zarr(n=50, spc=8, inner=(2, 2))  # 7 chunks; last holds 50-48=2
     src = srcs["t2m"]
-    geoms = open_geometries(url)
+    geoms = open_geometries(obstore_store(url))
     manifest = split_by_chunk(geoms["t2m"], fractions=(1.0, 0.0, 0.0))
     mean, std = src.astype("f8").mean(), src.astype("f8").std()  # global stats, pre-fit
     scaler = StandardScaler(mean={"t2m": np.float64(mean)}, std={"t2m": np.float64(std)})
 
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         shuffle=False,
         batch_size=6,

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -11,16 +11,16 @@ import pytest
 
 jax = pytest.importorskip("jax")
 
-from insitubatch import open_geometries, split_by_chunk  # noqa: E402
+from insitubatch import obstore_store, open_geometries, split_by_chunk  # noqa: E402
 from insitubatch.frameworks import to_jax  # noqa: E402
 from insitubatch.source import InSituDataset  # noqa: E402
 
 
 def test_to_jax_roundtrip(write_zarr) -> None:
     url, srcs = write_zarr(n=40, spc=8)
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
-    ds = InSituDataset(url, manifest, shuffle=False, batch_size=8, block_chunks=2)
+    ds = InSituDataset(obstore_store(url), manifest, shuffle=False, batch_size=8, block_chunks=2)
     ds.set_epoch(0)
 
     seen = []

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -24,7 +24,7 @@ import zarr
 from zarr.core.array_spec import ArraySpec
 from zarr.core.buffer import default_buffer_prototype
 
-from insitubatch import ensure_local_dir, open_geometries, store_from_url
+from insitubatch import ensure_local_dir, obstore_store, open_geometries
 from insitubatch.plan import build_stored_chunk_reads
 from insitubatch.pool import ChunkPool
 from insitubatch.types import ArrayGeometry, StoredChunkRead
@@ -39,7 +39,7 @@ def tiled_store(tmp_path):
     """Write the spike's two-layout store; return (url, {var: source array})."""
     url = f"file://{tmp_path}/tiled.zarr"
     ensure_local_dir(url)
-    group = zarr.open_group(store=store_from_url(url, read_only=False), mode="w")
+    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
     data = np.random.default_rng(0).standard_normal(SHAPE).astype("f4")
     srcs = {}
     for var, chunks in LAYOUTS.items():
@@ -51,7 +51,7 @@ def tiled_store(tmp_path):
 
 async def _decode_tiles(url: str, var: str) -> dict[tuple[int, ...], np.ndarray]:
     """Fetch + decode every stored tile of ``var`` (the spike's zarr-internals path)."""
-    aa = zarr.open_array(store=store_from_url(url), path=var, mode="r")._async_array
+    aa = zarr.open_array(store=obstore_store(url), path=var, mode="r")._async_array
     proto = default_buffer_prototype()
     spec = ArraySpec(
         shape=aa.metadata.chunks,
@@ -72,7 +72,7 @@ async def _decode_tiles(url: str, var: str) -> dict[tuple[int, ...], np.ndarray]
 
 def test_build_stored_chunk_reads_expands_and_dedups(tiled_store):
     url, _ = tiled_store
-    geoms = open_geometries(url)
+    geoms = open_geometries(obstore_store(url))
     reads = build_stored_chunk_reads([0, 1, 0], geoms)  # repeat 0 -> must dedup
 
     # spatial expands to its inner grid (3x2=6), single_inner to 1; x2 outer chunks.
@@ -94,7 +94,7 @@ def test_pool_aliased_labels_decode_once(tiled_store):
     """
     url, srcs = tiled_store
     array = "single_inner"
-    base = open_geometries(url, variables=[array])[array]  # base.name == array
+    base = open_geometries(obstore_store(url), variables=[array])[array]  # base.name == array
     geoms = {"now": base, "next": base}  # two labels, one underlying array
     tiles = asyncio.run(_decode_tiles(url, array))
     reads = build_stored_chunk_reads(range(base.n_chunks), {array: base})
@@ -121,7 +121,7 @@ def test_pool_aliased_labels_decode_once(tiled_store):
 def test_pool_scatter_reconstructs_array(tiled_store, var):
     """Concurrent tile scatter assembles each outer chunk == arr[:] (FT stress)."""
     url, srcs = tiled_store
-    geoms = open_geometries(url, variables=[var])
+    geoms = open_geometries(obstore_store(url), variables=[var])
     geom = geoms[var]
     tiles = asyncio.run(_decode_tiles(url, var))
     reads = build_stored_chunk_reads(range(geom.n_chunks), geoms)
@@ -186,7 +186,7 @@ def test_pool_mmap_backing_parity_and_cleanup(tiled_store, tmp_path, var):
     """mmap-backed slots reconstruct == arr[:], live as files on disk, and the
     files are freed on close()."""
     url, srcs = tiled_store
-    geoms = open_geometries(url, variables=[var])
+    geoms = open_geometries(obstore_store(url), variables=[var])
     geom = geoms[var]
     tiles = asyncio.run(_decode_tiles(url, var))
     backing = tmp_path / "slots"
@@ -213,7 +213,7 @@ def test_pool_mmap_backing_parity_and_cleanup(tiled_store, tmp_path, var):
 def test_pool_mmap_backing_with_transform(tiled_store, tmp_path):
     """A shape-preserving chunk_transform's output is written back into the memmap."""
     url, srcs = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
 
@@ -261,7 +261,7 @@ def test_pool_reshaping_transform_heap_gather(tiled_store):
     Today gather allocates at the *source* inner_shape and assigns from the post-transform
     slot (output shape) -> broadcast error. The output geometry must drive gather."""
     url, srcs = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     spc = geom.sample_chunk_size
@@ -279,7 +279,7 @@ def test_pool_reshaping_transform_heap_gather(tiled_store):
 def test_pool_reshaping_transform_dtype_recast(tiled_store):
     """A dtype-changing transform (f4 -> f8) propagates its dtype through gather."""
     url, srcs = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     spc = geom.sample_chunk_size
@@ -307,7 +307,7 @@ def test_pool_reshaping_transform_mmap_persist_roundtrip(
     if no_cloudpickle:
         monkeypatch.setattr("insitubatch.pool.cloudpickle", None)
     url, srcs = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     spc = geom.sample_chunk_size
@@ -337,7 +337,7 @@ def test_pool_reshaping_transform_structural_mismatch_is_miss(tiled_store, tmp_p
     """A persisted output-shaped entry whose *output* geometry no longer matches (the
     transform now yields a different inner shape) is invalidated structurally -- a miss."""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     backing = tmp_path / "cache"
@@ -371,7 +371,7 @@ def test_pool_reshaping_transform_structural_mismatch_is_miss(tiled_store, tmp_p
 def test_pool_wait_ready_raises_on_failure(tiled_store):
     """A poisoned tile surfaces on the waiting consumer (fail-fast), not a hang."""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["spatial"])
+    geoms = open_geometries(obstore_store(url), variables=["spatial"])
     pool = ChunkPool(geoms)
     pool.try_admit("spatial", 0)
     pool.fail("spatial", 0, RuntimeError("boom"))
@@ -383,7 +383,7 @@ def test_pool_lru_evicts_unpinned_under_budget(tiled_store):
     """Admission evicts unpinned-LRU to make room; pinned chunks are never dropped,
     and a still-resident chunk is retained (the cross-epoch-reuse mechanic)."""
     url, srcs = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     spc = geom.sample_chunk_size
@@ -419,7 +419,7 @@ def test_pool_pin_is_reference_counted_not_boolean(tiled_store):
     resident until the *last* release -- a single unpin after a double-pin must not free
     it (the boolean-set bug). Pins are counts: N pins need N unpins."""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     full = geom.sample_chunk_size * int(np.prod(geom.inner_shape)) * geom.dtype.itemsize
@@ -446,7 +446,7 @@ def test_pool_unpin_all_drops_abandoned_partial_keeps_ready(tiled_store):
     never be a valid cache entry -- but retain a fully ready chunk for cross-epoch
     reuse, with the byte accounting reclaimed."""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["spatial"])
+    geoms = open_geometries(obstore_store(url), variables=["spatial"])
     geom = geoms["spatial"]
     tiles = asyncio.run(_decode_tiles(url, "spatial"))
     inner = list(geom.inner_coords())
@@ -475,7 +475,7 @@ def test_pool_unpin_all_drops_abandoned_partial_keeps_ready(tiled_store):
 def test_pool_persist_requires_cache_dir(tiled_store):
     """persist=True only makes sense with a backing dir to keep files in -- fail fast."""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     with pytest.raises(ValueError, match="cache_dir|backing_dir"):
         ChunkPool(geoms, persist=True)
 
@@ -491,7 +491,7 @@ def test_pool_cross_run_persistence(tiled_store, tmp_path):
     """A persistent cache survives process exit: a new pool over the same dir serves
     each chunk as a ready hit (no re-scatter), reconstructing the source exactly."""
     url, srcs = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     spc = geom.sample_chunk_size
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
@@ -525,7 +525,7 @@ def test_pool_persist_crash_recovery_without_close(tiled_store, tmp_path):
     pool over the same dir revives them all as hits -- re-decoding ZERO. The close-only manifest
     could not do this: it wrote nothing on a crash."""
     url, srcs = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     spc = geom.sample_chunk_size
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
@@ -556,7 +556,7 @@ def test_pool_persist_partial_iteration_recovers_completed_subset(tiled_store, t
     """A crash partway through the first epoch: only the chunks that *completed* are logged, so
     a reopen revives exactly that subset -- the rest are misses (re-decoded), not false hits."""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     backing = tmp_path / "cache"
@@ -577,7 +577,7 @@ def test_pool_persist_log_dedups_across_epochs_and_runs(tiled_store, tmp_path):
     refetch, and across a close+reopen) never appends a duplicate line -- the count stays equal
     to the number of distinct cached chunks."""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     backing = tmp_path / "cache"
@@ -609,7 +609,7 @@ def test_pool_close_is_idempotent(tiled_store, tmp_path):
     and ChunkPool.__del__ is a third best-effort call. The second call releases nothing (the log
     handle is already None, the slots already freed) and must not raise."""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     backing = tmp_path / "cache"
@@ -626,7 +626,7 @@ def test_pool_persist_missing_file_is_miss_not_raise(tiled_store, tmp_path):
     eviction, which keeps the file) is a **miss**: revive fails to open it, drops the entry, and
     the chunk is re-fetched. Never a raise -- the cache is a transparent optimization."""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     backing = tmp_path / "cache"
@@ -652,7 +652,7 @@ def test_pool_persist_evicted_chunk_revives_from_kept_file(tiled_store, tmp_path
     budget pressure keeps its ``.npy`` on disk, so touching it again revives it as a HIT from
     NVMe -- no re-fetch. (This is why a missing file is never expected from eviction.)"""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     backing = tmp_path / "cache"
@@ -676,7 +676,7 @@ def test_pool_persist_invalidates_on_geometry_mismatch(tiled_store, tmp_path):
     geometry is ignored (a miss), not served -- the structural fingerprint check.
     The dataset/pipeline identity is the cache_dir path; the user versions that."""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     backing = tmp_path / "cache"
@@ -698,7 +698,7 @@ def test_pool_persist_invalidates_on_transform_change(tiled_store, tmp_path):
     hit; a changed transform is a *stale* cache, which RAISES by default (not a false hit, and
     not a silent cold-start -- a stale cache is almost never what the user intended)."""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     backing = tmp_path / "cache"
@@ -727,7 +727,7 @@ def test_pool_persist_reset_stale_cache_gcs_and_rebuilds(tiled_store, tmp_path):
     """reset_stale_cache=True opts into wiping a stale cache: the old .npy files and log are
     deleted and the cache rebuilds cold (no raise, no false hit)."""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     backing = tmp_path / "cache"
@@ -759,7 +759,7 @@ def test_pool_persist_cache_key_overrides_fingerprint(tiled_store, tmp_path):
     """An explicit transform.cache_key is authoritative: distinct function objects sharing
     a key reopen as a hit; bumping the key invalidates."""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     backing = tmp_path / "cache"
@@ -790,7 +790,7 @@ def test_pool_persist_cloudpickle_catches_closure_change(tiled_store, tmp_path):
     closed-over constant get different fingerprints (a source hash would falsely match)."""
     pytest.importorskip("cloudpickle")
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     backing = tmp_path / "cache"
@@ -817,7 +817,7 @@ def test_pool_persist_without_cloudpickle_warns_and_falls_back(
     warning. The source hash still reopens an unchanged transform as a hit."""
     monkeypatch.setattr("insitubatch.pool.cloudpickle", None)
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     backing = tmp_path / "cache"
@@ -842,7 +842,7 @@ def _persist_two(tiled_store, backing):
     tampered/malformed entry can be an *interior* (non-tail) line -- a corrupt tail is treated
     as a crash artifact and dropped, an interior one is corruption and raises."""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     pool = ChunkPool(geoms, backing_dir=backing, persist=True)
@@ -934,7 +934,7 @@ def test_pool_spill_unlinks_without_persist(tiled_store, tmp_path):
     """Without persist, a backing dir is scratch: files are unlinked on close and no
     manifest is written (the persistence machinery is persist-only)."""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     backing = tmp_path / "spill"

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -16,9 +16,9 @@ import zarr
 from insitubatch import (
     SplitName,
     ensure_local_dir,
+    obstore_store,
     open_geometries,
     split_by_chunk,
-    store_from_url,
 )
 from insitubatch.source import InSituDataset
 
@@ -26,7 +26,7 @@ from insitubatch.source import InSituDataset
 def _write(tmp_path, *, n=160, spc=8, inner=(2, 2)) -> str:
     url = f"file://{tmp_path}/d.zarr"
     ensure_local_dir(url)
-    group = zarr.open_group(store=store_from_url(url, read_only=False), mode="w")
+    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
     arr = group.create_array("t2m", shape=(n, *inner), chunks=(spc, *inner), dtype="f4")
     arr[:] = np.arange(n * int(np.prod(inner)), dtype="f4").reshape(n, *inner)
     return url
@@ -34,7 +34,7 @@ def _write(tmp_path, *, n=160, spc=8, inner=(2, 2)) -> str:
 
 def test_producer_runs_ahead_of_consumer(tmp_path) -> None:
     url = _write(tmp_path)
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(0.8, 0.1, 0.1))
 
     produced: list[int] = []
@@ -44,7 +44,7 @@ def test_producer_runs_ahead_of_consumer(tmp_path) -> None:
         return batch
 
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         batch_size=4,
         block_chunks=2,
@@ -69,12 +69,12 @@ def test_producer_runs_ahead_of_consumer(tmp_path) -> None:
 
 def test_prefetch_preserves_values_and_coverage(tmp_path) -> None:
     url = _write(tmp_path)
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(0.8, 0.1, 0.1))
-    src = zarr.open_group(store=store_from_url(url), mode="r")["t2m"][:]
+    src = zarr.open_group(store=obstore_store(url), mode="r")["t2m"][:]
 
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         batch_size=4,
         block_chunks=2,
@@ -104,10 +104,10 @@ def test_partial_iteration_reaps_producer(tmp_path) -> None:
     test.)
     """
     url = _write(tmp_path, n=160, spc=8)
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         batch_size=4,
         block_chunks=2,
@@ -142,13 +142,13 @@ def test_early_break_then_next_epoch_does_not_deadlock(tmp_path) -> None:
     parked, no in-flight work). Pins must not survive an epoch.
     """
     url = _write(tmp_path, n=160, spc=8)  # 20 chunks; train split ~16
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
 
     # budget = 2 * block_chunks chunks; batch_size < one block so a block yields
     # several batches -> breaking after one batch leaves the current block pinned too.
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         batch_size=4,
         block_chunks=2,

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -14,7 +14,7 @@ import numpy as np
 import pytest
 import zarr
 
-from insitubatch import ensure_local_dir, open_geometries, store_from_url, valid_anchor_range
+from insitubatch import ensure_local_dir, obstore_store, open_geometries, valid_anchor_range
 from insitubatch.pool import ChunkPool
 from insitubatch.scheduler import Scheduler, SchedulerConfig
 from insitubatch.types import ArrayGeometry
@@ -27,7 +27,7 @@ LAYOUTS = {"single_inner": (2, 9, 7), "spatial": (2, 4, 4)}
 def tiled_store(tmp_path):
     url = f"file://{tmp_path}/sched.zarr"
     ensure_local_dir(url)
-    group = zarr.open_group(store=store_from_url(url, read_only=False), mode="w")
+    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
     data = np.random.default_rng(1).standard_normal(SHAPE).astype("f4")
     srcs = {}
     for var, chunks in LAYOUTS.items():
@@ -60,7 +60,7 @@ def _drain_in_order(sched: Scheduler, geom: ArrayGeometry, var: str, *, unpin: b
 @pytest.mark.parametrize("bounded", [False, True])  # unbounded, then a 2-chunk budget
 def test_scheduler_fills_pool_matches_array(tiled_store, var, bounded):
     url, srcs = tiled_store
-    geoms = open_geometries(url, variables=[var])
+    geoms = open_geometries(obstore_store(url), variables=[var])
     geom = geoms[var]
     budget = None
     if bounded:
@@ -81,7 +81,9 @@ def test_scheduler_fills_pool_matches_array(tiled_store, var, bounded):
 def test_scheduler_inflight_saturates_to_budget(tiled_store):
     """With many tiles and a small budget, in-flight peaks at exactly max_inflight."""
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["spatial"])  # 3 chunks x 6 tiles = 18 reads
+    geoms = open_geometries(
+        obstore_store(url), variables=["spatial"]
+    )  # 3 chunks x 6 tiles = 18 reads
     with _make(url, geoms, max_inflight=4) as sched:
         fut = sched.start(range(geoms["spatial"].n_chunks))
         _drain_in_order(sched, geoms["spatial"], "spatial", unpin=False)
@@ -98,7 +100,7 @@ def test_scheduler_close_closes_the_loop(tiled_store):
     free-threaded 3.13t (where finalizer timing exposes the latent leak).
     """
     url, _ = tiled_store
-    geoms = open_geometries(url, variables=["single_inner"])
+    geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     sched = _make(url, geoms)
     sched.start(range(geoms["single_inner"].n_chunks))
     sched.close()
@@ -114,7 +116,7 @@ def test_scheduler_windowed_views_decode_once_and_lead(tiled_store):
     on the array (the producer drops edge anchors; here we do it explicitly).
     """
     url, srcs = tiled_store
-    base = open_geometries(url, variables=["single_inner"])["single_inner"]
+    base = open_geometries(obstore_store(url), variables=["single_inner"])["single_inner"]
     geoms = {"now": base, "next": base.shift(1)}  # one array, two views
     spc = base.sample_chunk_size
     src = srcs["single_inner"]

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -12,9 +12,9 @@ import zarr
 from insitubatch import (
     SplitName,
     ensure_local_dir,
+    obstore_store,
     open_geometries,
     split_by_chunk,
-    store_from_url,
 )
 from insitubatch.shuffle import block_shuffled_order
 from insitubatch.source import InSituDataset, _partition_blocks
@@ -49,22 +49,22 @@ def test_partition_blocks_empty() -> None:
 def test_unequal_chunking_raises(tmp_path) -> None:
     url = f"file://{tmp_path}/uv.zarr"
     ensure_local_dir(url)
-    group = zarr.open_group(store=store_from_url(url, read_only=False), mode="w")
+    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
     group.create_array("u10", shape=(40, 2, 2), chunks=(8, 2, 2), dtype="f4")
     group.create_array("v10", shape=(40, 2, 2), chunks=(4, 2, 2), dtype="f4")  # different spc
-    geoms = open_geometries(url)
+    geoms = open_geometries(obstore_store(url))
     manifest = split_by_chunk(geoms["u10"], fractions=(0.8, 0.1, 0.1))
 
     with pytest.raises(ValueError, match="same sample-axis"):
-        InSituDataset(url, manifest, geometries=geoms)
+        InSituDataset(obstore_store(url), manifest, geometries=geoms)
 
 
 def test_shuffle_false_is_in_order(write_zarr) -> None:
     url, _ = write_zarr(n=40, spc=8)
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         shuffle=False,
         batch_size=5,
@@ -77,10 +77,10 @@ def test_shuffle_false_is_in_order(write_zarr) -> None:
 
 def test_shuffle_true_covers_but_reorders(write_zarr) -> None:
     url, _ = write_zarr(n=40, spc=8)
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         shuffle=True,
         seed=1,
@@ -98,7 +98,7 @@ def test_chunk_decoded_once_per_epoch_without_cache(write_zarr) -> None:
     # non-consecutive batches. With the cache off, last-use eviction must still
     # decode each chunk exactly once per epoch (naive per-batch eviction re-reads).
     url, _ = write_zarr(n=80, spc=4)  # 20 chunks
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
 
     decoded: collections.Counter[int] = collections.Counter()
@@ -108,7 +108,7 @@ def test_chunk_decoded_once_per_epoch_without_cache(write_zarr) -> None:
         return chunk
 
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         batch_size=1,
         block_chunks=20,
@@ -130,11 +130,11 @@ def test_residency_is_bounded_by_block(write_zarr) -> None:
     # split. The lower bound is one block: a batch may draw across a whole block,
     # so the block must be co-resident to gather.
     url, _ = write_zarr(n=160, spc=4)  # 40 chunks
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     block_chunks, batch_size = 8, 4
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         batch_size=batch_size,
         block_chunks=block_chunks,
@@ -153,7 +153,7 @@ def test_cache_decode_once_across_epochs(write_zarr, tmp_path, kind) -> None:
     # + transformed exactly ONCE across two epochs; epoch 2 is served from the pool
     # (cross-epoch reuse, the B2 win). Both backings: heap and mmap'd-on-NVMe.
     url, _ = write_zarr(n=160, spc=8)  # 20 chunks
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
 
     transformed: collections.Counter[int] = collections.Counter()
@@ -163,7 +163,7 @@ def test_cache_decode_once_across_epochs(write_zarr, tmp_path, kind) -> None:
         return chunk
 
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         batch_size=4,
         block_chunks=4,
@@ -190,7 +190,7 @@ def test_cache_persists_across_runs(write_zarr, tmp_path) -> None:
     # same cache_dir serves every chunk from disk -- no re-decode (the chunk transform
     # never runs in run 2) -- and yields byte-identical batches in the same draw order.
     url, _ = write_zarr(n=160, spc=8)  # 20 chunks
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     cache = str(tmp_path / "cache")
 
@@ -202,7 +202,7 @@ def test_cache_persists_across_runs(write_zarr, tmp_path) -> None:
 
     def make() -> InSituDataset:
         return InSituDataset(
-            url,
+            obstore_store(url),
             manifest,
             batch_size=4,
             block_chunks=4,
@@ -244,7 +244,7 @@ def test_persist_stale_transform_raises_then_rebuilds_with_flag(write_zarr, tmp_
     # (a stale cache is almost never intended). reset_stale_cache=True instead wipes it and
     # rebuilds cold -- yielding correct batches again.
     url, _ = write_zarr(n=80, spc=8)  # 10 chunks
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     cache = str(tmp_path / "cache")
 
@@ -258,7 +258,7 @@ def test_persist_stale_transform_raises_then_rebuilds_with_flag(write_zarr, tmp_
 
     def make(transform, reset=False) -> InSituDataset:
         return InSituDataset(
-            url,
+            obstore_store(url),
             manifest,
             batch_size=4,
             block_chunks=4,
@@ -295,13 +295,13 @@ def test_persist_warns_when_cache_unusable(write_zarr, tmp_path, caplog) -> None
     # were deleted under a surviving manifest) -> one loud WARNING per epoch, and the
     # chunks are still re-fetched correctly (a miss, never a raise).
     url, _ = write_zarr(n=80, spc=8)  # 10 chunks
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     cache = tmp_path / "cache"
 
     def make() -> InSituDataset:
         return InSituDataset(
-            url,
+            obstore_store(url),
             manifest,
             batch_size=4,
             block_chunks=4,
@@ -337,9 +337,9 @@ def test_sample_range_subsets_what_the_dataset_reads(write_zarr) -> None:
     # sample_range restricts the manifest to the covering chunks; the dataset then
     # yields exactly those samples (chunk-aligned).
     url, _ = write_zarr(n=80, spc=8)  # 10 chunks
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0), sample_range=(16, 40))
-    ds = InSituDataset(url, manifest, shuffle=False, batch_size=8)
+    ds = InSituDataset(obstore_store(url), manifest, shuffle=False, batch_size=8)
     ds.set_epoch(0)
     idx = np.concatenate([b.sample_indices for b in ds.train])
     assert set(idx.tolist()) == set(range(16, 40))  # chunks 2,3,4 -> samples 16..39
@@ -349,9 +349,9 @@ def test_split_views_share_one_pool_and_cover_disjoint(write_zarr) -> None:
     """train / val / test / all are views on *one* dataset sharing *one* pool; the splits
     are disjoint and ``all`` is their union."""
     url, _ = write_zarr(n=80, spc=8)  # 10 chunks
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(0.6, 0.2, 0.2))
-    ds = InSituDataset(url, manifest, batch_size=8, block_chunks=4)
+    ds = InSituDataset(obstore_store(url), manifest, batch_size=8, block_chunks=4)
     pool = ds._pool  # the one pool every view shares
 
     seen: dict[str, set[int]] = {}
@@ -370,9 +370,11 @@ def test_split_views_share_one_pool_and_cover_disjoint(write_zarr) -> None:
 
 def test_val_view_is_deterministic_train_shuffles(write_zarr) -> None:
     url, _ = write_zarr(n=80, spc=8)
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(0.6, 0.2, 0.2))
-    ds = InSituDataset(url, manifest, batch_size=8, block_chunks=4, shuffle=True, seed=1)
+    ds = InSituDataset(
+        obstore_store(url), manifest, batch_size=8, block_chunks=4, shuffle=True, seed=1
+    )
     ds.set_epoch(0)
     val0 = np.concatenate([b.sample_indices for b in ds.val])
     ds.set_epoch(5)  # different epoch

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -8,10 +8,12 @@ threading -- the part that would break silently on a rename.
 
 from __future__ import annotations
 
+import asyncio
 import sys
+import threading
 from unittest.mock import MagicMock
 
-from insitubatch import arraylake_store
+from insitubatch import arraylake_store, close_store, obstore_store
 
 
 def test_arraylake_store_threads_repo_and_branch(monkeypatch) -> None:
@@ -46,3 +48,35 @@ def test_arraylake_store_defaults_to_main_branch(monkeypatch) -> None:
     arraylake_store("org/repo")
 
     repo.readonly_session.assert_called_once_with("main")
+
+
+def test_close_store_is_noop_for_obstore(tmp_path) -> None:
+    # obstore's ObjectStore has no async session (no .fs) -> close_store must be a
+    # harmless no-op, not raise. This is the common path (default backend).
+    close_store(obstore_store(f"file://{tmp_path}"))  # no exception = pass
+
+
+def test_close_store_closes_async_session_on_its_loop() -> None:
+    # An fsspec/gcsfs store's aiohttp session lives on some loop; close_store must close
+    # it *on that loop* and drop the handle so gcsfs's finalizer is a no-op. Mocked so it
+    # runs without a cloud backend: a live loop in a thread + a fake session.
+    loop = asyncio.new_event_loop()
+    threading.Thread(target=loop.run_forever, daemon=True).start()
+
+    class FakeSession:
+        def __init__(self) -> None:
+            self.closed = False
+            self._loop = loop
+
+        async def close(self) -> None:
+            self.closed = True
+
+    session = FakeSession()
+    fs = type("FakeFS", (), {"_session": session})()
+    store = type("FakeStore", (), {"fs": fs})()
+
+    close_store(store)  # type: ignore[arg-type]  # duck-typed store stand-in
+
+    assert session.closed is True  # closed on its own loop
+    assert fs._session is None  # handle dropped so the finalizer won't re-close
+    loop.call_soon_threadsafe(loop.stop)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,48 @@
+"""Store constructors that need no live backend to test the wiring.
+
+``arraylake_store`` is a thin promotion of the Arraylake/Icechunk session-store
+recipe into the library; it needs a client + auth + network to run for real, so
+here we mock the ``arraylake`` module and assert only the call chain + argument
+threading -- the part that would break silently on a rename.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+from insitubatch import arraylake_store
+
+
+def test_arraylake_store_threads_repo_and_branch(monkeypatch) -> None:
+    sentinel_store = object()  # stands in for the zarr session Store
+    session = MagicMock()
+    session.store = sentinel_store
+    repo = MagicMock()
+    repo.readonly_session.return_value = session
+    client = MagicMock()
+    client.get_repo.return_value = repo
+
+    fake_arraylake = MagicMock()
+    fake_arraylake.Client = MagicMock(return_value=client)
+    monkeypatch.setitem(sys.modules, "arraylake", fake_arraylake)
+
+    got = arraylake_store("org/repo", branch="dev")
+
+    assert got is sentinel_store
+    fake_arraylake.Client.assert_called_once_with()
+    client.get_repo.assert_called_once_with("org/repo")
+    repo.readonly_session.assert_called_once_with("dev")
+
+
+def test_arraylake_store_defaults_to_main_branch(monkeypatch) -> None:
+    repo = MagicMock()
+    client = MagicMock()
+    client.get_repo.return_value = repo
+    fake_arraylake = MagicMock()
+    fake_arraylake.Client = MagicMock(return_value=client)
+    monkeypatch.setitem(sys.modules, "arraylake", fake_arraylake)
+
+    arraylake_store("org/repo")
+
+    repo.readonly_session.assert_called_once_with("main")

--- a/tests/test_tf.py
+++ b/tests/test_tf.py
@@ -12,16 +12,16 @@ import pytest
 
 tf = pytest.importorskip("tensorflow")
 
-from insitubatch import open_geometries, split_by_chunk  # noqa: E402
+from insitubatch import obstore_store, open_geometries, split_by_chunk  # noqa: E402
 from insitubatch.frameworks import as_tf_dataset, to_tf  # noqa: E402
 from insitubatch.source import InSituDataset  # noqa: E402
 
 
 def _ds(write_zarr):
     url, srcs = write_zarr(n=40, spc=8)
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
-    ds = InSituDataset(url, manifest, shuffle=False, batch_size=8, block_chunks=2)
+    ds = InSituDataset(obstore_store(url), manifest, shuffle=False, batch_size=8, block_chunks=2)
     ds.set_epoch(0)
     return ds, srcs
 

--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -12,16 +12,16 @@ torch = pytest.importorskip("torch")
 
 from torch.utils.data import DataLoader  # noqa: E402
 
-from insitubatch import open_geometries, split_by_chunk  # noqa: E402
+from insitubatch import obstore_store, open_geometries, split_by_chunk  # noqa: E402
 from insitubatch.frameworks import as_torch, to_torch  # noqa: E402
 from insitubatch.source import InSituDataset  # noqa: E402
 
 
 def _ds(write_zarr):
     url, srcs = write_zarr(n=40, spc=8)
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
-    ds = InSituDataset(url, manifest, shuffle=False, batch_size=8, block_chunks=2)
+    ds = InSituDataset(obstore_store(url), manifest, shuffle=False, batch_size=8, block_chunks=2)
     ds.set_epoch(0)
     return ds, srcs
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -9,9 +9,9 @@ from insitubatch import (
     SplitName,
     StandardScaler,
     ensure_local_dir,
+    obstore_store,
     open_geometries,
     split_by_chunk,
-    store_from_url,
 )
 from insitubatch.source import InSituDataset
 from insitubatch.types import ChunkRead, DecodedChunk
@@ -20,7 +20,7 @@ from insitubatch.types import ChunkRead, DecodedChunk
 def _write(tmp_path, *, n=80, spc=8, inner=(3, 4), seed=0) -> tuple[str, np.ndarray]:
     url = f"file://{tmp_path}/d.zarr"
     ensure_local_dir(url)
-    store = store_from_url(url, read_only=False)
+    store = obstore_store(url, read_only=False)
     group = zarr.open_group(store=store, mode="w")
     arr = group.create_array("t2m", shape=(n, *inner), chunks=(spc, *inner), dtype="f4")
     src = (np.random.default_rng(seed).standard_normal((n, *inner)) * 5.0 + 10.0).astype("f4")
@@ -53,7 +53,7 @@ def test_standard_scaler_save_load(tmp_path) -> None:
 
 def test_chunk_transform_normalizes_batches(tmp_path) -> None:
     url, src = _write(tmp_path)
-    geoms = open_geometries(url)
+    geoms = open_geometries(obstore_store(url))
     manifest = split_by_chunk(geoms["t2m"], fractions=(0.8, 0.1, 0.1))
     # Pre-fit global stats over the train split (as a user would, or via the
     # partial_fit-over-loader pattern), then apply at the chunk stage.
@@ -62,7 +62,7 @@ def test_chunk_transform_normalizes_batches(tmp_path) -> None:
     sc = StandardScaler(mean={"t2m": np.float64(m)}, std={"t2m": np.float64(s)})
 
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         batch_size=10,
         block_chunks=4,
@@ -80,7 +80,7 @@ def test_reshaping_chunk_transform_through_dataset(tmp_path) -> None:
     """A reshaping chunk_transform (mean over the last inner axis, (3,4)->(3,)) flows
     end-to-end through InSituDataset: every batch carries the post-transform geometry."""
     url, src = _write(tmp_path, inner=(3, 4))
-    geoms = open_geometries(url)
+    geoms = open_geometries(obstore_store(url))
     manifest = split_by_chunk(geoms["t2m"], fractions=(0.8, 0.1, 0.1))
 
     class MeanLastAxis:
@@ -92,7 +92,11 @@ def test_reshaping_chunk_transform_through_dataset(tmp_path) -> None:
             return geom.inner_shape[:-1], geom.dtype
 
     ds = InSituDataset(
-        url, manifest, batch_size=10, block_chunks=4, chunk_transforms=[MeanLastAxis()]
+        obstore_store(url),
+        manifest,
+        batch_size=10,
+        block_chunks=4,
+        chunk_transforms=[MeanLastAxis()],
     )
     ds.set_epoch(0)
     for batch in ds.train:
@@ -106,14 +110,14 @@ def test_cross_variable_windspeed_is_a_batch_transform(tmp_path) -> None:
     # stage (the chunk stage sees one variable at a time).
     url = f"file://{tmp_path}/uv.zarr"
     ensure_local_dir(url)
-    group = zarr.open_group(store=store_from_url(url, read_only=False), mode="w")
+    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
     rng = np.random.default_rng(0)
     su = rng.standard_normal((40, 2, 2)).astype("f4")
     sv = rng.standard_normal((40, 2, 2)).astype("f4")
     group.create_array("u10", shape=(40, 2, 2), chunks=(8, 2, 2), dtype="f4")[:] = su
     group.create_array("v10", shape=(40, 2, 2), chunks=(8, 2, 2), dtype="f4")[:] = sv
 
-    geoms = open_geometries(url)
+    geoms = open_geometries(obstore_store(url))
     manifest = split_by_chunk(geoms["u10"], fractions=(0.8, 0.1, 0.1))
 
     def windspeed(batch):
@@ -121,7 +125,7 @@ def test_cross_variable_windspeed_is_a_batch_transform(tmp_path) -> None:
         return batch
 
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         batch_size=8,
         block_chunks=4,

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -12,7 +12,7 @@ import time
 import numpy as np
 import pytest
 
-from insitubatch import open_geometries, split_by_chunk, valid_anchor_range
+from insitubatch import obstore_store, open_geometries, split_by_chunk, valid_anchor_range
 from insitubatch.source import InSituDataset
 from insitubatch.types import ArrayGeometry, Batch
 
@@ -84,10 +84,10 @@ def _forecast_dataset(write_zarr, *, n, spc, shuffle, **kw):
     """A dataset with two views of one array: input ``x`` at the anchor, target ``y``
     one step ahead (``shift(1)``) -- the canonical forecast setup, no reshard."""
     url, srcs = write_zarr(n=n, spc=spc)
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     geoms = {"x": geom, "y": geom.shift(1)}
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
-    ds = InSituDataset(url, manifest, geometries=geoms, shuffle=shuffle, **kw)
+    ds = InSituDataset(obstore_store(url), manifest, geometries=geoms, shuffle=shuffle, **kw)
     return ds, srcs["t2m"]
 
 
@@ -130,10 +130,12 @@ def test_windowed_history_and_target(write_zarr) -> None:
     """A three-view window {-1, 0, +1} drops both edge anchors and reads each offset."""
     url, srcs = write_zarr(n=24, spc=4)
     src = srcs["t2m"]
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     geoms = {"prev": geom.shift(-1), "now": geom, "next": geom.shift(1)}
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
-    ds = InSituDataset(url, manifest, geometries=geoms, shuffle=True, batch_size=5, seed=1)
+    ds = InSituDataset(
+        obstore_store(url), manifest, geometries=geoms, shuffle=True, batch_size=5, seed=1
+    )
     ds.set_epoch(0)
 
     anchors = []
@@ -154,13 +156,15 @@ def test_windowed_eviction_and_cross_epoch_reuse(write_zarr) -> None:
     where a chunk freed for a miss was gathered as stale memory."""
     url, srcs = write_zarr(n=160, spc=8)  # 20 chunks
     src = srcs["t2m"]
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     geoms = {"x": geom, "y": geom.shift(1)}
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     # block_chunks=2, no override: the windowed working set holds only a few blocks, so
     # 20 chunks force repeated eviction. shuffle=False keeps the read-union local (the
     # tight budget is viable) while still exercising churn and cross-epoch reuse.
-    ds = InSituDataset(url, manifest, geometries=geoms, shuffle=False, batch_size=5, block_chunks=2)
+    ds = InSituDataset(
+        obstore_store(url), manifest, geometries=geoms, shuffle=False, batch_size=5, block_chunks=2
+    )
     for epoch in range(3):
         ds.set_epoch(epoch)
         anchors = []
@@ -182,11 +186,11 @@ def test_windowed_partial_iteration_then_clean_epoch(write_zarr) -> None:
     """
     url, srcs = write_zarr(n=160, spc=8)  # 20 chunks
     src = srcs["t2m"]
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     geoms = {"x": geom, "y": geom.shift(1)}
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         geometries=geoms,
         shuffle=True,
@@ -226,10 +230,10 @@ def test_windowed_val_correct_after_train_shared_pool(write_zarr) -> None:
     corrupted) -- the cross-split overlap the single shared pool is meant to exploit."""
     url, srcs = write_zarr(n=120, spc=8)  # 15 chunks
     src = srcs["t2m"]
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     geoms = {"x": geom, "y": geom.shift(1)}  # forecast: input x[t], target y[t]=x[t+1]
     manifest = split_by_chunk(geom, fractions=(0.7, 0.3, 0.0))
-    ds = InSituDataset(url, manifest, geometries=geoms, batch_size=6, block_chunks=2)
+    ds = InSituDataset(obstore_store(url), manifest, geometries=geoms, batch_size=6, block_chunks=2)
 
     ds.set_epoch(0)
     for _ in ds.train:  # warm/pollute the shared pool (windowed reads spill across the split)

--- a/tests/test_zarr_v2.py
+++ b/tests/test_zarr_v2.py
@@ -22,9 +22,9 @@ import zarr
 
 from insitubatch import (
     ensure_local_dir,
+    obstore_store,
     open_geometries,
     split_by_chunk,
-    store_from_url,
 )
 from insitubatch.source import InSituDataset
 
@@ -37,7 +37,7 @@ def test_iterates_store_v2_and_v3(
     url = f"file://{tmp_path}/d.zarr"
     ensure_local_dir(url)
     group = zarr.open_group(
-        store=store_from_url(url, read_only=False), mode="w", zarr_format=zarr_format
+        store=obstore_store(url, read_only=False), mode="w", zarr_format=zarr_format
     )
     arr = group.create_array(
         "t2m",
@@ -49,10 +49,10 @@ def test_iterates_store_v2_and_v3(
     src = np.arange(40 * 16, dtype="f4").reshape(40, 4, 4)
     arr[:] = src
 
-    geom = open_geometries(url)["t2m"]
+    geom = open_geometries(obstore_store(url))["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     ds = InSituDataset(
-        url,
+        obstore_store(url),
         manifest,
         shuffle=False,
         batch_size=8,

--- a/uv.lock
+++ b/uv.lock
@@ -528,7 +528,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -559,34 +559,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -1278,6 +1278,9 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
+gcsfs = [
+    { name = "gcsfs" },
+]
 gpu = [
     { name = "cupy-cuda12x" },
     { name = "kvikio-cu12" },
@@ -1317,6 +1320,7 @@ requires-dist = [
     { name = "cupy-cuda12x", marker = "extra == 'gpu'", specifier = ">=13.0" },
     { name = "flax", marker = "extra == 'jax'", specifier = ">=0.8" },
     { name = "gcsfs", marker = "extra == 'bench'", specifier = ">=2024.6" },
+    { name = "gcsfs", marker = "extra == 'gcsfs'", specifier = ">=2024.6" },
     { name = "icechunk", marker = "extra == 'icechunk'", specifier = ">=0.2" },
     { name = "jax", marker = "extra == 'jax'", specifier = ">=0.4.30" },
     { name = "kvikio-cu12", marker = "extra == 'gpu'", specifier = ">=24.10" },
@@ -1337,7 +1341,7 @@ requires-dist = [
     { name = "xbatcher", marker = "extra == 'bench'", specifier = ">=0.3" },
     { name = "zarr", specifier = ">=3.0" },
 ]
-provides-extras = ["torch", "jax", "tf", "gpu", "virtual", "cache", "bench", "docs", "icechunk", "arraylake"]
+provides-extras = ["torch", "jax", "tf", "gpu", "virtual", "cache", "bench", "docs", "icechunk", "gcsfs", "arraylake"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2155,7 +2159,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2194,7 +2198,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2206,7 +2210,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2236,9 +2240,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2250,7 +2254,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },


### PR DESCRIPTION
## What

Collapses the store layer to a **Store-only core** (per-backend constructors, no URL/kwargs dispatch) and makes **fsspec/gcsfs a genuinely working backend** for the async engine — then evaluates it against obstore on GCS. Headline result: **on standard HTTP GCS, obstore wins the transfer floor ~2×; fsspec's case rests entirely on the Rapid/gRPC path obstore can't reach, which is still pending quota.**

## The store API (Store-only collapse)

- `obstore_store` / `fsspec_store` / `arraylake_store` — the engine reads a zarr `Store`; no str-vs-`Store` dispatch, no `**store_kwargs` on the hot path (PEP 20).
- `fsspec_store` reaches what obstore can't (GCS Rapid/zonal gRPC, requester-pays) and also supports local writes (`auto_mkdir` for `file://`).

## The load-bearing fix — event-loop ownership

A genuinely-async fsspec backend (gcsfs, s3fs) binds its aiohttp session to the **first loop that awaits it**, permanently — no ctor knob pins it. For a zarr store that's **zarr's** loop, because any zarr sync call (`open_geometries`) touches it first. The scheduler drove reads on its *own* loop → `InSituDataset` over gcsfs crashed on every chunk (`Future attached to a different loop`).

Fix: route an fsspec store's opens + chunk reads to **zarr's store-IO loop** (`zarr.core.sync._get_loop`, where the session lives), bridge the result back — concurrency preserved. That's the correct owner: keeping the session on zarr's loop is what keeps the store drivable by *any* zarr code, so insitu **conforms** rather than hijacking. obstore is loop-agnostic (Rust) and is awaited inline. DESIGN.md documents this with a diagram + a TODO to unify onto zarr's loop (gated on a stress test).

## Teardown

`close_store` closes the gcsfs session on its own loop so gcsfs's finalizer (which targets the wrong loop) is a no-op — no leaked connections, no GC traceback. Called from `InSituDataset.close()` (once, not per-epoch). No-op for obstore.

## Bench tooling

- `--backend {obstore,fsspec,arraylake}` across `bench`, `make_dataset`, `probe_decode`; one `build_store` dispatch; `Result.backend` on every JSONL row.
- `probe_decode` wires the two backend-sensitive sections (1b `max_inflight` scaling through the bridge; 2 raw obstore GET vs gcsfs `cat_file` transfer floor); a raw-GET teardown that exits clean.
- `--storage` dropped (derived from the URL scheme). `--anon` made explicit so owned/private buckets read with ambient creds.

## Initial findings — standard HTTP GCS (`n2-standard-8`)

Decode-free **raw concurrent GET**, best of a 4→32 concurrency sweep (MB/s):

| chunk | obstore | gcsfs | obstore lead |
|---|---|---|---|
| c1 | 1211 | 529 | 2.3× |
| c4 | 1581 | 606 | 2.6× |
| c16 | 802 | 487 | 1.6× |

**obstore scales** with concurrency (c1: 376→681→1042→1211); **gcsfs `cat_file` plateaus ~500–600 and degrades past 16 threads** (c1: 343→513→529→358) — the per-request Python/aiohttp path on the one fsspec loop is the ceiling. End-to-end (insitu) the gap compresses to ~1.15–1.2× **only because the 8-core box is decode-bound at ~450 MB/s** — so that ~20% is a *floor* that re-widens toward the raw ~2× on faster decode.

**Takeaway:** obstore stays the HTTP default; fsspec is **not** a co-equal fast path on HTTP, but **not a regression** either. Its case is Rapid/zonal gRPC — the deciding, still-unrun experiment (blocked on quota). Recipe + hardware caveats (decode-bound masking, sustained-vs-burst on big chunks, fresh-per-backend cache) live in `ops_gcp.md §7a`; the preliminary result is in DESIGN.md M-GCS. Deliberately **not** on `docs/benchmarks.md` yet — that waits for the complete standard-vs-Rapid story so the numbers aren't read as "fsspec is worse."

## Tests

Loop selection, local write, `close_store` (obstore no-op + mocked session close), bench `--backend` round-trips — all cloud-free. Full suite green (152 passed / 4 skipped), ruff + mypy clean.

## Next

Run `ops_gcp.md §7a` Step 1 raw-GET against a **Rapid bucket** vs obstore-on-HTTP's ~1.2–1.6 GB/s ceiling — that number decides fsspec's core-dep / co-equal status. Then the `docs/benchmarks.md` write-up and the DESIGN loop-unification refactor.