### PR TITLE
feat(examples): GPU advection benchmark — stall/ceiling metrics + cloud synthetic store

### DIFF
--- a/bench/advection_report.py
+++ b/bench/advection_report.py
@@ -1,0 +1,156 @@
+"""Aggregate an advection sweep JSONL into the finding: median +/- IQR tables and one figure
+per sweep.
+
+    uv run python -m bench.advection_report --in bench/results/advection_sweep.jsonl \
+        --out bench/figures
+
+Reads rows written by ``bench.advection_sweep`` (each an ``examples._forecast_metrics``
+row plus a ``config`` dict and ``repeat``). For every config it takes the **steady** epochs
+(epoch > 0, dropping the cold first pass), medians per repeat, then reports the
+median and inter-quartile range across repeats -- so no single run carries the claim.
+
+The compute-only ceiling is joined per ``geom`` (field geometry = the conv cost), giving each
+insitu config its ``% of ceiling``. Prints a Markdown table per sweep (paste-ready for
+docs/benchmarks.md) and, if plotly is present, writes an interactive HTML figure per sweep.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+
+def load(path: str | Path) -> pd.DataFrame:
+    """Flatten the nested ``config`` dict into columns and keep steady (epoch>0) rows."""
+    raw = pd.read_json(path, lines=True)
+    cfg = pd.json_normalize(raw["config"]).add_prefix("cfg_")
+    df = pd.concat([raw.drop(columns=["config"]), cfg], axis=1)
+    steady = df[df["epoch"] > 0].copy()
+    # Fall back to all rows if a run only had one epoch (no warm rows to keep).
+    return steady if not steady.empty else df
+
+
+def _per_repeat(df: pd.DataFrame, run: str, keys: list[str]) -> pd.DataFrame:
+    """Median throughput/stall per (config, repeat) for one run, over its steady epochs."""
+    sub = df[df["run"] == run]
+    return (
+        sub.groupby([*keys, "repeat"], dropna=False)
+        .agg(samples_per_s=("samples_per_s", "median"), stall=("data_stall_fraction", "median"))
+        .reset_index()
+    )
+
+
+def _iqr(s: pd.Series) -> float:
+    return float(s.quantile(0.75) - s.quantile(0.25))
+
+
+def summarize(df: pd.DataFrame, sweep: str) -> pd.DataFrame:
+    """One row per config of ``sweep``: median +/- IQR samples/s + stall, and % of ceiling."""
+    sdf = df[df["cfg_sweep"] == sweep]
+    # The knob that varies in this sweep (for a readable leading column).
+    knob = {
+        "inflight": "cfg_max_inflight",
+        "size": "cfg_size",
+        "chunk": "cfg_sample_chunk",
+        "inner": "cfg_inner_chunk",
+    }[sweep]
+    keys = [knob, "cfg_geom"]
+
+    insitu = _per_repeat(sdf, "insitu", keys)
+    agg = (
+        insitu.groupby(keys, dropna=False)
+        .agg(
+            samples_per_s=("samples_per_s", "median"),
+            samples_iqr=("samples_per_s", _iqr),
+            stall=("stall", "median"),
+            n=("repeat", "count"),
+        )
+        .reset_index()
+    )
+
+    # Ceiling per geom (median over its repeats/epochs), joined for % of ceiling.
+    ceil = (
+        df[df["run"] == "ceiling"]
+        .groupby("cfg_geom")["samples_per_s"]
+        .median()
+        .rename("ceiling_samples_per_s")
+    )
+    agg = agg.join(ceil, on="cfg_geom")
+    agg["pct_of_ceiling"] = 100 * agg["samples_per_s"] / agg["ceiling_samples_per_s"]
+    return agg.sort_values(knob).reset_index(drop=True)
+
+
+def to_markdown(agg: pd.DataFrame, sweep: str) -> str:
+    knob = {
+        "inflight": "max_inflight",
+        "size": "size",
+        "chunk": "sample_chunk",
+        "inner": "inner_chunk",
+    }[sweep]
+    knob_col = f"cfg_{knob}"
+    lines = [
+        f"### {sweep}",
+        f"| {knob} | samples/s (med) | IQR | stall | % of ceiling | n |",
+        "|---|---|---|---|---|---|",
+    ]
+    for _, r in agg.iterrows():
+        val = "default" if pd.isna(r[knob_col]) else int(r[knob_col])
+        pct = "-" if pd.isna(r["pct_of_ceiling"]) else f"{r['pct_of_ceiling']:.1f}%"
+        lines.append(
+            f"| {val} | {r['samples_per_s']:.1f} | ±{r['samples_iqr']:.1f} | "
+            f"{r['stall']:.1%} | {pct} | {int(r['n'])} |"
+        )
+    return "\n".join(lines)
+
+
+def _figure(agg: pd.DataFrame, sweep: str, out_dir: Path) -> str | None:
+    try:
+        import plotly.graph_objects as go
+    except ImportError:
+        return None
+    knob = {
+        "inflight": "max_inflight",
+        "size": "size",
+        "chunk": "sample_chunk",
+        "inner": "inner_chunk",
+    }[sweep]
+    x = agg[f"cfg_{knob}"].fillna(-1).astype(int).astype(str).replace("-1", "default")
+    fig = go.Figure()
+    fig.add_bar(
+        x=x, y=agg["samples_per_s"], name="samples/s", error_y={"array": agg["samples_iqr"]}
+    )
+    fig.add_scatter(x=x, y=agg["stall"] * 100, name="stall %", yaxis="y2", mode="lines+markers")
+    fig.update_layout(
+        title=f"advection sweep: {sweep}",
+        xaxis_title=knob,
+        yaxis_title="samples/s (median, IQR)",
+        yaxis2={"title": "stall %", "overlaying": "y", "side": "right", "rangemode": "tozero"},
+        legend={"orientation": "h"},
+    )
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / f"advection_{sweep}.html"
+    fig.write_html(path, include_plotlyjs="cdn")
+    return str(path)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="aggregate the advection sweep JSONL")
+    p.add_argument("--in", dest="inp", required=True, help="sweep JSONL from bench.advection_sweep")
+    p.add_argument("--out", type=Path, default=Path(__file__).parent / "figures")
+    args = p.parse_args()
+
+    df = load(args.inp)
+    for sweep in ["inflight", "size", "chunk", "inner"]:
+        if not (df["cfg_sweep"] == sweep).any():
+            continue
+        agg = summarize(df, sweep)
+        print("\n" + to_markdown(agg, sweep) + "\n")
+        fig = _figure(agg, sweep, args.out)
+        if fig:
+            print(f"figure -> {fig}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/advection_sweep.py
+++ b/bench/advection_sweep.py
@@ -1,0 +1,207 @@
+"""Drive the advection stall/ceiling benchmark across the axes that back the finding.
+
+    uv run python -m bench.advection_sweep --url-prefix gs://bucket/adv \
+        --device cuda --epochs 5 --repeats 5 --sweeps inflight,size,chunk,inner
+
+Each config runs ``examples.advection.train_torch_metrics`` **in its own process** -- so the
+unbounded in-memory decoded cache and CUDA allocator start clean every time, and peak host
+RSS / peak GPU memory are that config's alone (an in-process loop would let one config's 14 GB
+cache inflate the next). The child writes its per-(run, epoch) rows to a temp JSONL; this
+runner stamps the config onto each row and appends them to one combined ``--out`` file that
+``bench.advection_report`` aggregates.
+
+The sweeps, and the claim each one confirms:
+
+* **inflight** -- throttle read-ahead depth over a fixed store (WB2 by default). Stall must
+  *rise* as prefetch is starved and *fall* back as it is restored: validates the stall metric
+  is real and produces the IO-bound datapoint the compute-bound runs never hit.
+* **size** -- same model, synthetic field 64/128/256. Shows MB/s demand is ~size-invariant
+  (bytes and conv compute both scale with pixels), so growing the field can't reach IO-bound.
+* **chunk** -- sample-axis fat <-> GRIB (``sample_chunk`` large -> 1). The DESIGN spectrum:
+  does the loader stay ahead as chunks shrink toward one-sample-per-read?
+* **inner** -- spatial fan-out (``inner_chunk``: one fat chunk -> a tiled grid). The ARCO norm;
+  restores concurrency *within* a fat sample chunk.
+
+The compute-only ceiling depends only on the field geometry (the conv cost), not on
+inflight / chunking / cache, so ``--ceiling`` is run exactly once per distinct ``geom`` and the
+report matches every insitu config to its geom's ceiling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+DEFAULT_OUT = Path(__file__).parent / "results" / "advection_sweep.jsonl"
+
+# n_steps for the synthetic sweep stores: enough chunks to split/shuffle and to make cloud IO
+# non-trivial, small enough to generate quickly. Overridable for a heavier run.
+SYNTH_STEPS = 4000
+
+
+def _synth(size: int, sample_chunk: int, inner_chunk: int | None) -> dict[str, Any]:
+    """A synthetic-store config: its geom (compute identity) is the field size alone."""
+    return {
+        "source": "synthetic",
+        "size": size,
+        "sample_chunk": sample_chunk,
+        "inner_chunk": inner_chunk,
+        "geom": f"synth{size}",
+    }
+
+
+def _configs(sweeps: set[str], *, wb2_range: str) -> Iterator[dict[str, Any]]:
+    """Yield the insitu configs for the requested sweeps (ceiling is added per geom later).
+
+    Each config is a dict of the knobs that vary; fixed knobs take the store/CLI defaults.
+    ``max_inflight=None`` means the engine default (unthrottled)."""
+    if "inflight" in sweeps:
+        # Fixed real store (WB2), vary only read-ahead depth. geom "wb2" -> its own ceiling.
+        for mi in (1, 2, 4, 8, 16, None):
+            yield {
+                "sweep": "inflight",
+                "source": "wb2",
+                "geom": "wb2",
+                "sample_range": wb2_range,
+                "max_inflight": mi,
+            }
+    if "size" in sweeps:
+        for size in (64, 128, 256):
+            yield {"sweep": "size", **_synth(size, 64, None)}
+    if "chunk" in sweeps:
+        # Sample-axis fat (256) -> GRIB-ish (4), field size fixed so compute (and ceiling) match.
+        for spc in (256, 64, 16, 4):
+            yield {"sweep": "chunk", **_synth(128, spc, None)}
+    if "inner" in sweeps:
+        # Spatial fan-out: one fat 128-chunk -> 64 (4 tiles) -> 32 (16 tiles), field size fixed.
+        for ic in (128, 64, 32):
+            yield {"sweep": "inner", **_synth(128, 64, ic)}
+
+
+def _command(
+    cfg: dict[str, Any],
+    *,
+    url_prefix: str,
+    device: str,
+    epochs: int,
+    n_steps: int,
+    ceiling: bool,
+) -> list[str]:
+    """Build the child ``train_torch_metrics`` command for one config (``--metrics-out`` is
+    appended per run by :func:`_run_config`)."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "examples.advection.train_torch_metrics",
+        "--source",
+        cfg["source"],
+        "--device",
+        device,
+        "--epochs",
+        str(epochs),
+    ]
+    if cfg["source"] == "synthetic":
+        inner = cfg["inner_chunk"] or cfg["size"]
+        url = f"{url_prefix}_{cfg['geom']}_c{cfg['sample_chunk']}_i{inner}.zarr"
+        cmd += ["--url", url, "--n-steps", str(n_steps)]
+        cmd += ["--size", str(cfg["size"]), "--sample-chunk", str(cfg["sample_chunk"])]
+        if cfg["inner_chunk"] is not None:
+            cmd += ["--inner-chunk", str(cfg["inner_chunk"])]
+    if cfg.get("sample_range"):
+        cmd += ["--sample-range", cfg["sample_range"]]
+    if cfg.get("max_inflight") is not None:
+        cmd += ["--max-inflight", str(cfg["max_inflight"])]
+    if ceiling:
+        cmd += ["--ceiling"]
+    return cmd
+
+
+def _run_config(cmd: list[str], cfg: dict[str, Any], repeat: int, out_fh: Any) -> None:
+    """Run one child, tag its rows with the config + repeat, append to the combined file."""
+    with tempfile.NamedTemporaryFile("r+", suffix=".jsonl") as tmp:
+        subprocess.run([*cmd, "--metrics-out", tmp.name], check=True)
+        tmp.seek(0)
+        for line in tmp:
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            row["config"] = cfg
+            row["repeat"] = repeat
+            out_fh.write(json.dumps(row) + "\n")
+    out_fh.flush()
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="advection stall/ceiling sweep runner")
+    p.add_argument(
+        "--sweeps",
+        default="inflight,size,chunk",
+        help="comma list of: inflight,size,chunk,inner",
+    )
+    p.add_argument(
+        "--url-prefix",
+        default="file:///tmp/insitu_adv_sweep",
+        help="synthetic store URL prefix (gs://bucket/adv on the box; file:// for local)",
+    )
+    p.add_argument("--device", default="cuda", help="cpu or cuda")
+    p.add_argument("--epochs", type=int, default=5)
+    p.add_argument("--repeats", type=int, default=5, help="repeats per config (variance)")
+    p.add_argument(
+        "--n-steps", type=int, default=SYNTH_STEPS, help="synthetic trajectory length per store"
+    )
+    p.add_argument(
+        "--wb2-range", default="0,4000", metavar="START,STOP", help="WB2 time window for --inflight"
+    )
+    p.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    args = p.parse_args()
+
+    sweeps = {s.strip() for s in args.sweeps.split(",") if s.strip()}
+    unknown = sweeps - {"inflight", "size", "chunk", "inner"}
+    if unknown:
+        p.error(f"unknown sweeps: {sorted(unknown)}")
+
+    configs = list(_configs(sweeps, wb2_range=args.wb2_range))
+    # A 0.8/0.1/0.1 split needs >=3 sample-axis chunks, so the synthetic trajectory must be a
+    # few chunks long; catch a too-short --n-steps here rather than as an empty-val crash later.
+    for cfg in configs:
+        if cfg["source"] == "synthetic" and args.n_steps < 3 * cfg["sample_chunk"]:
+            p.error(
+                f"--n-steps {args.n_steps} too short for sample_chunk {cfg['sample_chunk']} "
+                f"(need >= 3 chunks to split; use --n-steps >= {3 * cfg['sample_chunk']})"
+            )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    seen_geom: set[str] = set()
+    with args.out.open("a") as out_fh:
+        for i, cfg in enumerate(configs):
+            # One ceiling per geom (compute identity); the report joins every config to it.
+            ceiling = cfg["geom"] not in seen_geom
+            seen_geom.add(cfg["geom"])
+            for r in range(args.repeats):
+                # The ceiling (compute-only) is geom-invariant, so collect it on the first repeat.
+                do_ceiling = ceiling and r == 0
+                cmd = _command(
+                    cfg,
+                    url_prefix=args.url_prefix,
+                    device=args.device,
+                    epochs=args.epochs,
+                    n_steps=args.n_steps,
+                    ceiling=do_ceiling,
+                )
+                label = f"[{i + 1}/{len(configs)}] {cfg['sweep']} {cfg['geom']}"
+                extra = {
+                    k: cfg[k] for k in ("max_inflight", "sample_chunk", "inner_chunk") if k in cfg
+                }
+                print(f"=== {label} repeat {r + 1}/{args.repeats} {extra} ceiling={do_ceiling} ===")
+                _run_config(cmd, cfg, r, out_fh)
+    print(f"\nwrote sweep rows -> {args.out}")
+    print(f"aggregate with: uv run python -m bench.advection_report --in {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/_forecast_metrics.py
+++ b/examples/_forecast_metrics.py
@@ -1,0 +1,200 @@
+"""Framework-neutral training metrics for the forecast examples.
+
+The headline is the **data-stall fraction**: the share of wall-clock the compute
+device idles waiting on the loader. Prefetch hiding IO behind compute drives it
+toward zero -- the run is compute-bound and the loader is effectively free. It is
+self-referential (no competitor baseline), so it replaces an xbatcher A/B.
+
+The paired ``--ceiling`` run feeds the *same* model + loop from a RAM-preloaded
+list of batches (no fetch, no decode); its throughput is the compute-only ceiling
+and ``insitu_samples_per_s / ceiling_samples_per_s`` is the loader overhead.
+
+This module owns everything framework-independent: the per-(run, epoch) JSONL
+schema (:class:`ForecastMetrics`), the stall/throughput timer, and the in-memory
+log that patches the final validation RMSE onto the last row before flushing. The
+torch loop supplies only the two framework-specific numbers (a synced step and the
+GPU peak); a later JAX/TF port reuses the same collector with their own sync.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import platform
+import socket
+import time
+from collections.abc import Iterable, Iterator
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+# Reuse the bench suite's RssAnon reader so host-memory is measured the same way the
+# storage benchmarks report it (heap/stack only -- the true bound; mmap cache pages
+# are reclaimable and excluded). bench is a repo-root dev package; the examples run
+# from the repo root (``python -m examples...``), so this import resolves there.
+from bench.result import rss_breakdown_mb
+from insitubatch.types import Batch
+
+
+@dataclass
+class ForecastMetrics:
+    """One self-describing row per (run, epoch) for the forecast training benchmark.
+
+    ``run`` is ``insitu`` (fed by the loader) or ``ceiling`` (fed from RAM). The
+    headline is ``data_stall_fraction``; ``val_*`` are filled only on the final row
+    of a run (one training run's forecast skill, a sanity check that it really trained).
+    """
+
+    run: str  # insitu | ceiling
+    framework: str  # torch | jax | tf
+    source: str  # synthetic | wb2 | arraylake
+    device: str  # cpu | cuda
+    epoch: int
+    n_samples: int
+    n_batches: int
+    batch_size: int
+    wall_s: float
+    data_wait_s: float
+    compute_s: float
+    data_stall_fraction: float  # data_wait_s / wall_s -- the HEADLINE
+    samples_per_s: float
+    mb_per_s: float  # decoded volume delivered to the model
+    mean_data_wait_ms: float  # per batch
+    mean_compute_ms: float  # per batch
+    ttfb_ms: float  # wait for the first batch of the epoch (cold start on epoch 0)
+    peak_rss_anon_mb: float  # heap/stack high-water at epoch end (the real host bound)
+    peak_gpu_mem_mb: float  # torch.cuda peak this epoch (0 on cpu)
+    val_model_rmse: float = math.nan  # set on the last row of a run only
+    val_persistence_rmse: float = math.nan
+    host: str = field(default_factory=socket.gethostname)
+    platform: str = field(default_factory=platform.platform)
+    ts: float = field(default_factory=time.time)
+
+
+class StallTimer:
+    """Accumulate data-stall vs compute time over one epoch by wrapping its iterator.
+
+    ``wrap`` yields each batch, timing the gap *before* it arrives as ``data_wait``
+    (the loader stall) and the caller's loop body after it as ``compute``. This is
+    only valid when the compute body synchronizes every step -- the torch loop's
+    ``loss.item()`` does; a JAX/TF port must block equivalently.
+    """
+
+    def __init__(self) -> None:
+        self.data_wait = 0.0
+        self.compute = 0.0
+        self.ttfb = 0.0
+        self.n_batches = 0
+        self.n_samples = 0
+        self.total_bytes = 0
+
+    def wrap(self, source: Iterable[Batch]) -> Iterator[Batch]:
+        t = time.perf_counter()
+        for i, batch in enumerate(source):
+            now = time.perf_counter()
+            wait = now - t
+            self.data_wait += wait
+            if i == 0:
+                self.ttfb = wait
+            self.n_batches += 1
+            self.n_samples += len(batch.sample_indices)
+            self.total_bytes += sum(a.nbytes for a in batch.arrays.values())
+            yield batch  # caller runs (and synchronizes) the compute step here
+            after = time.perf_counter()
+            self.compute += after - now
+            t = after
+
+    def metrics(
+        self,
+        *,
+        run: str,
+        framework: str,
+        source: str,
+        device: str,
+        epoch: int,
+        batch_size: int,
+        peak_gpu_mem_mb: float,
+    ) -> ForecastMetrics:
+        """Finalize the epoch into a row. Sample host RSS now (epoch-end ~= steady-state
+        peak for a bounded prefetch buffer -- kept out of the timed loop so the /proc read
+        never counts as compute)."""
+        wall = self.data_wait + self.compute
+        nb = max(self.n_batches, 1)
+        return ForecastMetrics(
+            run=run,
+            framework=framework,
+            source=source,
+            device=device,
+            epoch=epoch,
+            n_samples=self.n_samples,
+            n_batches=self.n_batches,
+            batch_size=batch_size,
+            wall_s=wall,
+            data_wait_s=self.data_wait,
+            compute_s=self.compute,
+            data_stall_fraction=self.data_wait / wall if wall else 0.0,
+            samples_per_s=self.n_samples / wall if wall else 0.0,
+            mb_per_s=(self.total_bytes / 1e6) / wall if wall else 0.0,
+            mean_data_wait_ms=self.data_wait / nb * 1e3,
+            mean_compute_ms=self.compute / nb * 1e3,
+            ttfb_ms=self.ttfb * 1e3,
+            peak_rss_anon_mb=rss_breakdown_mb()[0],
+            peak_gpu_mem_mb=peak_gpu_mem_mb,
+        )
+
+
+class MetricsLog:
+    """Collect rows in memory, print a one-line summary each, flush to JSONL at the end.
+
+    Rows are held (not streamed) so the final validation RMSE -- known only after all
+    epochs and the eval pass -- can be patched onto the last row of the ``insitu`` run
+    before writing. ``path=None`` prints only (the CPU-validation path leaves no file).
+    """
+
+    def __init__(self, path: str | None) -> None:
+        self.path = path
+        self.rows: list[ForecastMetrics] = []
+
+    def add(self, m: ForecastMetrics) -> None:
+        self.rows.append(m)
+        print(
+            f"  [{m.run:>7}] epoch {m.epoch}  stall {m.data_stall_fraction:5.1%}  "
+            f"{m.samples_per_s:7.1f} samp/s  {m.mb_per_s:6.1f} MB/s  "
+            f"wait {m.mean_data_wait_ms:5.1f}ms  compute {m.mean_compute_ms:5.1f}ms  "
+            f"ttfb {m.ttfb_ms:6.1f}ms  rss {m.peak_rss_anon_mb:6.0f}MB  "
+            f"gpu {m.peak_gpu_mem_mb:6.0f}MB"
+        )
+
+    def set_val(self, run: str, model_rmse: float, persistence_rmse: float) -> None:
+        """Attach the run's forecast skill to its final row (last epoch of that run)."""
+        for m in reversed(self.rows):
+            if m.run == run:
+                m.val_model_rmse = model_rmse
+                m.val_persistence_rmse = persistence_rmse
+                return
+
+    def steady_samples_per_s(self, run: str) -> float:
+        """Mean throughput over the run's rows, excluding epoch 0 (cold TTFB) when possible."""
+        rows = [m for m in self.rows if m.run == run]
+        warm = [m for m in rows if m.epoch > 0] or rows
+        return sum(m.samples_per_s for m in warm) / len(warm) if warm else 0.0
+
+    def summary(self) -> None:
+        """Print the headline: insitu stall and its % of the in-memory ceiling (if run)."""
+        insitu = self.steady_samples_per_s("insitu")
+        ceiling = self.steady_samples_per_s("ceiling")
+        stall = sum(m.data_stall_fraction for m in self.rows if m.run == "insitu" and m.epoch > 0)
+        n = max(len([m for m in self.rows if m.run == "insitu" and m.epoch > 0]), 1)
+        line = f"\ninsitu: {insitu:.1f} samp/s (steady), stall {stall / n:.1%}"
+        if ceiling:
+            line += f"  ->  {insitu / ceiling:.1%} of the {ceiling:.1f} samp/s in-memory ceiling"
+        print(line)
+
+    def flush(self) -> None:
+        if not self.path:
+            return
+        p = Path(self.path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with p.open("a") as f:
+            for m in self.rows:
+                f.write(json.dumps(asdict(m)) + "\n")
+        print(f"wrote {len(self.rows)} rows -> {self.path}")

--- a/examples/_forecast_metrics.py
+++ b/examples/_forecast_metrics.py
@@ -32,6 +32,7 @@ from pathlib import Path
 # are reclaimable and excluded). bench is a repo-root dev package; the examples run
 # from the repo root (``python -m examples...``), so this import resolves there.
 from bench.result import rss_breakdown_mb
+from insitubatch.source import InSituDataset
 from insitubatch.types import Batch
 
 
@@ -198,3 +199,14 @@ class MetricsLog:
             for m in self.rows:
                 f.write(json.dumps(asdict(m)) + "\n")
         print(f"wrote {len(self.rows)} rows -> {self.path}")
+
+
+def preload_epoch(ds: InSituDataset) -> list[Batch]:
+    """Materialize one shuffled epoch of training batches into RAM (the ``--ceiling`` feed).
+
+    The compute-only ceiling run replays this list every epoch: same model, same loop, same
+    batch volume, but zero fetch/decode. Building it reads through the loader once (setup, not
+    measured); ``insitu_samples_per_s / ceiling_samples_per_s`` is then the pure loader
+    overhead. Cheap where the epoch's decoded batches fit in RAM (synthetic / WB2-128x64)."""
+    ds.set_epoch(0)
+    return list(ds.train)

--- a/examples/advection/data.py
+++ b/examples/advection/data.py
@@ -170,6 +170,18 @@ def forecast_dataset(
     )
 
 
+def preload_epoch(ds: InSituDataset) -> list[Batch]:
+    """Materialize one shuffled epoch of training batches into RAM (the ``--ceiling`` feed).
+
+    The compute-only ceiling run replays this list every epoch: same model, same loop,
+    same batch volume, but zero fetch/decode. Building it reads through the loader once
+    (setup, not measured); ``insitu_samples_per_s / ceiling_samples_per_s`` is then the
+    pure loader overhead. Cheap here -- the synthetic/WB2-128x64 window fits in RAM.
+    """
+    ds.set_epoch(0)
+    return list(ds.train)
+
+
 def inputs_and_targets(batch: Batch) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Split a windowed ``Batch`` into ``(x, persistence, target)`` numpy arrays.
 
@@ -249,6 +261,17 @@ def cli() -> argparse.Namespace:
         type=int,
         default=None,
         help="throttle read-ahead depth (lower = lower cold TTFB over a high-latency network)",
+    )
+    p.add_argument(
+        "--ceiling",
+        action="store_true",
+        help="also run the compute-only in-memory ceiling (RAM-preloaded batches, no IO)",
+    )
+    p.add_argument(
+        "--metrics-out",
+        default=None,
+        metavar="PATH",
+        help="append per-(run,epoch) JSONL metrics here (default: print only, no file)",
     )
     return p.parse_args()
 

--- a/examples/advection/data.py
+++ b/examples/advection/data.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Callable, Iterable
+from typing import Literal
 
 import numpy as np
 import zarr
@@ -75,7 +76,17 @@ def _advect(field: np.ndarray, u: np.ndarray, v: np.ndarray) -> np.ndarray:
     )
 
 
-def make_advection_store(url: str, *, n_steps: int = 768, size: int = 48, seed: int = 0) -> None:
+def make_advection_store(
+    url: str,
+    *,
+    n_steps: int = 768,
+    size: int = 48,
+    sample_chunk: int = 48,
+    seed: int = 0,
+    compress: bool = True,
+    write_batch_mb: int = 256,
+    write_concurrency: int = 32,
+) -> None:
     """Write a synthetic 3-variable advected-field zarr (``t2m``, ``u10``, ``v10``).
 
     A smooth, time-*constant* deformation wind advects the temperature field; every hour is
@@ -83,7 +94,13 @@ def make_advection_store(url: str, *, n_steps: int = 768, size: int = 48, seed: 
     -- see below) so every timestep has the same statistics and a contiguous split is honest.
     ``u10`` / ``v10`` are stored over time (broadcast) so all three arrays share the sample
     axis the engine batches along. Fields are ~unit-scale (no normalization needed). Chunked
-    at 48 steps so there are several chunks to split/shuffle.
+    at ``sample_chunk`` steps so there are several chunks to split/shuffle.
+
+    Scales to a large cloud store (``url`` a ``gs://`` / ``s3://`` prefix) without
+    materializing the whole array: the sequential advection is generated and written a
+    **slab of whole chunks at a time**, bounding writer RAM to ``write_batch_mb`` while
+    ``write_concurrency`` overlaps the chunk PUTs on zarr's async loop. ``size`` sets the
+    spatial resolution; total volume is ``3 * n_steps * size**2 * 4`` bytes uncompressed.
     """
     rng = np.random.default_rng(seed)
     yy, xx = np.mgrid[0:size, 0:size] / size
@@ -92,6 +109,7 @@ def make_advection_store(url: str, *, n_steps: int = 768, size: int = 48, seed: 
     # field, and varying enough that the model must *read* the wind, not memorize a shift.
     u = 0.20 * (np.sin(2 * np.pi * yy) * np.cos(2 * np.pi * xx))
     v = 0.20 * (np.cos(2 * np.pi * yy) * np.sin(2 * np.pi * xx))
+    wind_u, wind_v = u.astype("f4"), v.astype("f4")
 
     def smooth_field() -> np.ndarray:
         """A random unit-scale field of mid-frequency modes (a ~5-cell shift is visible)."""
@@ -101,32 +119,61 @@ def make_advection_store(url: str, *, n_steps: int = 768, size: int = 48, seed: 
             f += rng.normal() * np.cos(2 * np.pi * (kx * xx + ky * yy) + rng.uniform(0, 2 * np.pi))
         return (f - f.mean()) / f.std()
 
+    ensure_local_dir(url)
+    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
+    shape = (n_steps, size, size)
+    chunks = (sample_chunk, size, size)
+    compressors: Literal["auto"] | None = "auto" if compress else None
+    arrays = {
+        name: group.create_array(
+            name,
+            shape=shape,
+            chunks=chunks,
+            dtype="f4",
+            compressors=compressors,
+            dimension_names=("time", "lat", "lon"),
+        )
+        for name in ("t2m", "u10", "v10")
+    }
+
+    # Slab = a whole number of sample-axis chunks fitting in write_batch_mb, so every slab
+    # write is chunk-aligned (no read-modify-write) and the writer's RAM stays bounded.
+    rows_that_fit = max(1, (write_batch_mb * 1_000_000) // (size * size * 4))
+    slab_rows = max(sample_chunk, (rows_that_fit // sample_chunk) * sample_chunk)
+
     # A *stationary* forced-advection process: each step advects the field by the wind, then
     # adds a little fresh structure to replenish what bilinear interpolation dissipates, and
     # renormalizes. Every timestep then has the same statistics (so a contiguous split is
     # honest), and t2m(t+24) is the field advected 24 steps -- predictable from t2m(t) + the
     # wind (the model beats persistence by learning the displacement) up to the small forcing.
     field = smooth_field()
-    t2m = np.empty((n_steps, size, size), dtype="f4")
-    for t in range(n_steps):
-        t2m[t] = field
-        field = _advect(field, u, v) + 0.12 * smooth_field()
-        field = (field - field.mean()) / field.std()
+    buf = np.empty((slab_rows, size, size), dtype="f4")
+    with zarr.config.set({"async.concurrency": write_concurrency}):
+        for start in range(0, n_steps, slab_rows):
+            stop = min(start + slab_rows, n_steps)
+            n = stop - start
+            for i in range(n):
+                buf[i] = field
+                field = _advect(field, u, v) + 0.12 * smooth_field()
+                field = (field - field.mean()) / field.std()
+            arrays["t2m"][start:stop] = buf[:n]
+            arrays["u10"][start:stop] = np.broadcast_to(wind_u, (n, size, size))
+            arrays["v10"][start:stop] = np.broadcast_to(wind_v, (n, size, size))
 
-    wind_u = np.broadcast_to(u.astype("f4"), (n_steps, size, size))
-    wind_v = np.broadcast_to(v.astype("f4"), (n_steps, size, size))
 
-    ensure_local_dir(url)
-    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
-    for name, data in (("t2m", t2m), ("u10", wind_u), ("v10", wind_v)):
-        arr = group.create_array(
-            name,
-            shape=data.shape,
-            chunks=(48, size, size),
-            dtype="f4",
-            dimension_names=("time", "lat", "lon"),
-        )
-        arr[:] = data
+def _synthetic_ready(url: str, n_steps: int, size: int) -> bool:
+    """True if a synthetic store already exists at ``url`` with the requested geometry.
+
+    Lets ``--source synthetic --url gs://...`` generate a large cloud store once and reuse
+    it across training runs instead of rewriting it every time. A shape mismatch (different
+    ``--n-steps`` / ``--size``) or any open failure (absent / partial) returns False, so a
+    changed request regenerates rather than silently training on the stale store.
+    """
+    try:
+        t2m = zarr.open_group(store=obstore_store(url), mode="r")["t2m"]
+        return isinstance(t2m, zarr.Array) and t2m.shape == (n_steps, size, size)
+    except Exception:
+        return False
 
 
 def forecast_dataset(
@@ -250,7 +297,20 @@ def cli() -> argparse.Namespace:
     p.add_argument("--epochs", type=int, default=8)
     p.add_argument("--batch-size", type=int, default=32)
     p.add_argument("--n-steps", type=int, default=768, help="synthetic trajectory length (hours)")
-    p.add_argument("--url", default=None, help="synthetic store path (default: a temp file)")
+    p.add_argument("--size", type=int, default=48, help="synthetic spatial resolution (NxN grid)")
+    p.add_argument(
+        "--sample-chunk", type=int, default=48, help="synthetic sample-axis chunk length (steps)"
+    )
+    p.add_argument(
+        "--url",
+        default=None,
+        help="synthetic store path (file:// temp default; gs://... for a cloud store)",
+    )
+    p.add_argument(
+        "--regenerate",
+        action="store_true",
+        help="force-rewrite the synthetic store even if one with the same geometry exists",
+    )
     p.add_argument(
         "--cache-dir",
         default=None,
@@ -291,7 +351,10 @@ def build_datasets(args: argparse.Namespace) -> InSituDataset:
         variables, horizon = WB2_VARS, WB2_HORIZON
     else:
         url = args.url or "file:///tmp/insitu_advection.zarr"
-        make_advection_store(url, n_steps=args.n_steps)
+        if args.regenerate or not _synthetic_ready(url, args.n_steps, args.size):
+            make_advection_store(
+                url, n_steps=args.n_steps, size=args.size, sample_chunk=args.sample_chunk
+            )
         store = obstore_store(url)
         variables, horizon = SYNTH_VARS, SYNTH_HORIZON
     return forecast_dataset(

--- a/examples/advection/data.py
+++ b/examples/advection/data.py
@@ -217,18 +217,6 @@ def forecast_dataset(
     )
 
 
-def preload_epoch(ds: InSituDataset) -> list[Batch]:
-    """Materialize one shuffled epoch of training batches into RAM (the ``--ceiling`` feed).
-
-    The compute-only ceiling run replays this list every epoch: same model, same loop,
-    same batch volume, but zero fetch/decode. Building it reads through the loader once
-    (setup, not measured); ``insitu_samples_per_s / ceiling_samples_per_s`` is then the
-    pure loader overhead. Cheap here -- the synthetic/WB2-128x64 window fits in RAM.
-    """
-    ds.set_epoch(0)
-    return list(ds.train)
-
-
 def inputs_and_targets(batch: Batch) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Split a windowed ``Batch`` into ``(x, persistence, target)`` numpy arrays.
 
@@ -271,8 +259,9 @@ def _range(s: str) -> tuple[int, int]:
     return (start, stop)
 
 
-def cli() -> argparse.Namespace:
-    """Shared CLI for the three training files (only the model + loop differ)."""
+def build_parser() -> argparse.ArgumentParser:
+    """The shared example CLI (source, device, dataset geometry). The three training files
+    parse it via :func:`cli`; ``train_torch_metrics.py`` extends it with its benchmark flags."""
     p = argparse.ArgumentParser(description="advected-field 24 h forecast")
     p.add_argument(
         "--source",
@@ -322,18 +311,12 @@ def cli() -> argparse.Namespace:
         default=None,
         help="throttle read-ahead depth (lower = lower cold TTFB over a high-latency network)",
     )
-    p.add_argument(
-        "--ceiling",
-        action="store_true",
-        help="also run the compute-only in-memory ceiling (RAM-preloaded batches, no IO)",
-    )
-    p.add_argument(
-        "--metrics-out",
-        default=None,
-        metavar="PATH",
-        help="append per-(run,epoch) JSONL metrics here (default: print only, no file)",
-    )
-    return p.parse_args()
+    return p
+
+
+def cli() -> argparse.Namespace:
+    """Parse the shared CLI for the three canonical training files."""
+    return build_parser().parse_args()
 
 
 def build_datasets(args: argparse.Namespace) -> InSituDataset:

--- a/examples/advection/data.py
+++ b/examples/advection/data.py
@@ -20,6 +20,7 @@ regardless of the store, so the training files are store-agnostic.
 from __future__ import annotations
 
 import argparse
+import time
 from collections.abc import Callable, Iterable
 from typing import Literal
 
@@ -82,6 +83,7 @@ def make_advection_store(
     n_steps: int = 768,
     size: int = 48,
     sample_chunk: int = 48,
+    inner_chunk: int | None = None,
     seed: int = 0,
     compress: bool = True,
     write_batch_mb: int = 256,
@@ -96,12 +98,20 @@ def make_advection_store(
     axis the engine batches along. Fields are ~unit-scale (no normalization needed). Chunked
     at ``sample_chunk`` steps so there are several chunks to split/shuffle.
 
+    ``inner_chunk`` tiles the spatial dims into ``inner_chunk x inner_chunk`` stored chunks
+    (default: one chunk covering the whole ``size x size`` field). Tiling makes one sample's
+    field fan out into a grid of concurrent reads -- the ARCO/ERA5 norm, and the axis for
+    sweeping inner fan-out vs the single-fat-chunk regime.
+
     Scales to a large cloud store (``url`` a ``gs://`` / ``s3://`` prefix) without
     materializing the whole array: the sequential advection is generated and written a
     **slab of whole chunks at a time**, bounding writer RAM to ``write_batch_mb`` while
     ``write_concurrency`` overlaps the chunk PUTs on zarr's async loop. ``size`` sets the
     spatial resolution; total volume is ``3 * n_steps * size**2 * 4`` bytes uncompressed.
     """
+    ic = inner_chunk or size
+    if not 1 <= ic <= size:
+        raise ValueError(f"inner_chunk {ic} must be in 1..size ({size})")
     rng = np.random.default_rng(seed)
     yy, xx = np.mgrid[0:size, 0:size] / size
     # A smooth, spatially-varying deformation wind (a couple of low modes), ~0.2 cells/step
@@ -122,7 +132,7 @@ def make_advection_store(
     ensure_local_dir(url)
     group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
     shape = (n_steps, size, size)
-    chunks = (sample_chunk, size, size)
+    chunks = (sample_chunk, ic, ic)
     compressors: Literal["auto"] | None = "auto" if compress else None
     arrays = {
         name: group.create_array(
@@ -140,6 +150,15 @@ def make_advection_store(
     # write is chunk-aligned (no read-modify-write) and the writer's RAM stays bounded.
     rows_that_fit = max(1, (write_batch_mb * 1_000_000) // (size * size * 4))
     slab_rows = max(sample_chunk, (rows_that_fit // sample_chunk) * sample_chunk)
+
+    total_mb = 3 * n_steps * size * size * 4 / 1e6
+    print(
+        f"make_advection_store: {url}\n"
+        f"  3 vars x ({n_steps}, {size}, {size})  chunks=({sample_chunk}, {ic}, {ic})  "
+        f"~{total_mb:.0f} MB uncompressed  compress={'auto' if compress else 'none'}",
+        flush=True,
+    )
+    t0 = time.perf_counter()
 
     # A *stationary* forced-advection process: each step advects the field by the wind, then
     # adds a little fresh structure to replenish what bilinear interpolation dissipates, and
@@ -159,19 +178,35 @@ def make_advection_store(
             arrays["t2m"][start:stop] = buf[:n]
             arrays["u10"][start:stop] = np.broadcast_to(wind_u, (n, size, size))
             arrays["v10"][start:stop] = np.broadcast_to(wind_v, (n, size, size))
+            elapsed = time.perf_counter() - t0
+            rate = stop / elapsed if elapsed else 0.0
+            print(
+                f"  wrote {stop}/{n_steps} steps ({stop / n_steps:.0%})  "
+                f"{elapsed:.1f}s  {rate:.0f} steps/s",
+                flush=True,
+            )
+    print(f"  done: {url} in {time.perf_counter() - t0:.1f}s", flush=True)
 
 
-def _synthetic_ready(url: str, n_steps: int, size: int) -> bool:
+def _synthetic_ready(
+    url: str, n_steps: int, size: int, sample_chunk: int, inner_chunk: int | None
+) -> bool:
     """True if a synthetic store already exists at ``url`` with the requested geometry.
 
     Lets ``--source synthetic --url gs://...`` generate a large cloud store once and reuse
-    it across training runs instead of rewriting it every time. A shape mismatch (different
-    ``--n-steps`` / ``--size``) or any open failure (absent / partial) returns False, so a
-    changed request regenerates rather than silently training on the stale store.
+    it across training runs instead of rewriting it every time. A mismatch in shape
+    (``--n-steps`` / ``--size``) *or chunking* (``--sample-chunk`` / ``--inner-chunk``), or any
+    open failure (absent / partial), returns False, so a changed request regenerates rather
+    than silently training on the stale store.
     """
+    ic = inner_chunk or size
     try:
         t2m = zarr.open_group(store=obstore_store(url), mode="r")["t2m"]
-        return isinstance(t2m, zarr.Array) and t2m.shape == (n_steps, size, size)
+        return (
+            isinstance(t2m, zarr.Array)
+            and t2m.shape == (n_steps, size, size)
+            and t2m.chunks == (sample_chunk, ic, ic)
+        )
     except Exception:
         return False
 
@@ -291,6 +326,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--sample-chunk", type=int, default=48, help="synthetic sample-axis chunk length (steps)"
     )
     p.add_argument(
+        "--inner-chunk",
+        type=int,
+        default=None,
+        help="synthetic inner (spatial) chunk edge; default one chunk over the whole field",
+    )
+    p.add_argument(
         "--url",
         default=None,
         help="synthetic store path (file:// temp default; gs://... for a cloud store)",
@@ -334,9 +375,15 @@ def build_datasets(args: argparse.Namespace) -> InSituDataset:
         variables, horizon = WB2_VARS, WB2_HORIZON
     else:
         url = args.url or "file:///tmp/insitu_advection.zarr"
-        if args.regenerate or not _synthetic_ready(url, args.n_steps, args.size):
+        if args.regenerate or not _synthetic_ready(
+            url, args.n_steps, args.size, args.sample_chunk, args.inner_chunk
+        ):
             make_advection_store(
-                url, n_steps=args.n_steps, size=args.size, sample_chunk=args.sample_chunk
+                url,
+                n_steps=args.n_steps,
+                size=args.size,
+                sample_chunk=args.sample_chunk,
+                inner_chunk=args.inner_chunk,
             )
         store = obstore_store(url)
         variables, horizon = SYNTH_VARS, SYNTH_HORIZON

--- a/examples/advection/train_torch.py
+++ b/examples/advection/train_torch.py
@@ -12,6 +12,8 @@ layer is ``examples/advection/data.py``.
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable
+
 import torch
 from torch import nn
 
@@ -19,7 +21,8 @@ from insitubatch.frameworks import to_torch
 from insitubatch.source import InSituDataset
 from insitubatch.types import Batch
 
-from .data import build_datasets, cli, evaluate
+from .._forecast_metrics import MetricsLog, StallTimer
+from .data import build_datasets, cli, evaluate, preload_epoch
 
 
 class AdvectionCNN(nn.Module):
@@ -58,32 +61,120 @@ def _forecast(model: AdvectionCNN, batch: Batch, device: torch.device) -> torch.
     return d["t2m"][:, None].to(device) + model(x)  # (B, 1, H, W)
 
 
-def train(ds: InSituDataset, *, epochs: int, device: str = "cpu") -> tuple[float, float]:
-    """Train the CNN; return ``(model_rmse, persistence_rmse)`` -- 24 h forecast skill on val."""
-    dev = torch.device(device)
+def _fit(
+    epochs_source: Callable[[int], Iterable[Batch]],
+    *,
+    epochs: int,
+    dev: torch.device,
+    log: MetricsLog,
+    run: str,
+    source: str,
+    batch_size: int,
+) -> AdvectionCNN:
+    """Train a fresh CNN over ``epochs``, recording one metrics row per epoch.
+
+    ``epochs_source(epoch)`` yields that epoch's batches -- the loader (``insitu``) or the
+    RAM-preloaded list (``ceiling``). The step syncs via ``loss.item()`` so the
+    :class:`StallTimer`'s data-wait / compute split is real wall-clock, not queued async."""
+    cuda = dev.type == "cuda"
     model = AdvectionCNN().to(dev)
     opt = torch.optim.Adam(model.parameters(), lr=1e-3)
     for epoch in range(epochs):
-        ds.set_epoch(epoch)
         model.train()
-        last = 0.0
-        for batch in ds.train:
+        if cuda:
+            torch.cuda.reset_peak_memory_stats(dev)
+        timer = StallTimer()
+        for batch in timer.wrap(epochs_source(epoch)):
             target = to_torch(batch)["target"][:, None].to(dev)
             loss = nn.functional.mse_loss(_forecast(model, batch, dev), target)
             opt.zero_grad()
             loss.backward()
             opt.step()
-            last = loss.item()
-        print(f"epoch {epoch}  train mse {last:.4f}")
+            loss.item()  # sync: makes the timer's compute window real GPU wall-clock
+        gpu_mb = torch.cuda.max_memory_allocated(dev) / 1e6 if cuda else 0.0
+        log.add(
+            timer.metrics(
+                run=run,
+                framework="torch",
+                source=source,
+                device=dev.type,
+                epoch=epoch,
+                batch_size=batch_size,
+                peak_gpu_mem_mb=gpu_mb,
+            )
+        )
+    return model
+
+
+def _val_rmse(model: AdvectionCNN, ds: InSituDataset, dev: torch.device) -> tuple[float, float]:
     model.eval()
     with torch.no_grad():
         return evaluate(ds.val, lambda b: _forecast(model, b, dev).detach().cpu().numpy())
 
 
+def train(
+    ds: InSituDataset,
+    *,
+    epochs: int,
+    device: str = "cpu",
+    source: str = "synthetic",
+    batch_size: int = 32,
+    ceiling: bool = False,
+    log: MetricsLog | None = None,
+) -> tuple[float, float]:
+    """Train the CNN; return ``(model_rmse, persistence_rmse)`` -- 24 h forecast skill on val.
+
+    Records stall/throughput metrics to ``log``. With ``ceiling=True`` it then trains a
+    second, identical model on a RAM-preloaded epoch (no IO) -- the compute-only ceiling the
+    ``insitu`` run is scored against."""
+    dev = torch.device(device)
+    log = log or MetricsLog(None)
+
+    def loader_epoch(epoch: int) -> Iterable[Batch]:
+        ds.set_epoch(epoch)
+        return ds.train
+
+    model = _fit(
+        loader_epoch,
+        epochs=epochs,
+        dev=dev,
+        log=log,
+        run="insitu",
+        source=source,
+        batch_size=batch_size,
+    )
+    model_rmse, persistence_rmse = _val_rmse(model, ds, dev)
+    log.set_val("insitu", model_rmse, persistence_rmse)
+
+    if ceiling:
+        preloaded = preload_epoch(ds)  # one shuffled epoch in RAM; replayed each epoch
+        _fit(
+            lambda epoch: preloaded,
+            epochs=epochs,
+            dev=dev,
+            log=log,
+            run="ceiling",
+            source=source,
+            batch_size=batch_size,
+        )
+    return model_rmse, persistence_rmse
+
+
 def main() -> None:
     args = cli()
     ds = build_datasets(args)
-    model_rmse, persistence_rmse = train(ds, epochs=args.epochs, device=args.device)
+    log = MetricsLog(args.metrics_out)
+    model_rmse, persistence_rmse = train(
+        ds,
+        epochs=args.epochs,
+        device=args.device,
+        source=args.source,
+        batch_size=args.batch_size,
+        ceiling=args.ceiling,
+        log=log,
+    )
+    log.summary()
+    log.flush()
     print(
         f"\n24 h forecast RMSE on held-out data: model {model_rmse:.3f}  vs  "
         f"persistence {persistence_rmse:.3f}  ({persistence_rmse / model_rmse:.1f}x better)"

--- a/examples/advection/train_torch.py
+++ b/examples/advection/train_torch.py
@@ -7,12 +7,12 @@ persistence), so beating persistence means it read the wind-driven advection.
 
 Sources (``--source``), the finite training window (``--sample-range``), GPU placement and
 the NVMe cache flags are documented in ``examples/README.md``; the framework-neutral data
-layer is ``examples/advection/data.py``.
+layer is ``examples/advection/data.py``. For the loader stall / in-memory-ceiling benchmark
+built on top of this loop, see ``train_torch_metrics.py`` -- kept separate so this file
+stays a clean usage example.
 """
 
 from __future__ import annotations
-
-from collections.abc import Callable, Iterable
 
 import torch
 from torch import nn
@@ -21,8 +21,7 @@ from insitubatch.frameworks import to_torch
 from insitubatch.source import InSituDataset
 from insitubatch.types import Batch
 
-from .._forecast_metrics import MetricsLog, StallTimer
-from .data import build_datasets, cli, evaluate, preload_epoch
+from .data import build_datasets, cli, evaluate
 
 
 class AdvectionCNN(nn.Module):
@@ -61,120 +60,32 @@ def _forecast(model: AdvectionCNN, batch: Batch, device: torch.device) -> torch.
     return d["t2m"][:, None].to(device) + model(x)  # (B, 1, H, W)
 
 
-def _fit(
-    epochs_source: Callable[[int], Iterable[Batch]],
-    *,
-    epochs: int,
-    dev: torch.device,
-    log: MetricsLog,
-    run: str,
-    source: str,
-    batch_size: int,
-) -> AdvectionCNN:
-    """Train a fresh CNN over ``epochs``, recording one metrics row per epoch.
-
-    ``epochs_source(epoch)`` yields that epoch's batches -- the loader (``insitu``) or the
-    RAM-preloaded list (``ceiling``). The step syncs via ``loss.item()`` so the
-    :class:`StallTimer`'s data-wait / compute split is real wall-clock, not queued async."""
-    cuda = dev.type == "cuda"
+def train(ds: InSituDataset, *, epochs: int, device: str = "cpu") -> tuple[float, float]:
+    """Train the CNN; return ``(model_rmse, persistence_rmse)`` -- 24 h forecast skill on val."""
+    dev = torch.device(device)
     model = AdvectionCNN().to(dev)
     opt = torch.optim.Adam(model.parameters(), lr=1e-3)
     for epoch in range(epochs):
+        ds.set_epoch(epoch)
         model.train()
-        if cuda:
-            torch.cuda.reset_peak_memory_stats(dev)
-        timer = StallTimer()
-        for batch in timer.wrap(epochs_source(epoch)):
+        last = 0.0
+        for batch in ds.train:
             target = to_torch(batch)["target"][:, None].to(dev)
             loss = nn.functional.mse_loss(_forecast(model, batch, dev), target)
             opt.zero_grad()
             loss.backward()
             opt.step()
-            loss.item()  # sync: makes the timer's compute window real GPU wall-clock
-        gpu_mb = torch.cuda.max_memory_allocated(dev) / 1e6 if cuda else 0.0
-        log.add(
-            timer.metrics(
-                run=run,
-                framework="torch",
-                source=source,
-                device=dev.type,
-                epoch=epoch,
-                batch_size=batch_size,
-                peak_gpu_mem_mb=gpu_mb,
-            )
-        )
-    return model
-
-
-def _val_rmse(model: AdvectionCNN, ds: InSituDataset, dev: torch.device) -> tuple[float, float]:
+            last = loss.item()
+        print(f"epoch {epoch}  train mse {last:.4f}")
     model.eval()
     with torch.no_grad():
         return evaluate(ds.val, lambda b: _forecast(model, b, dev).detach().cpu().numpy())
 
 
-def train(
-    ds: InSituDataset,
-    *,
-    epochs: int,
-    device: str = "cpu",
-    source: str = "synthetic",
-    batch_size: int = 32,
-    ceiling: bool = False,
-    log: MetricsLog | None = None,
-) -> tuple[float, float]:
-    """Train the CNN; return ``(model_rmse, persistence_rmse)`` -- 24 h forecast skill on val.
-
-    Records stall/throughput metrics to ``log``. With ``ceiling=True`` it then trains a
-    second, identical model on a RAM-preloaded epoch (no IO) -- the compute-only ceiling the
-    ``insitu`` run is scored against."""
-    dev = torch.device(device)
-    log = log or MetricsLog(None)
-
-    def loader_epoch(epoch: int) -> Iterable[Batch]:
-        ds.set_epoch(epoch)
-        return ds.train
-
-    model = _fit(
-        loader_epoch,
-        epochs=epochs,
-        dev=dev,
-        log=log,
-        run="insitu",
-        source=source,
-        batch_size=batch_size,
-    )
-    model_rmse, persistence_rmse = _val_rmse(model, ds, dev)
-    log.set_val("insitu", model_rmse, persistence_rmse)
-
-    if ceiling:
-        preloaded = preload_epoch(ds)  # one shuffled epoch in RAM; replayed each epoch
-        _fit(
-            lambda epoch: preloaded,
-            epochs=epochs,
-            dev=dev,
-            log=log,
-            run="ceiling",
-            source=source,
-            batch_size=batch_size,
-        )
-    return model_rmse, persistence_rmse
-
-
 def main() -> None:
     args = cli()
     ds = build_datasets(args)
-    log = MetricsLog(args.metrics_out)
-    model_rmse, persistence_rmse = train(
-        ds,
-        epochs=args.epochs,
-        device=args.device,
-        source=args.source,
-        batch_size=args.batch_size,
-        ceiling=args.ceiling,
-        log=log,
-    )
-    log.summary()
-    log.flush()
+    model_rmse, persistence_rmse = train(ds, epochs=args.epochs, device=args.device)
     print(
         f"\n24 h forecast RMSE on held-out data: model {model_rmse:.3f}  vs  "
         f"persistence {persistence_rmse:.3f}  ({persistence_rmse / model_rmse:.1f}x better)"

--- a/examples/advection/train_torch_metrics.py
+++ b/examples/advection/train_torch_metrics.py
@@ -1,0 +1,170 @@
+"""Loader stall / in-memory-ceiling benchmark for the advection torch loop (backlog #9).
+
+Wraps the *same* model and step as ``train_torch.py`` (imported, not duplicated) in the
+:class:`~examples._forecast_metrics.StallTimer` so each epoch records the **data-stall
+fraction** -- the share of wall-clock the GPU idles waiting on the loader. ``--ceiling``
+trains a second, identical model on a RAM-preloaded epoch (no fetch/decode) to get the
+compute-only in-memory ceiling the loader run is scored against; ``--metrics-out`` appends
+per-(run, epoch) JSONL.
+
+Kept out of ``train_torch.py`` so that file stays a clean usage example. Run with::
+
+    python -m examples.advection.train_torch_metrics --source wb2 --device cuda \\
+        --epochs 5 --ceiling --metrics-out bench/results/advection_torch_wb2_gpu.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Iterable
+
+import torch
+from torch import nn
+
+from insitubatch.frameworks import to_torch
+from insitubatch.source import InSituDataset
+from insitubatch.types import Batch
+
+from .._forecast_metrics import MetricsLog, StallTimer, preload_epoch
+from .data import build_datasets, build_parser, evaluate
+from .train_torch import AdvectionCNN, _forecast
+
+
+def _fit(
+    epochs_source: Callable[[int], Iterable[Batch]],
+    *,
+    epochs: int,
+    dev: torch.device,
+    log: MetricsLog,
+    run: str,
+    source: str,
+    batch_size: int,
+) -> AdvectionCNN:
+    """Train a fresh CNN over ``epochs``, recording one metrics row per epoch.
+
+    ``epochs_source(epoch)`` yields that epoch's batches -- the loader (``insitu``) or the
+    RAM-preloaded list (``ceiling``). The step syncs via ``loss.item()`` so the
+    :class:`StallTimer`'s data-wait / compute split is real wall-clock, not queued async."""
+    cuda = dev.type == "cuda"
+    model = AdvectionCNN().to(dev)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    for epoch in range(epochs):
+        model.train()
+        if cuda:
+            torch.cuda.reset_peak_memory_stats(dev)
+        timer = StallTimer()
+        for batch in timer.wrap(epochs_source(epoch)):
+            target = to_torch(batch)["target"][:, None].to(dev)
+            loss = nn.functional.mse_loss(_forecast(model, batch, dev), target)
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            loss.item()  # sync: makes the timer's compute window real GPU wall-clock
+        gpu_mb = torch.cuda.max_memory_allocated(dev) / 1e6 if cuda else 0.0
+        log.add(
+            timer.metrics(
+                run=run,
+                framework="torch",
+                source=source,
+                device=dev.type,
+                epoch=epoch,
+                batch_size=batch_size,
+                peak_gpu_mem_mb=gpu_mb,
+            )
+        )
+    return model
+
+
+def _val_rmse(model: AdvectionCNN, ds: InSituDataset, dev: torch.device) -> tuple[float, float]:
+    model.eval()
+    with torch.no_grad():
+        return evaluate(ds.val, lambda b: _forecast(model, b, dev).detach().cpu().numpy())
+
+
+def train(
+    ds: InSituDataset,
+    *,
+    epochs: int,
+    device: str = "cpu",
+    source: str = "synthetic",
+    batch_size: int = 32,
+    ceiling: bool = False,
+    log: MetricsLog | None = None,
+) -> tuple[float, float]:
+    """Train the CNN and record stall/throughput metrics to ``log``; return the val skill.
+
+    With ``ceiling=True`` it then trains a second, identical model on a RAM-preloaded epoch
+    (no IO) -- the compute-only ceiling the ``insitu`` run is scored against."""
+    dev = torch.device(device)
+    log = log or MetricsLog(None)
+
+    def loader_epoch(epoch: int) -> Iterable[Batch]:
+        ds.set_epoch(epoch)
+        return ds.train
+
+    model = _fit(
+        loader_epoch,
+        epochs=epochs,
+        dev=dev,
+        log=log,
+        run="insitu",
+        source=source,
+        batch_size=batch_size,
+    )
+    model_rmse, persistence_rmse = _val_rmse(model, ds, dev)
+    log.set_val("insitu", model_rmse, persistence_rmse)
+
+    if ceiling:
+        preloaded = preload_epoch(ds)  # one shuffled epoch in RAM; replayed each epoch
+        _fit(
+            lambda epoch: preloaded,
+            epochs=epochs,
+            dev=dev,
+            log=log,
+            run="ceiling",
+            source=source,
+            batch_size=batch_size,
+        )
+    return model_rmse, persistence_rmse
+
+
+def cli() -> argparse.Namespace:
+    """The shared example CLI plus the two benchmark-only flags."""
+    p = build_parser()
+    p.add_argument(
+        "--ceiling",
+        action="store_true",
+        help="also run the compute-only in-memory ceiling (RAM-preloaded batches, no IO)",
+    )
+    p.add_argument(
+        "--metrics-out",
+        default=None,
+        metavar="PATH",
+        help="append per-(run,epoch) JSONL metrics here (default: print only, no file)",
+    )
+    return p.parse_args()
+
+
+def main() -> None:
+    args = cli()
+    ds = build_datasets(args)
+    log = MetricsLog(args.metrics_out)
+    model_rmse, persistence_rmse = train(
+        ds,
+        epochs=args.epochs,
+        device=args.device,
+        source=args.source,
+        batch_size=args.batch_size,
+        ceiling=args.ceiling,
+        log=log,
+    )
+    log.summary()
+    log.flush()
+    print(
+        f"\n24 h forecast RMSE on held-out data: model {model_rmse:.3f}  vs  "
+        f"persistence {persistence_rmse:.3f}  ({persistence_rmse / model_rmse:.1f}x better)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -58,6 +58,42 @@ def test_torch_beats_persistence(synth_store) -> None:
     assert model_rmse < persistence_rmse
 
 
+def test_torch_metrics_collects_stall_ceiling_and_writes_jsonl(synth_store, tmp_path) -> None:
+    pytest.importorskip("torch")
+    import json
+
+    from examples._forecast_metrics import MetricsLog
+    from examples.advection.train_torch_metrics import train
+
+    out = tmp_path / "metrics.jsonl"
+    log = MetricsLog(str(out))
+    model_rmse, persistence_rmse = train(_dataset(synth_store), epochs=3, ceiling=True, log=log)
+    log.flush()
+
+    assert model_rmse > 0 and persistence_rmse > 0  # a real training run happened (skill: sibling)
+
+    runs: dict[str, list] = {}
+    for m in log.rows:
+        runs.setdefault(m.run, []).append(m)
+    assert set(runs) == {"insitu", "ceiling"}  # --ceiling ran the compute-only baseline too
+    assert len(runs["insitu"]) == len(runs["ceiling"]) == 3  # one row per epoch per run
+
+    for m in log.rows:
+        assert 0.0 <= m.data_stall_fraction <= 1.0
+        assert m.n_batches > 0 and m.n_samples > 0 and m.samples_per_s > 0
+        assert m.wall_s == pytest.approx(m.data_wait_s + m.compute_s)  # wall is the split's sum
+        assert m.data_stall_fraction == pytest.approx(m.data_wait_s / m.wall_s)
+
+    # val skill is patched onto the insitu run's final row only (known after the eval pass)
+    assert runs["insitu"][-1].val_model_rmse == model_rmse
+    assert np.isnan(runs["ceiling"][-1].val_model_rmse)
+
+    # the JSONL mirrors the in-memory rows one line each
+    written = [json.loads(line) for line in out.read_text().splitlines()]
+    assert len(written) == len(log.rows) == 6
+    assert {r["run"] for r in written} == {"insitu", "ceiling"}
+
+
 def test_jax_beats_persistence(synth_store) -> None:
     pytest.importorskip("flax")
     from examples.advection.train_jax import train


### PR DESCRIPTION
## GPU advection benchmark — round 1 (backlog #9)

Instruments the advection torch training loop with a self-referential loader-health
metric set and runs it on GPU against WeatherBench2 ERA5 and a large synthetic store
on GCS. Grounds the M2 `device_transform` design in measured behavior before building it.

### What's added
- **`examples/_forecast_metrics.py`** — framework-neutral collector: `ForecastMetrics`
  (per-(run,epoch) JSONL row), `StallTimer` (data-wait vs compute split), `MetricsLog`
  (prints, patches final val RMSE onto the last row, flushes JSONL).
- **`train_torch.py`** — loop instrumented; `--ceiling` trains an identical model on a
  RAM-preloaded epoch (no fetch/decode) = the compute-only in-memory ceiling.
- **`data.py`** — `--ceiling` / `--metrics-out` / `--size` / `--sample-chunk` /
  `--regenerate`; `make_advection_store` now **streams to bounded RAM** (chunk-aligned
  slab writes + raised `async.concurrency`) so `--source synthetic --url gs://…` writes a
  multi-GB cloud store idempotently (generate once, reuse on matching geometry).

Headline metric = **data-stall fraction** (share of wall-clock the GPU idles on the
loader; ~0 ⇒ compute-bound ⇒ loader effectively free) — self-referential, no competitor
baseline. `--ceiling` gives the fair substitute baseline.

Raw JSONL lives in `bench/results/` (gitignored); numbers summarized below.

### Findings

**WB2 ERA5 (128×64), read live from GCS, cuda** — the headline result:

| | steady samp/s | stall | % of ceiling | host RssAnon | val (model / persist) |
|---|---|---|---|---|---|
| insitu (no cache) | 1294 | 7.3% | **91.8%** | 1168 MB | 1.98 / 2.23 |
| insitu (NVMe cache) | 1294 | 6.2% | 92.1% | 848 MB | 1.99 / 2.23 |
| in-memory ceiling | 1410 | 0% | — | 1601 MB | — |

insitu keeps the GPU ~93% fed streaming ERA5 from `gs://`, at ~92% of the in-memory
ceiling, on **bounded** host memory (1168 MB vs the ceiling's 1601 MB full-epoch preload).
Cold epoch 0 is 24% stall / 885 ms TTFB, then warm epochs collapse to 4–12% as prefetch
fills.

**The NVMe cache is redundant here** — identical throughput ± noise. The no-cache run is
already compute-bound (7% stall), so there's nothing to remove; the cache only shifts
decoded chunks from heap (`RssAnon`) to reclaimable mmap (`RssFile`), lowering heap
1153→848 MB. Disk cache earns its keep only when the working set exceeds host RAM.

**Synthetic (48×48), cuda (GPU torture test — trivially cheap compute):** 5627 samp/s,
7.7% stall, 83.8% of ceiling, val 0.57 / 0.88. Floor case: near-zero compute leaves little
to hide IO behind, yet still 84% of ceiling.

**Large synthetic (256×256, ~13 GB on GCS), cuda (partial — 3 epochs before the box
hung):** stall **0.2–0.9%**, 144 samp/s, 149 MB/s, `RssAnon` ~14 GB, gpu 2207 MB. Fully
compute-bound: at 256² the CNN is ~222 ms/batch, so the loader is invisible even cold.

Two takeaways from the large run:
1. **Growing the field can't reach an IO-bound regime.** For this conv model, MB/s demand
   is ~size-invariant — bytes/sample and compute/sample both scale with pixel count and
   cancel, pinning demand near ~150 MB/s regardless of `--size`. Exposing the loader
   requires choking *supply* (low `--max-inflight` / GRIB-tiny `--sample-chunk`), not a
   bigger field.
2. The 14 GB `RssAnon` is the in-memory decoded cache holding the **entire** working set —
   which is why epoch-1+ stall is ~0 (served from RAM). It's currently **unbounded** (OOM
   risk on smaller boxes); an in-memory cache-budget knob would let us force eviction and
   make the NVMe-cache comparison bite without a store larger than host RAM.

### Verification
- CPU-validated end to end (timing, JSONL schema, val-RMSE patching); `--source synthetic
  --url gs://…` written to a real bucket, read back, trained (model beats persistence),
  cleaned up.
- `ruff` / `mypy` clean on `src bench examples`; `pytest -q` 143 passed / 11 skipped
  (`test_advection` green — streamed generator preserves the learnable signal).

### Bottom line
Across WB2 and a 13 GB synthetic store, **insitu is compute-bound with the loader
effectively free** — the strong result. Not merged-blocking, but the remaining round-1
datapoint is one *throttled* run (`--max-inflight 2`) to characterize the failure edge;
round 2 (pynvml per-step, H2D split) and the JAX/TF port are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
