### PR TITLE
feat(geometry): per-variable sample-axis chunk size + use-case table

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -117,6 +117,17 @@ The ladder, in the order it was built:
    one `moveaxis` the sample axis leads and every downstream stage is unchanged.
    Cross-domain validated end-to-end against a real IDR OME-NGFF microscopy store (zarr
    v2, anonymous S3), streaming over `Z` with byte-exact reads.
+4. **Per-variable sample-axis chunk size** — co-registered variables may chunk the sample
+   axis *differently* (OME-NGFF raw Z-chunk 1 + label mask Z-chunk 30) as long as they share
+   its *length*. The manifest's chunk size becomes the **reference anchor grid**
+   (shuffle/split/gather); each variable maps global anchors onto its *own* chunk grid in the
+   read planner and `gather`. Orthogonal to `sample_axis`, and it composes with windowing and
+   arbitrary axes — tests cover all three overlapping, plus the uneven tail where a coarse
+   chunk runs out at the end of the axis. Cross-domain validated end-to-end on the real IDR
+   raw+mask pairing (byte-exact). *Residency deferral (same class as windowed+shuffle, M-W):*
+   under shuffle a non-uniform variable's chunk can be needed by scattered blocks, so the
+   budget currently holds the whole train split resident per variable; a tighter bound
+   (per-block re-fetch) is the shared deferred bounded-residency work.
 
 **Deferred generalizations, and *why* (so they aren't relitigated):**
 
@@ -142,13 +153,6 @@ The ladder, in the order it was built:
   assembles (and budgets) the *whole* field per outer chunk, so bounded memory on a giant
   ERA5/radio field needs the pool to hold only a crop's tiles. That is a residency change,
   not a `Batch`-contract change — which is what keeps it an *additive* future.
-- **Per-variable sample-axis chunk size** — pairing e.g. an OME-NGFF raw array (Z-chunk 1)
-  with its label mask (Z-chunk 30) is blocked by the shared-chunk-size guard. Orthogonal to
-  `sample_axis`; the next increment. It's genuinely separate work (not a one-liner) because
-  the read planner and `gather` both interpret draw chunk-ids in a single reference grid —
-  lifting that means mapping one anchor grid onto each variable's own chunk grid, and it
-  interacts with windowed residency.
-
 GRIB / NetCDF are consumed via a **virtual-zarr** view (virtualizarr / kerchunk /
 icechunk) so the engine only ever speaks zarr-async — we never parse GRIB.
 
@@ -492,10 +496,12 @@ residency flat across the concurrency sweep. **B2 done** — the `ChunkPool` is 
 the cache too (byte budget + pin/unpin + LRU, heap or mmap backing; cross-epoch
 decode-once reuse via `cache_dir`/`cache_budget_bytes`; cross-*run* persistence via
 `persist=True`, M-C2). **Arbitrary sample axis** — `sample_axis` lets any single
-physical axis be the sample axis (cross-domain validated end-to-end on a real IDR OME-NGFF
-microscopy store, sampling over `Z`); see the geometry-ladder section. **Not yet built:**
-`Regrid` + the GPU/device transform stage (M2), bounded read-ahead (M-RA), per-variable
-sample-axis chunk size (the raw+labels microscopy pairing).
+physical axis be the sample axis, and **per-variable sample-axis chunk size** lets
+co-registered variables chunk it differently (the raw Z-chunk 1 + label mask Z-chunk 30
+pairing) — both cross-domain validated end-to-end on a real IDR OME-NGFF microscopy store
+(sampling over `Z`); see the geometry-ladder section. **Not yet built:** `Regrid` + the
+GPU/device transform stage (M2), bounded read-ahead (M-RA), and bounded windowed/non-uniform
+residency under shuffle (per-block re-fetch instead of holding the whole train split).
 
 ## Roadmap / milestones
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -177,6 +177,41 @@ forecasting `{"x": g, "y": g.shift(horizon)}` pattern, which composes with any
 - Cross-node concatenation (many well-arrays into one stream) is a **catalog layer above
   the core**, not part of this contract.
 
+### Use-case support
+
+Concrete cross-domain use cases against the contract above — what works today, what is a
+reserved (additive) extension, and what is deliberately out of scope.
+
+**Supported now:**
+
+| Use case | Example | How |
+|---|---|---|
+| Train over a time/sample axis | ERA5/HRRR reanalysis; astronomy light curves | `sample_axis=0` (default) |
+| Sample over *any* single axis | OME-NGFF 2D segmentation over `Z`; `T`-frame or volumetric stacks | `open_geometries(store, sample_axis=2)` |
+| Paired inputs+targets with *different* sample-axis chunking | microscopy raw image + label mask (Z-chunk 1 vs 30) | two variables, one manifest |
+| Forecasting input/target windows | weather: input@`t`, target@`t+h` | `g.shift(h)` views (decode-once) |
+| Whole inner field per sample, spatial grid fetched decode-once | ARCO/ERA5 `721×1440` fields; microscopy planes | inner (field) chunking |
+| Cross-variable derived fields & per-sample random augmentation | `windspeed=√(u²+v²)`; random crop of the whole field | `batch_transform` |
+| Chunk-aligned splits, block shuffle, cross-run cache | all domains | shipped |
+
+**Reserved (committed as additive, not yet built):**
+
+| Use case | Example | Extension |
+|---|---|---|
+| Multiple sample axes (product index) | HCS `Well×Field×Time`; `Year×Day` | `sample_axis` widens `int → int \| tuple` |
+| Native spatial patch / sliding window (memory-optimal crops) | ERA5 `64×64` patches for a ViT; radio-astronomy cubes | patch *extent* (geometry) + origin sampler + partial-field residency |
+| GPU `device_transform` stage | any | milestone M2 |
+
+**Out of scope (by design):**
+
+| Not supported | Example | Why |
+|---|---|---|
+| Cross-chunk / cross-sample-boundary stencils | finite differences across a time-chunk seam | a sample cannot span a chunk boundary |
+| Cross-node concatenation into one stream | many HCS well-arrays as one dataset | catalog layer above the core |
+| General compute graph / cross-chunk reductions | lazy dask-style evaluation | dask is off the hot path by design; reductions run *over* the loader |
+| Resharding into a sample-per-file format | MDS/tar/WebDataset ETL | we train **in place**, no reshard |
+| Scattered / boolean sample selection for splits | arbitrary index masks | splits are chunk-contiguous (leakage-safe) |
+
 ## Prefetch
 
 `source.InSituDataset.__iter__` runs a **background producer thread** that

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,9 +4,11 @@ Runnable examples (not shipped in the wheel). Run from the repo root, e.g.
 `python -m examples.advection.train_torch`.
 
 The InsituDataset is a general purpose, batteries included, tool for batching zarr compatible 
-data into the python ML ecosystem. The examples are forecasting focused because there are large
+data into the python ML ecosystem. Most examples are forecasting focused because there are large
 public zarr datasets available and the time shifting on insitu data is an added challenge that
-shows the generalization.
+shows the generalization; [`microscopy/`](#microscopy--ome-ngff-cell-segmentation-over-z) is the
+cross-domain companion — a different geometry (sample over Z, two variables chunked differently)
+on a real bio-imaging store, to show the engine is not weather-specific.
 
 ## advection/ — a 24-hour forecast, one dataset, three frameworks
 
@@ -67,6 +69,41 @@ CUDA torch via `--torch-backend`, Arraylake auth) is documented in
 and a shifted target as `(label, path, offset)` views, and train in your framework — the
 windowing (`Batch.offsets`, `Batch.stack`, `Batch.read_indices`) and the no-reshard,
 chunk-once IO are the engine's job.
+
+## microscopy/ — OME-NGFF cell segmentation over Z
+
+The cross-domain showcase: **the same engine, a different geometry.** Where advection samples
+the *outer* time axis and windows it, [`microscopy/`](microscopy/data.py) samples a *middle*
+axis — one Z-plane of an OME-NGFF `(T,C,Z,Y,X)` confocal stack (`sample_axis=2`) — and gathers
+two co-registered variables at each anchor: the 2-channel `raw` image (chunked **one plane
+deep** on Z) and its `mask` label (chunked **30 planes deep**, tiled in Y/X). Different physical
+chunking, different channel count, one sample grid, **no reshard** — the arbitrary-sample-axis +
+per-variable-chunking unlock, on a real store.
+
+```bash
+uv sync --extra torch
+uv run python -m examples.microscopy.train_torch                    # synthetic cells (offline)
+uv run python -m examples.microscopy.train_torch --source idr       # the real IDR image (streamed)
+```
+
+The task is per-plane **foreground segmentation**, and the baseline is a global intensity
+threshold (**Otsu**) — the segmentation analog of persistence. Otsu reads each pixel's intensity
+alone, so a smooth autofluorescence *haze* gradient defeats it (a bright-background pixel
+outshines a dim cell elsewhere; no single threshold separates them). A tiny CNN that reads the
+neighborhood — sharp cells vs low-frequency haze — beats it: on the synthetic store by
+construction, on the real IDR image the claim is "same pipeline, real data, no reshard" (not
+SOTA Dice — the label is expert instance annotation and the model is four conv layers). Each run
+prints the held-out foreground IoU, model vs Otsu.
+
+### Data sources (`--source`)
+
+| `--source` | store | notes |
+| --- | --- | --- |
+| `synthetic` *(default)* | offline **cell stack** written to a temp zarr | Gaussian cells + a haze gradient noise Otsu can't beat; `--n-planes` / `--size` / `--mask-chunk` size it |
+| `idr` | the public **IDR** OME-NGFF image `s3://idr/...` (EMBL-EBI) | streamed anonymously; `--sample-range` subsets the 236-plane stack |
+
+Only `train_torch.py` ships here — framework-neutrality is the advection example's job; this
+example's job is to prove the *geometry* generalizes.
 
 ## The WeatherBench2 cold-start pair (with xbatcher)
 

--- a/examples/microscopy/__init__.py
+++ b/examples/microscopy/__init__.py
@@ -1,0 +1,13 @@
+"""OME-NGFF cell segmentation: one insitu dataset, raw + mask co-batched over Z.
+
+The cross-domain companion to ``examples/advection`` -- same engine, a different
+geometry. Here a *sample* is one Z-plane of a confocal stack (``sample_axis=2`` of the
+OME-NGFF ``(T,C,Z,Y,X)`` layout), and two variables are gathered at the same anchor: the
+2-channel ``raw`` image (chunked one plane deep) and its ``mask`` label (chunked 30 planes
+deep, tiled in Y/X). Different physical chunking, different channel count, one sample grid,
+no reshard -- the arbitrary-sample-axis + per-variable-chunking unlock on a real store.
+
+``data.py`` builds the store (synthetic cells, or the real IDR image), the dataset, and the
+shared eval; ``train_torch.py`` trains a tiny segmentation CNN that beats a global-threshold
+(Otsu) baseline by reading spatial context the threshold cannot see.
+"""

--- a/examples/microscopy/data.py
+++ b/examples/microscopy/data.py
@@ -1,0 +1,374 @@
+"""Shared data for the cell-segmentation example: the store, the one dataset, the eval.
+
+**The task -- per-plane foreground segmentation.** Each sample is one Z-plane of a confocal
+stack. Two variables are gathered at the *same* anchor: ``raw`` (a 2-channel fluorescence
+image) and ``mask`` (its binary foreground label). Nothing is resharded -- the two arrays are
+chunked differently along Z (``raw`` one plane deep, ``mask`` many planes deep) and carry a
+different channel count, yet the engine batches them row-for-row off a single sample grid.
+That is the arbitrary-sample-axis (``sample_axis=2``) + per-variable-chunking unlock.
+
+A **global intensity threshold (Otsu)** is the no-context baseline a useful model must beat --
+the segmentation analog of persistence in the advection example. Otsu reads each pixel's
+intensity alone, so a smooth autofluorescence *haze* gradient defeats it: a bright-haze
+background pixel can outshine a dim cell elsewhere, and no single threshold separates them. A
+tiny CNN that *sees the neighborhood* (sharp cells vs low-frequency haze) does better. On the
+synthetic store it beats Otsu by construction; on the real IDR store the same code runs on a
+real OME-NGFF image (we claim "same pipeline, real data, no reshard" -- not SOTA Dice).
+
+``segmentation_dataset`` returns one dataset whose labels are always ``raw, mask`` regardless
+of the store, so the training file is store-agnostic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from collections.abc import Callable, Iterable
+from typing import Literal
+
+import numpy as np
+import zarr
+from zarr.abc.store import Store
+
+from insitubatch import (
+    ensure_local_dir,
+    obstore_store,
+    open_geometries,
+    split_by_chunk,
+)
+from insitubatch.source import InSituDataset
+from insitubatch.types import Batch
+
+# A public OME-NGFF (zarr v0.1) image in the EMBL-EBI Image Data Repository: a 3D two-channel
+# confocal stack with an expert instance-segmentation label. Read anonymously off the IDR S3.
+IDR_URL = "s3://idr/zarr/v0.1/6001240.zarr"
+IDR_ENDPOINT = "https://uk1s3.embassy.ebi.ac.uk"
+IDR_RAW = "0"  # full-resolution image (T=1, C=2, Z=236, Y=275, X=271), Z-chunk 1
+IDR_MASK = "labels/masks/0"  # the label (T=1, C=1, Z=236, Y=275, X=271), Z-chunk 30, Y/X tiled
+
+# OME-NGFF is (T, C, Z, Y, X); we sample over Z. The synthetic store uses the same 5-D layout
+# (leading T=1) so one code path serves both sources.
+SAMPLE_AXIS = 2
+LABELS = ("raw", "mask")  # canonical labels (store-independent)
+
+
+def _idr_store() -> Store:
+    """Anonymous read of the public IDR bucket (custom S3 endpoint, path-style, no signing)."""
+    return obstore_store(
+        IDR_URL,
+        endpoint=IDR_ENDPOINT,
+        skip_signature=True,
+        virtual_hosted_style_request=False,
+        region="us-east-1",
+    )
+
+
+def _smooth_field(
+    rng: np.random.Generator, yy: np.ndarray, xx: np.ndarray, modes: int
+) -> np.ndarray:
+    """A non-negative smooth low-frequency field in [0, 1] -- the autofluorescence haze.
+
+    A few random low modes give a gradient that a *global* threshold cannot separate from dim
+    cells, but whose low spatial frequency a CNN trivially distinguishes from sharp cells.
+    """
+    f = np.zeros_like(yy)
+    for _ in range(modes):
+        kx, ky = rng.integers(1, 3, size=2)
+        f += rng.normal() * np.cos(2 * np.pi * (kx * xx + ky * yy) + rng.uniform(0, 2 * np.pi))
+    f -= f.min()
+    return f / (f.max() + 1e-9)
+
+
+def make_cells_store(
+    url: str,
+    *,
+    n_planes: int = 64,
+    size: int = 96,
+    mask_chunk: int = 16,
+    inner_chunk: int | None = None,
+    cells_per_plane: int = 14,
+    seed: int = 0,
+    compress: bool = True,
+) -> None:
+    """Write a synthetic two-channel cell stack (``raw``) + its foreground label (``mask``).
+
+    Mirrors the real IDR geometry: ``raw`` is ``(1, 2, n_planes, size, size)`` chunked **one
+    plane deep** on Z; ``mask`` is ``(1, 1, n_planes, size, size)`` chunked ``mask_chunk``
+    planes deep and tiled in Y/X. Same Z length, different chunking and channel count -- the
+    per-variable-chunking case the engine handles with no reshard.
+
+    Each plane holds a few Gaussian cells (sharp, high spatial frequency). Both channels add a
+    different smooth *haze* gradient and read noise, so a global threshold on intensity cannot
+    separate a dim cell from bright background -- but a CNN reading the neighborhood can. The
+    ``mask`` is the haze-free, noise-free ground truth (cells above half-max). The stack is
+    small (fits in RAM); scale ``n_planes``/``size`` for a larger store.
+    """
+    ic = inner_chunk or (size // 2)
+    if not 1 <= ic <= size:
+        raise ValueError(f"inner_chunk {ic} must be in 1..size ({size})")
+    rng = np.random.default_rng(seed)
+    yy, xx = (np.mgrid[0:size, 0:size] / size).astype(np.float64)
+    haze0 = _smooth_field(rng, yy, xx, modes=3)
+    haze1 = _smooth_field(rng, yy, xx, modes=3)
+
+    raw = np.empty((1, 2, n_planes, size, size), dtype="f4")
+    mask = np.empty((1, 1, n_planes, size, size), dtype="i4")
+    gy, gx = np.mgrid[0:size, 0:size].astype(np.float64)
+    for z in range(n_planes):
+        clean = np.zeros((size, size))
+        for _ in range(cells_per_plane):
+            cy, cx = rng.uniform(0, size, size=2)
+            r = rng.uniform(3, 7)
+            bright = rng.uniform(0.6, 1.0)
+            clean += bright * np.exp(-((gy - cy) ** 2 + (gx - cx) ** 2) / (2 * r * r))
+        clean = np.clip(clean, 0, 1)
+        mask[0, 0, z] = (clean > 0.5).astype("i4")
+        # Cells at ~0.6 haze gain; haze background up to ~0.5 -- overlapping ranges, so no
+        # global threshold works, but the CNN reads sharp-vs-smooth structure.
+        noise0 = rng.normal(0, 0.05, size=(size, size))
+        noise1 = rng.normal(0, 0.05, size=(size, size))
+        raw[0, 0, z] = (0.6 * clean + 0.5 * haze0 + noise0).astype("f4")
+        raw[0, 1, z] = (0.6 * clean + 0.5 * haze1 + noise1).astype("f4")
+
+    ensure_local_dir(url)
+    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
+    compressors: Literal["auto"] | None = "auto" if compress else None
+    dims = ("t", "c", "z", "y", "x")
+    total_mb = (raw.nbytes + mask.nbytes) / 1e6
+    print(
+        f"make_cells_store: {url}\n"
+        f"  raw (1, 2, {n_planes}, {size}, {size}) Z-chunk 1  +  "
+        f"mask (1, 1, {n_planes}, {size}, {size}) Z-chunk {mask_chunk}  "
+        f"~{total_mb:.0f} MB  compress={'auto' if compress else 'none'}",
+        flush=True,
+    )
+    t0 = time.perf_counter()
+    raw_arr = group.create_array(
+        IDR_RAW,
+        shape=raw.shape,
+        chunks=(1, 1, 1, size, size),
+        dtype="f4",
+        compressors=compressors,
+        dimension_names=dims,
+    )
+    mask_arr = group.create_array(
+        IDR_MASK,
+        shape=mask.shape,
+        chunks=(1, 1, mask_chunk, ic, ic),
+        dtype="i4",
+        compressors=compressors,
+        dimension_names=dims,
+    )
+    raw_arr[:] = raw
+    mask_arr[:] = mask
+    print(f"  done: {url} in {time.perf_counter() - t0:.1f}s", flush=True)
+
+
+def _synthetic_ready(url: str, n_planes: int, size: int, mask_chunk: int) -> bool:
+    """True if a synthetic store with the requested geometry already exists at ``url``.
+
+    A mismatch in shape or Z-chunking, or any open failure (absent / partial), returns False so
+    a changed request regenerates rather than training on a stale store.
+    """
+    try:
+        group = zarr.open_group(store=obstore_store(url), mode="r")
+        raw, mask = group[IDR_RAW], group[IDR_MASK]
+        return (
+            isinstance(raw, zarr.Array)
+            and isinstance(mask, zarr.Array)
+            and raw.shape == (1, 2, n_planes, size, size)
+            and mask.chunks[2] == mask_chunk
+        )
+    except Exception:
+        return False
+
+
+def segmentation_dataset(
+    store: Store,
+    *,
+    raw_var: str = IDR_RAW,
+    mask_var: str = IDR_MASK,
+    sample_axis: int = SAMPLE_AXIS,
+    sample_range: tuple[int, int] | None = None,
+    batch_size: int = 16,
+    shuffle: bool = True,
+    cache_dir: str | None = None,
+    max_inflight: int | None = None,
+) -> InSituDataset:
+    """One dataset: ``raw`` (2-channel image) + ``mask`` (foreground label), sampled over Z.
+
+    ``store`` is a zarr Store -- build it with :func:`~insitubatch.obstore_store` /
+    :func:`~insitubatch.fsspec_store`. ``raw_var`` / ``mask_var`` name the two arrays in the
+    store; the dataset's labels are always ``raw, mask`` so the model code is store-agnostic.
+    Both share the Z (sample) axis *length* but may chunk it differently -- the engine maps the
+    single sample grid (the ``raw`` chunking, one plane per anchor) onto each variable's own
+    chunks. ``sample_range`` restricts the split to a finite Z window. Iterate the returned
+    dataset's ``.train`` / ``.val`` views.
+    """
+    opened = open_geometries(store, variables=[raw_var, mask_var], sample_axis=sample_axis)
+    geoms = {"raw": opened[raw_var], "mask": opened[mask_var]}
+    # The raw (one plane per chunk) is the reference sample grid: one Z-plane = one sample.
+    manifest = split_by_chunk(opened[raw_var], fractions=(0.8, 0.1, 0.1), sample_range=sample_range)
+    return InSituDataset(
+        store,
+        manifest,
+        geometries=geoms,
+        batch_size=batch_size,
+        shuffle=shuffle,
+        cache_dir=cache_dir,
+        max_inflight=max_inflight,
+    )
+
+
+def inputs_and_targets(batch: Batch) -> tuple[np.ndarray, np.ndarray]:
+    """Split a ``Batch`` into ``(x, target)``: the 2-channel image and the binary foreground.
+
+    ``raw`` arrives as ``(B, T=1, C=2, Y, X)`` and ``mask`` as ``(B, T=1, C=1, Y, X)`` -- the
+    singleton OME-NGFF ``T`` axis is a field axis carried whole; we squeeze it here. ``x`` is
+    ``(B, 2, Y, X)`` float; ``target`` is ``(B, 1, Y, X)`` in {0, 1} (the label is instance
+    IDs in the real store, binarized to foreground). The framework loop only touches these.
+    """
+    x = batch.arrays["raw"][:, 0].astype("f4")  # (B, 2, Y, X)
+    target = (batch.arrays["mask"][:, 0] > 0).astype("f4")  # (B, 1, Y, X)
+    return x, target
+
+
+def _otsu(img: np.ndarray, bins: int = 256) -> float:
+    """Otsu's threshold for one image: the intensity maximizing between-class variance."""
+    lo, hi = float(img.min()), float(img.max())
+    if hi <= lo:
+        return hi
+    hist, edges = np.histogram(img, bins=bins, range=(lo, hi))
+    centers = (edges[:-1] + edges[1:]) / 2
+    w = hist.astype(np.float64)
+    wf = np.cumsum(w)  # cumulative weight of the below-threshold (foreground-candidate) class
+    wb = w.sum() - wf
+    cs = np.cumsum(w * centers)
+    mf = cs / np.maximum(wf, 1)
+    mb = (cs[-1] - cs) / np.maximum(wb, 1)
+    between = wf * wb * (mf - mb) ** 2
+    return float(centers[int(np.argmax(between))])
+
+
+def otsu_foreground(batch: Batch) -> np.ndarray:
+    """The no-context baseline: per-plane Otsu threshold on the mean of the two channels.
+
+    Returns a ``(B, 1, Y, X)`` {0, 1} foreground mask -- what you get reading pixel intensity
+    alone, blind to the neighborhood (and so to the smooth haze). The CNN must beat this.
+    """
+    x, _ = inputs_and_targets(batch)
+    intensity = x.mean(axis=1)  # (B, Y, X) -- combine both channels
+    out = np.stack([plane > _otsu(plane) for plane in intensity])  # (B, Y, X)
+    return out[:, None].astype("f4")
+
+
+def iou(pred: np.ndarray, target: np.ndarray) -> float:
+    """Micro-averaged foreground IoU (Jaccard) over all pixels of all planes."""
+    p, t = pred > 0.5, target > 0.5
+    inter = np.logical_and(p, t).sum()
+    union = np.logical_or(p, t).sum()
+    return float(inter / union) if union else 1.0
+
+
+def evaluate(view: Iterable[Batch], predict: Callable[[Batch], np.ndarray]) -> tuple[float, float]:
+    """Foreground IoU on a held-out split view (e.g. ``ds.val``): ``(model_iou, otsu_iou)``.
+
+    ``predict`` maps a ``Batch`` to the model's ``(B, 1, Y, X)`` foreground probability (each
+    framework supplies its own, so this stays framework-neutral). Otsu -- the best a global
+    intensity threshold can do -- is the baseline a useful model must beat. The view is
+    deterministic (eval splits don't shuffle), so no epoch is set.
+    """
+    preds, targets, otsus = [], [], []
+    for batch in view:
+        _x, target = inputs_and_targets(batch)
+        preds.append(predict(batch))
+        targets.append(target)
+        otsus.append(otsu_foreground(batch))
+    pred, target, otsu = (np.concatenate(a) for a in (preds, targets, otsus))
+    return iou(pred, target), iou(otsu, target)
+
+
+def _range(s: str) -> tuple[int, int]:
+    start, stop = (int(x) for x in s.split(","))
+    return (start, stop)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """The shared example CLI (source, device, dataset geometry)."""
+    p = argparse.ArgumentParser(description="OME-NGFF cell segmentation over Z")
+    p.add_argument(
+        "--source",
+        choices=("synthetic", "idr"),
+        default="synthetic",
+        help="offline synthetic cells | the real IDR OME-NGFF image (streamed anonymously)",
+    )
+    p.add_argument(
+        "--device", default="cpu", help="cpu or cuda -- the train loop moves tensors there"
+    )
+    p.add_argument(
+        "--sample-range",
+        type=_range,
+        default=None,
+        metavar="START,STOP",
+        help="finite training window on the Z axis (subset the stack)",
+    )
+    p.add_argument("--epochs", type=int, default=12)
+    p.add_argument("--batch-size", type=int, default=16)
+    p.add_argument("--n-planes", type=int, default=64, help="synthetic stack depth (Z)")
+    p.add_argument("--size", type=int, default=96, help="synthetic plane size (Y=X)")
+    p.add_argument("--mask-chunk", type=int, default=16, help="synthetic mask Z-chunk depth")
+    p.add_argument(
+        "--url",
+        default=None,
+        help="synthetic store path (file:// temp default; gs://... / s3://... for a cloud store)",
+    )
+    p.add_argument(
+        "--regenerate",
+        action="store_true",
+        help="force-rewrite the synthetic store even if one with the same geometry exists",
+    )
+    p.add_argument(
+        "--cache-dir",
+        default=None,
+        help="spill the decoded-chunk cache here (e.g. NVMe) for cross-epoch reuse",
+    )
+    p.add_argument(
+        "--max-inflight",
+        type=int,
+        default=None,
+        help="throttle read-ahead depth (lower = lower cold TTFB over a high-latency network)",
+    )
+    return p
+
+
+def cli() -> argparse.Namespace:
+    """Parse the shared CLI."""
+    return build_parser().parse_args()
+
+
+def build_datasets(args: argparse.Namespace) -> InSituDataset:
+    """One segmentation dataset from CLI args -- iterate ``ds.train`` / ``ds.val``. ``--source``
+    picks offline synthetic cells (written fresh) or the real IDR OME-NGFF image."""
+    if args.source == "idr":
+        store = _idr_store()
+        return segmentation_dataset(
+            store,
+            raw_var=IDR_RAW,
+            mask_var=IDR_MASK,
+            sample_range=args.sample_range,
+            batch_size=args.batch_size,
+            shuffle=True,
+            cache_dir=args.cache_dir,
+            max_inflight=args.max_inflight,
+        )
+    url = args.url or "file:///tmp/insitu_cells.zarr"
+    if args.regenerate or not _synthetic_ready(url, args.n_planes, args.size, args.mask_chunk):
+        make_cells_store(url, n_planes=args.n_planes, size=args.size, mask_chunk=args.mask_chunk)
+    return segmentation_dataset(
+        obstore_store(url),
+        sample_range=args.sample_range,
+        batch_size=args.batch_size,
+        shuffle=True,
+        cache_dir=args.cache_dir,
+        max_inflight=args.max_inflight,
+    )

--- a/examples/microscopy/train_torch.py
+++ b/examples/microscopy/train_torch.py
@@ -1,0 +1,94 @@
+"""Segment cells with a tiny CNN, in **PyTorch**, on one insitu dataset.
+
+Only this file is torch: ``to_torch`` is a zero-copy DLPack hand-off and the train loop moves
+each batch to ``--device``. The model reads the 2-channel image plus its spatial neighborhood,
+so beating the Otsu (global-threshold) baseline means it used context the threshold cannot see
+-- the haze that overlaps cell and background intensity ranges. The dataset stays numpy; the
+two variables (``raw`` Z-chunk 1, ``mask`` Z-chunk 30) are co-batched over Z with no reshard.
+
+Sources (``--source synthetic|idr``), the finite Z window (``--sample-range``), GPU placement
+and the NVMe cache flags are documented in ``examples/README.md``; the framework-neutral data
+layer is ``examples/microscopy/data.py``.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from insitubatch.frameworks import to_torch
+from insitubatch.source import InSituDataset
+from insitubatch.types import Batch
+
+from .data import build_datasets, cli, evaluate, inputs_and_targets
+
+
+class SegCNN(nn.Module):
+    """2 input channels -> 1 foreground logit. Inputs are standardized per channel; four 3x3
+    convolutions (reflect-padded -- microscopy is not periodic) give a receptive field of 9,
+    enough to tell a sharp cell from the smooth haze a per-pixel threshold cannot."""
+
+    def __init__(self, hidden: int = 32) -> None:
+        super().__init__()
+
+        def conv(i: int, o: int) -> nn.Conv2d:
+            return nn.Conv2d(i, o, 3, padding=1, padding_mode="reflect")
+
+        self.net = nn.Sequential(
+            conv(2, hidden),
+            nn.ReLU(),
+            conv(hidden, hidden),
+            nn.ReLU(),
+            conv(hidden, hidden),
+            nn.ReLU(),
+            conv(hidden, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # x: (B, 2, H, W) -> logits (B, 1, H, W)
+        xn = (x - x.mean((0, 2, 3), keepdim=True)) / (x.std((0, 2, 3), keepdim=True) + 1e-6)
+        return self.net(xn)
+
+
+def _logits(model: SegCNN, batch: Batch, device: torch.device) -> torch.Tensor:
+    """Foreground logits for one batch. ``to_torch`` is a zero-copy DLPack hand-off on CPU;
+    moving to ``device`` is the H2D copy -- placement is the loop's job, not the dataset's."""
+    d = to_torch(batch)  # {label: (B, T, C, H, W) tensor}, CPU via DLPack
+    x = d["raw"][:, 0].float().to(device)  # (B, 2, H, W); float (real raw is uint16), drop T
+    return model(x)
+
+
+def train(ds: InSituDataset, *, epochs: int, device: str = "cpu") -> tuple[float, float]:
+    """Train the CNN; return ``(model_iou, otsu_iou)`` -- foreground IoU on val."""
+    dev = torch.device(device)
+    model = SegCNN().to(dev)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    for epoch in range(epochs):
+        ds.set_epoch(epoch)
+        model.train()
+        last = 0.0
+        for batch in ds.train:
+            _x, target = inputs_and_targets(batch)
+            y = torch.from_numpy(target).to(dev)  # (B, 1, H, W) in {0, 1}
+            loss = nn.functional.binary_cross_entropy_with_logits(_logits(model, batch, dev), y)
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            last = loss.item()
+        print(f"epoch {epoch}  train bce {last:.4f}")
+    model.eval()
+    with torch.no_grad():
+        return evaluate(ds.val, lambda b: torch.sigmoid(_logits(model, b, dev)).cpu().numpy())
+
+
+def main() -> None:
+    args = cli()
+    ds = build_datasets(args)
+    model_iou, otsu_iou = train(ds, epochs=args.epochs, device=args.device)
+    print(
+        f"\nforeground IoU on held-out data: model {model_iou:.3f}  vs  "
+        f"Otsu threshold {otsu_iou:.3f}  ({model_iou - otsu_iou:+.3f})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/insitubatch/plan.py
+++ b/src/insitubatch/plan.py
@@ -20,6 +20,7 @@ from .types import ArrayGeometry, StoredChunkRead
 def build_stored_chunk_reads(
     chunk_ids: Sequence[int] | np.ndarray,
     geometries: dict[str, ArrayGeometry],
+    ref_spc: int,
 ) -> list[StoredChunkRead]:
     """Expand outer chunk ids into deduped stored-chunk reads, in priority order.
 
@@ -40,17 +41,18 @@ def build_stored_chunk_reads(
     (same path, different ``offset``) collapse to a single fetch -- decode-once.
     Dedup also makes the function safe to call with repeated ids.
 
-    ``chunk_ids`` are *anchor* chunks. A windowed variable reads ``array[anchor +
-    offset]``, so its anchor chunk's samples map to one or two offset-shifted *read*
-    chunks; each is expanded here (clamped to the array, since edge anchors that would
-    read off the array are dropped from the draw upstream). With every ``offset == 0``
-    this is exactly ``anchor chunk -> itself``.
+    ``chunk_ids`` are *anchor* chunks in the **reference** grid (``ref_spc`` = the
+    manifest's sample-chunk size, which defines the shuffle/split anchor grid). A windowed
+    variable reads ``array[anchor + offset]``, and a variable that chunks the sample axis
+    differently from the reference maps those anchor samples onto *its own* chunks -- so one
+    anchor chunk expands to the (offset-shifted) chunks each variable needs. With every
+    ``offset == 0`` and a uniform chunk size this is exactly ``anchor chunk -> itself``.
     """
     reads: list[StoredChunkRead] = []
     seen: set[StoredChunkRead] = set()
     for cid in chunk_ids:
         for geom in geometries.values():
-            for read_cid in _read_chunks(geom, int(cid)):
+            for read_cid in _read_chunks(geom, int(cid), ref_spc):
                 for inner in geom.inner_coords():
                     read = StoredChunkRead(geom.path, read_cid, inner)
                     if read not in seen:
@@ -59,17 +61,21 @@ def build_stored_chunk_reads(
     return reads
 
 
-def _read_chunks(geom: ArrayGeometry, anchor_chunk: int) -> range:
-    """Offset-shifted read chunks an anchor chunk needs for ``geom`` (1-2, clamped).
+def _read_chunks(geom: ArrayGeometry, anchor_chunk: int, ref_spc: int) -> range:
+    """Offset-shifted read chunks an anchor chunk needs for ``geom`` (clamped).
 
-    The anchor samples ``[start, stop)`` of ``anchor_chunk`` read array samples
-    ``[start+offset, stop-1+offset]``; clamp to ``[0, n_samples)`` (edge anchors are
-    dropped from the draw) and return the half-open range of chunks they span.
+    ``anchor_chunk`` is in the reference grid: its anchor samples are ``[k*ref_spc,
+    (k+1)*ref_spc)`` (clamped to the array). Those read array samples ``[start+offset,
+    stop-1+offset]``, mapped onto ``geom``'s *own* chunk grid (``geom.sample_chunk_size``).
+    A variable coarser than the reference collapses several anchor chunks onto one of its
+    chunks; a finer one spans several. Edge anchors that read off the array are dropped from
+    the draw upstream, so an empty span here means nothing to fetch.
     """
-    spc = geom.sample_chunk_size
-    anchors = geom.samples_in_chunk(anchor_chunk)
-    lo = max(0, anchors.start + geom.offset)
-    hi = min(geom.n_samples - 1, anchors.stop - 1 + geom.offset)
+    start = anchor_chunk * ref_spc
+    stop = min(start + ref_spc, geom.n_samples)
+    lo = max(0, start + geom.offset)
+    hi = min(geom.n_samples - 1, stop - 1 + geom.offset)
     if lo > hi:  # the whole anchor chunk reads off the array (edge); nothing to fetch
         return range(0)
+    spc = geom.sample_chunk_size
     return range(lo // spc, hi // spc + 1)

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -662,16 +662,16 @@ class ChunkPool:
     def gather(self, rows: np.ndarray, variables: list[str], sample_chunk_size: int) -> Batch:
         """Assemble one batch from ``[chunk_id, within]`` *anchor* draw rows.
 
-        Each row is one sample anchor ``t = chunk_id*spc + within``; each variable
-        reads its array at ``t + offset`` (offset 0 is the plain non-windowed case).
-        Output is in anchor-row order: row ``i`` of every variable is the same anchor,
-        ``sample_indices[i] == t_i``. Per variable the reads are grouped by the
-        variable's *own* (offset-shifted) chunk -- one coalesced fancy-index per chunk,
-        never a Python per-sample loop. The caller must have waited every referenced
-        ``(path, offset-shifted chunk)`` ready.
+        Each row is one sample anchor ``t = chunk_id*ref_spc + within`` in the reference
+        (manifest) grid; each variable reads its array at ``t + offset`` (offset 0 is the
+        plain non-windowed case). Output is in anchor-row order: row ``i`` of every variable
+        is the same anchor, ``sample_indices[i] == t_i``. Per variable the reads are grouped
+        by the variable's *own* (offset-shifted) chunk -- computed with that variable's
+        chunk size, so variables may chunk the sample axis differently -- one coalesced
+        fancy-index per chunk, never a Python per-sample loop. The caller must have waited
+        every referenced ``(path, offset-shifted chunk)`` ready.
         """
-        spc = sample_chunk_size
-        anchor = rows[:, 0].astype(np.int64) * spc + rows[:, 1].astype(np.int64)  # (N,)
+        anchor = rows[:, 0].astype(np.int64) * sample_chunk_size + rows[:, 1].astype(np.int64)
         n = anchor.shape[0]
 
         arrays: dict[str, np.ndarray] = {}
@@ -679,6 +679,7 @@ class ChunkPool:
             geom = self._geom[var]  # source: drives the read math (offset, path, chunking)
             out_geom = self._out_geom[var]  # post-transform: shape/dtype the consumer sees
             sample = anchor + geom.offset  # this view reads array[anchor + offset]
+            spc = geom.sample_chunk_size  # the variable's own grid (may differ from ref)
             read_cid = sample // spc
             within = sample % spc
             out = np.empty((n, *out_geom.inner_shape), dtype=out_geom.dtype)

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -232,13 +232,15 @@ class Scheduler:
 
     # -- public, synchronous surface ---------------------------------------
 
-    def start(self, chunk_ids: Sequence[int] | np.ndarray) -> Future:
+    def start(self, chunk_ids: Sequence[int] | np.ndarray, ref_spc: int) -> Future:
         """Begin streaming the stored chunks of ``chunk_ids`` (priority order).
 
+        ``chunk_ids`` are in the reference (manifest) grid; ``ref_spc`` is that grid's
+        sample-chunk size, used to map anchor chunks onto each variable's own chunks.
         Returns the driver future; a failure there poisons the pool so consumers
         re-raise. The consumer drives demand independently via :attr:`pool`.
         """
-        reads = build_stored_chunk_reads(chunk_ids, self._geometries)
+        reads = build_stored_chunk_reads(chunk_ids, self._geometries, ref_spc)
         fut = asyncio.run_coroutine_threadsafe(self._drive(reads), self._loop)
         fut.add_done_callback(self._on_drive_done)
         return fut

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -130,16 +130,22 @@ class InSituDataset:
         self.manifest = manifest
         self.variables = list(self.geometries)
 
-        # Variables must share the sample axis (length + chunk size): the draw order
-        # and gather use a single chunk size for all variables.
-        spcs = {g.sample_chunk_size for g in self.geometries.values()}
+        # Variables must share the sample-axis *length* (samples are paired row-for-row);
+        # they may chunk that axis differently (raw Z-chunk 1 + label mask Z-chunk 30). The
+        # manifest defines the reference anchor grid; each variable maps anchors onto its own
+        # chunks. n_samples must match the manifest so the anchor grid indexes every variable.
         lengths = {g.n_samples for g in self.geometries.values()}
-        if len(spcs) > 1 or len(lengths) > 1:
+        if len(lengths) > 1:
             raise ValueError(
-                "All variables must share the same sample-axis length and chunk "
-                f"size; got sample_chunk_size={sorted(spcs)}, "
+                f"All variables must share the same sample-axis length; got "
                 f"n_samples={sorted(lengths)}."
             )
+        if lengths and manifest.n_samples != next(iter(lengths)):
+            raise ValueError(
+                f"manifest sample-axis length {manifest.n_samples} does not match the "
+                f"variables' n_samples {next(iter(lengths))}."
+            )
+        self._ref_spc = manifest.sample_chunk_size  # the anchor grid (shuffle/split/gather)
 
         self.batch_size = batch_size
         self.block_chunks = block_chunks
@@ -175,31 +181,56 @@ class InSituDataset:
         # boundary, so an anchor chunk's read-union spans up to 2 + ceil(span/spc)
         # chunks per variable (span = max offset - min offset); with every offset 0 the
         # factor is 1 -- the plain 2 * block_chunks working set.
-        spc0 = next(iter(self.geometries.values())).sample_chunk_size
         offsets = [g.offset for g in self.geometries.values()]
         span = max(offsets) - min(offsets)
         windowed = any(o != 0 for o in offsets)
-        window_factor = 2 + (-(-span // spc0)) if windowed else 1  # 2 + ceil(span/spc)
+        uniform_spc = len({g.sample_chunk_size for g in self.geometries.values()}) == 1
         # Size from the OUTPUT geometry: the pool caches post-transform chunks, so a regrid
         # that grows (or shrinks) the data changes the resident footprint the budget must hold.
-        per_chunk_all_vars = int(
-            sum(
-                g.sample_chunk_size * int(np.prod(o.inner_shape)) * o.dtype.itemsize
-                for g, o in zip(
-                    self.geometries.values(), self._out_geometries.values(), strict=True
-                )
+        out_geoms = list(self._out_geometries.values())
+        geoms = list(self.geometries.values())
+
+        def bytes_per_chunk(g: ArrayGeometry, o: ArrayGeometry) -> int:
+            return int(g.sample_chunk_size * int(np.prod(o.inner_shape)) * o.dtype.itemsize)
+
+        if uniform_spc:
+            # Uniform chunk size: every variable's chunk aligns to the reference grid, so a
+            # block reads exactly its own chunks. (Unchanged formula.)
+            spc0 = geoms[0].sample_chunk_size
+            window_factor = 2 + (-(-span // spc0)) if windowed else 1  # 2 + ceil(span/spc)
+            per_chunk_all_vars = sum(
+                bytes_per_chunk(g, o) for g, o in zip(geoms, out_geoms, strict=True)
             )
-        )
-        working_set = 2 * block_chunks * window_factor * per_chunk_all_vars
-        if windowed and self.shuffle:
-            # Shuffle permutes chunk order, so a windowed read can spill into chunks
-            # owned by any other block: a chunk admitted early may be needed late. Until
-            # bounded residency (re-fetch the spill) lands, hold the whole split resident
-            # -- decode-once, the accepted memory cost of windows (spill to NVMe via
-            # cache_dir on large splits). Only `.train` shuffles (eval views are
-            # sequential and spill only locally), so size to the train split.
-            n_train_chunks = len(self.manifest.chunks[SplitName.TRAIN.value])
-            working_set = max(working_set, n_train_chunks * per_chunk_all_vars)
+            working_set = 2 * block_chunks * window_factor * per_chunk_all_vars
+            if windowed and self.shuffle:
+                # Shuffle permutes chunk order, so a windowed read can spill into chunks
+                # owned by any other block: a chunk admitted early may be needed late. Until
+                # bounded residency (re-fetch the spill) lands, hold the whole split resident
+                # -- decode-once, the accepted memory cost of windows (spill to NVMe via
+                # cache_dir on large splits). Only `.train` shuffles (eval views are
+                # sequential and spill only locally), so size to the train split.
+                n_train_chunks = len(self.manifest.chunks[SplitName.TRAIN.value])
+                working_set = max(working_set, n_train_chunks * per_chunk_all_vars)
+        else:
+            # Non-uniform chunk size: a variable maps the reference anchor grid onto its own
+            # chunks, so a block touches a variable-specific chunk count. A 2-block read-ahead
+            # window of `2*block_chunks*ref_spc` anchor samples (plus the offset span) covers,
+            # per variable, ceil(window/spc)+1 of its chunks (the +1 for boundary misalignment).
+            def var_bytes(g: ArrayGeometry, o: ArrayGeometry, samples: int) -> int:
+                n_chunks = -(-(samples + span) // g.sample_chunk_size) + 1
+                return n_chunks * bytes_per_chunk(g, o)
+
+            pairs = list(zip(geoms, out_geoms, strict=True))
+            window_samples = 2 * block_chunks * self._ref_spc
+            working_set = sum(var_bytes(g, o, window_samples) for g, o in pairs)
+            if self.shuffle:
+                # Under shuffle a variable chunk can be needed by scattered blocks (a coarse
+                # chunk straddling reference-block boundaries) -- like a window spill -- so
+                # hold the train split resident per variable (decode-once). A tighter bound is
+                # future work; different-axis-chunking is today a modest-sized microscopy case.
+                train_samples = len(self.manifest.chunks[SplitName.TRAIN.value]) * self._ref_spc
+                train_ws = sum(var_bytes(g, o, train_samples) for g, o in pairs)
+                working_set = max(working_set, train_ws)
         self.cache_budget_bytes = max(int(cache_budget_bytes or 0), working_set)
         # persist turns the cache_dir mmap tier into a cross-run cache (files + manifest
         # survive close; reopen revives them as hits). It needs a dir to keep files in;
@@ -259,21 +290,21 @@ class InSituDataset:
         return np.asarray(ids, dtype=np.int64)
 
     def _draw_order(self, split: SplitName | None, shuffle: bool) -> np.ndarray:
-        geom = self.geometries[self.variables[0]]
         chunk_ids = self._chunk_ids(split)
-        spc = geom.sample_chunk_size
+        spc = self._ref_spc  # the manifest's anchor grid, shared by every variable
+        n_samples = self.manifest.n_samples
         if shuffle:
             order = block_shuffled_order(
                 chunk_ids,
                 spc,
-                geom.n_samples,
+                n_samples,
                 block_chunks=self.block_chunks,
                 seed=self.seed,
                 epoch=self._epoch,
             )
         else:
-            order = sequential_order(chunk_ids, spc, geom.n_samples)
-        return self._drop_edge_anchors(order, spc, geom.n_samples)
+            order = sequential_order(chunk_ids, spc, n_samples)
+        return self._drop_edge_anchors(order, spc, n_samples)
 
     def _drop_edge_anchors(self, order: np.ndarray, spc: int, n_samples: int) -> np.ndarray:
         """Keep only anchors whose every windowed read ``anchor + offset`` is on the
@@ -294,7 +325,7 @@ class InSituDataset:
         anchor = block_rows[:, 0].astype(np.int64) * spc + block_rows[:, 1].astype(np.int64)
         keys: set[tuple[str, int]] = set()
         for geom in self.geometries.values():
-            read_cid = (anchor + geom.offset) // spc
+            read_cid = (anchor + geom.offset) // geom.sample_chunk_size  # variable's own grid
             keys.update((geom.path, int(c)) for c in np.unique(read_cid))
         return keys
 
@@ -313,8 +344,7 @@ class InSituDataset:
         overlaps the per-batch compute. Chunks the pool already holds (cross-epoch or
         cross-split hits) cost no fetch.
         """
-        geom = self.geometries[self.variables[0]]
-        spc = geom.sample_chunk_size
+        spc = self._ref_spc  # the manifest anchor grid, shared by every variable
         order = self._draw_order(split, shuffle)
         blocks = _partition_blocks(order, self.block_chunks)
         ordered_chunks = [int(c) for _rstart, _rstop, cids in blocks for c in cids]
@@ -345,7 +375,7 @@ class InSituDataset:
         def produce(sched: Scheduler) -> None:
             bs = self.batch_size
             try:
-                sched.start(ordered_chunks)
+                sched.start(ordered_chunks, spc)
                 for bi, (rstart, rstop, _cids) in enumerate(blocks):
                     # A block's batches draw across its whole read-union, so wait it all
                     # assembled (and claimed by the driver -- see ChunkPool.wait_ready)

--- a/tests/test_microscopy.py
+++ b/tests/test_microscopy.py
@@ -1,0 +1,72 @@
+"""OME-NGFF segmentation example: per-variable-chunked, over-Z sampling + the model learns.
+
+One fixture builds a small synthetic cell stack whose two variables are chunked *differently*
+along the Z (sample) axis -- ``raw`` one plane deep, ``mask`` many planes deep. The tests
+assert the engine co-batches them off one sample grid with no reshard, and that the torch
+model beats the Otsu (global-threshold) baseline it can only beat by reading spatial context.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from examples.microscopy.data import (
+    IDR_MASK,
+    IDR_RAW,
+    SAMPLE_AXIS,
+    inputs_and_targets,
+    iou,
+    make_cells_store,
+    otsu_foreground,
+    segmentation_dataset,
+)
+from insitubatch import obstore_store, open_geometries
+
+MASK_CHUNK = 12
+
+
+@pytest.fixture
+def cells_store(tmp_path) -> str:
+    """A small two-channel cell stack (fast: shallow, small planes)."""
+    url = f"file://{tmp_path}/cells.zarr"
+    make_cells_store(url, n_planes=48, size=48, mask_chunk=MASK_CHUNK, seed=0)
+    return url
+
+
+def test_dataset_is_per_variable_chunked_over_z(cells_store) -> None:
+    geoms = open_geometries(
+        obstore_store(cells_store), variables=[IDR_RAW, IDR_MASK], sample_axis=SAMPLE_AXIS
+    )
+    # Same Z (sample) length, different chunking along it -- the per-variable-chunking case.
+    assert geoms[IDR_RAW].n_samples == geoms[IDR_MASK].n_samples == 48
+    assert geoms[IDR_RAW].sample_chunk_size == 1
+    assert geoms[IDR_MASK].sample_chunk_size == MASK_CHUNK
+
+    ds = segmentation_dataset(obstore_store(cells_store), batch_size=8, shuffle=False)
+    ds.set_epoch(0)
+    batch = next(iter(ds.train))
+
+    assert set(batch.arrays) == {"raw", "mask"}
+    assert batch.arrays["raw"].shape[1:] == (1, 2, 48, 48)  # (T=1, C=2, Y, X) carried whole
+    assert batch.arrays["mask"].shape[1:] == (1, 1, 48, 48)
+    x, target = inputs_and_targets(batch)
+    assert x.shape[1] == 2  # two input channels (T squeezed)
+    assert target.shape[1] == 1
+    assert set(target.ravel().tolist()) <= {0.0, 1.0}  # binarized foreground
+
+
+def test_otsu_baseline_is_beatable(cells_store) -> None:
+    # The synthetic haze defeats a global threshold, so Otsu leaves real headroom to beat.
+    ds = segmentation_dataset(obstore_store(cells_store), batch_size=8, shuffle=False)
+    ds.set_epoch(0)
+    batch = next(iter(ds.train))
+    _x, target = inputs_and_targets(batch)
+    assert iou(otsu_foreground(batch), target) < 0.9
+
+
+def test_torch_beats_otsu(cells_store) -> None:
+    pytest.importorskip("torch")
+    from examples.microscopy.train_torch import train
+
+    model_iou, otsu_iou = train(segmentation_dataset(obstore_store(cells_store)), epochs=12)
+    assert model_iou > otsu_iou

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -73,7 +73,8 @@ async def _decode_tiles(url: str, var: str) -> dict[tuple[int, ...], np.ndarray]
 def test_build_stored_chunk_reads_expands_and_dedups(tiled_store):
     url, _ = tiled_store
     geoms = open_geometries(obstore_store(url))
-    reads = build_stored_chunk_reads([0, 1, 0], geoms)  # repeat 0 -> must dedup
+    ref_spc = geoms["spatial"].sample_chunk_size
+    reads = build_stored_chunk_reads([0, 1, 0], geoms, ref_spc)  # repeat 0 -> must dedup
 
     # spatial expands to its inner grid (3x2=6), single_inner to 1; x2 outer chunks.
     per_outer = sum(g.n_inner_chunks(0) for g in geoms.values())
@@ -97,7 +98,7 @@ def test_pool_aliased_labels_decode_once(tiled_store):
     base = open_geometries(obstore_store(url), variables=[array])[array]  # base.name == array
     geoms = {"now": base, "next": base}  # two labels, one underlying array
     tiles = asyncio.run(_decode_tiles(url, array))
-    reads = build_stored_chunk_reads(range(base.n_chunks), {array: base})
+    reads = build_stored_chunk_reads(range(base.n_chunks), {array: base}, base.sample_chunk_size)
 
     pool = ChunkPool(geoms)
     for cid in range(base.n_chunks):
@@ -124,7 +125,7 @@ def test_pool_scatter_reconstructs_array(tiled_store, var):
     geoms = open_geometries(obstore_store(url), variables=[var])
     geom = geoms[var]
     tiles = asyncio.run(_decode_tiles(url, var))
-    reads = build_stored_chunk_reads(range(geom.n_chunks), geoms)
+    reads = build_stored_chunk_reads(range(geom.n_chunks), geoms, geom.sample_chunk_size)
 
     pool = ChunkPool(geoms)
     for cid in range(geom.n_chunks):

--- a/tests/test_sample_axis.py
+++ b/tests/test_sample_axis.py
@@ -90,3 +90,41 @@ def test_windowing_composes_with_sample_axis(tmp_path) -> None:
             np.testing.assert_array_equal(b.arrays["x"][i], logical[anchor])
             np.testing.assert_array_equal(b.arrays["y"][i], logical[anchor + 1])
     ds.close()
+
+
+@pytest.mark.parametrize("shuffle", [False, True])
+def test_shift_and_uneven_chunks_compose_with_sample_axis(tmp_path, shuffle) -> None:
+    # All three seams at once: a shifted target (window) drawn from a *differently-chunked*
+    # variable (per-variable chunks) over a *non-zero* sample axis. raw Z-chunk 1, labels
+    # Z-chunk 3, sampled over Z (axis 1); target = labels one Z-slice ahead. Exercises the
+    # plan/gather offset math, the per-variable spc mapping, and the scheduler moveaxis together.
+    url = f"file://{tmp_path}/zwc.zarr"
+    ensure_local_dir(url)
+    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
+    rdata = np.arange(2 * 9 * 4 * 4, dtype="f4").reshape(2, 9, 4, 4)  # (C, Z, Y, X)
+    ldata = rdata + 1000.0  # distinguishable per variable
+    group.create_array("raw", shape=(2, 9, 4, 4), chunks=(2, 1, 4, 4), dtype="f4")[:] = rdata
+    group.create_array("labels", shape=(2, 9, 4, 4), chunks=(2, 3, 4, 4), dtype="f4")[:] = ldata
+
+    opened = open_geometries(obstore_store(url), sample_axis=1)
+    geoms = {"x": opened["raw"], "y": opened["labels"].shift(1)}
+    manifest = split_by_chunk(opened["raw"], fractions=(1.0, 0.0, 0.0))  # anchor grid = raw spc=1
+    ds = InSituDataset(
+        obstore_store(url),
+        manifest,
+        geometries=geoms,
+        batch_size=2,
+        block_chunks=3,
+        shuffle=shuffle,
+    )
+
+    rlog = np.moveaxis(rdata, 1, 0)  # (Z, C, Y, X)
+    llog = np.moveaxis(ldata, 1, 0)
+    anchors: list[int] = []
+    for b in ds.all:
+        for i, anchor in enumerate(b.sample_indices):
+            np.testing.assert_array_equal(b.arrays["x"][i], rlog[anchor])  # B+C: no shift
+            np.testing.assert_array_equal(b.arrays["y"][i], llog[anchor + 1])  # A+B+C
+            anchors.append(int(anchor))
+    assert sorted(anchors) == list(range(8))  # 9 Z-slices, shift(1) drops the last, each once
+    ds.close()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -68,7 +68,7 @@ def test_scheduler_fills_pool_matches_array(tiled_store, var, bounded):
         budget = 2 * full  # holds two full chunks; admission must evict to fit the 3rd
 
     with _make(url, geoms, budget=budget) as sched:
-        fut = sched.start(range(geom.n_chunks))
+        fut = sched.start(range(geom.n_chunks), geom.sample_chunk_size)
         got = _drain_in_order(sched, geom, var, unpin=bounded)
         fut.result(timeout=30)  # surface any driver error
         assert sched.inflight_peak <= 4  # the single max_inflight budget holds
@@ -85,7 +85,7 @@ def test_scheduler_inflight_saturates_to_budget(tiled_store):
         obstore_store(url), variables=["spatial"]
     )  # 3 chunks x 6 tiles = 18 reads
     with _make(url, geoms, max_inflight=4) as sched:
-        fut = sched.start(range(geoms["spatial"].n_chunks))
+        fut = sched.start(range(geoms["spatial"].n_chunks), geoms["spatial"].sample_chunk_size)
         _drain_in_order(sched, geoms["spatial"], "spatial", unpin=False)
         fut.result(timeout=30)
         assert sched.inflight_peak == 4
@@ -102,7 +102,7 @@ def test_scheduler_close_closes_the_loop(tiled_store):
     url, _ = tiled_store
     geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     sched = _make(url, geoms)
-    sched.start(range(geoms["single_inner"].n_chunks))
+    sched.start(range(geoms["single_inner"].n_chunks), geoms["single_inner"].sample_chunk_size)
     sched.close()
     assert sched._loop.is_closed()
 
@@ -125,7 +125,7 @@ def test_scheduler_windowed_views_decode_once_and_lead(tiled_store):
     rows = np.stack([anchors // spc, anchors % spc], axis=1).astype(np.int64)
 
     with _make(url, geoms) as sched:
-        fut = sched.start(range(base.n_chunks))
+        fut = sched.start(range(base.n_chunks), base.sample_chunk_size)
         for cid in range(base.n_chunks):
             sched.pool.wait_ready(base.path, cid)  # slots are keyed by path
         batch = sched.pool.gather(rows, ["now", "next"], spc)
@@ -143,7 +143,7 @@ def test_scheduler_poisons_pool_on_driver_failure(tiled_store):
     url, _ = tiled_store
     ghost = ArrayGeometry(path="ghost", shape=(4, 2, 2), chunks=(2, 2, 2), dtype=np.dtype("f4"))
     with _make(url, {"ghost": ghost}) as sched:
-        fut = sched.start([0, 1])
+        fut = sched.start([0, 1], ghost.sample_chunk_size)
         with pytest.raises(Exception):  # noqa: B017 - zarr surfaces a store-specific error type
             fut.result(timeout=30)
         with pytest.raises(Exception):  # noqa: B017 - same error re-raised to the consumer

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -46,16 +46,17 @@ def test_partition_blocks_empty() -> None:
     assert _partition_blocks(np.empty((0, 2), dtype=np.int64), block_chunks=4) == []
 
 
-def test_unequal_chunking_raises(tmp_path) -> None:
+def test_unequal_sample_length_raises(tmp_path) -> None:
     url = f"file://{tmp_path}/uv.zarr"
+    # Different sample-axis *length* is genuinely unsupported (samples aren't paired).
     ensure_local_dir(url)
     group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
     group.create_array("u10", shape=(40, 2, 2), chunks=(8, 2, 2), dtype="f4")
-    group.create_array("v10", shape=(40, 2, 2), chunks=(4, 2, 2), dtype="f4")  # different spc
+    group.create_array("v10", shape=(32, 2, 2), chunks=(8, 2, 2), dtype="f4")  # different length
     geoms = open_geometries(obstore_store(url))
     manifest = split_by_chunk(geoms["u10"], fractions=(0.8, 0.1, 0.1))
 
-    with pytest.raises(ValueError, match="same sample-axis"):
+    with pytest.raises(ValueError, match="sample-axis length"):
         InSituDataset(obstore_store(url), manifest, geometries=geoms)
 
 

--- a/tests/test_uneven_chunking.py
+++ b/tests/test_uneven_chunking.py
@@ -61,6 +61,27 @@ def test_fine_variable_maps_onto_coarse_reference(tmp_path) -> None:
     ds.close()
 
 
+def test_windowed_target_on_coarser_variable(tmp_path) -> None:
+    # shift + per-variable chunks together: a forecast whose target is a *differently-chunked*
+    # variable read one step ahead. input = raw (spc=1); target = labels (spc=8) shifted +1.
+    url = f"file://{tmp_path}/w.zarr"
+    srcs = _write_two(url, n=40, spc_a=1, spc_b=8)
+    opened = open_geometries(obstore_store(url))
+    geoms = {"x": opened["raw"], "y": opened["labels"].shift(1)}
+    manifest = split_by_chunk(opened["raw"], fractions=(1.0, 0.0, 0.0))  # anchor grid spc=1
+    ds = InSituDataset(
+        obstore_store(url), manifest, geometries=geoms, batch_size=6, block_chunks=3, shuffle=False
+    )
+    seen = 0
+    for b in ds.all:
+        for i, anchor in enumerate(b.sample_indices):
+            np.testing.assert_array_equal(b.arrays["x"][i], srcs["raw"][anchor])
+            np.testing.assert_array_equal(b.arrays["y"][i], srcs["labels"][anchor + 1])
+            seen += 1
+    assert seen == 39  # shift(1) drops the last anchor (no sample at n)
+    ds.close()
+
+
 def test_uneven_chunking_shuffled(tmp_path) -> None:
     url = f"file://{tmp_path}/c.zarr"
     srcs = _write_two(url, n=48, spc_a=2, spc_b=12)

--- a/tests/test_uneven_chunking.py
+++ b/tests/test_uneven_chunking.py
@@ -1,0 +1,80 @@
+"""Variables may chunk the sample axis differently (the OME-NGFF raw+labels pairing:
+raw Z-chunk 1, label mask Z-chunk 30). They must still share the sample-axis *length*;
+the anchor grid is the manifest's chunking, and each variable maps global anchors onto
+its own chunk grid.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import zarr
+
+from insitubatch import ensure_local_dir, obstore_store, open_geometries, split_by_chunk
+from insitubatch.source import InSituDataset
+
+
+def _write_two(url: str, n: int, spc_a: int, spc_b: int, inner=(3, 3)):
+    ensure_local_dir(url)
+    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
+    srcs = {}
+    for name, spc in (("raw", spc_a), ("labels", spc_b)):
+        arr = group.create_array(name, shape=(n, *inner), chunks=(spc, *inner), dtype="f4")
+        data = np.arange(n * int(np.prod(inner)), dtype="f4").reshape(n, *inner)
+        data = data + (0.0 if name == "raw" else 1000.0)  # distinguishable per variable
+        arr[:] = data
+        srcs[name] = data
+    return srcs
+
+
+def _check_values(ds: InSituDataset, srcs: dict[str, np.ndarray]) -> int:
+    seen = 0
+    for b in ds.all:
+        for i, anchor in enumerate(b.sample_indices):
+            for name, src in srcs.items():
+                np.testing.assert_array_equal(b.arrays[name][i], src[anchor])
+            seen += 1
+    return seen
+
+
+def test_coarse_variable_maps_onto_fine_reference(tmp_path) -> None:
+    # reference = fine (raw spc=1); the coarse label chunks (spc=8) map onto the anchor grid.
+    url = f"file://{tmp_path}/a.zarr"
+    srcs = _write_two(url, n=40, spc_a=1, spc_b=8)
+    geoms = open_geometries(obstore_store(url))
+    manifest = split_by_chunk(geoms["raw"], fractions=(1.0, 0.0, 0.0))  # anchor grid spc=1
+    ds = InSituDataset(obstore_store(url), manifest, geometries=geoms, batch_size=6, shuffle=False)
+    assert _check_values(ds, srcs) == 40
+    ds.close()
+
+
+def test_fine_variable_maps_onto_coarse_reference(tmp_path) -> None:
+    # reference = coarse (labels spc=8); the fine raw chunks (spc=1) map on -- the budget
+    # must hold enough of the fine variable's many chunks per block (else admission deadlocks).
+    url = f"file://{tmp_path}/b.zarr"
+    srcs = _write_two(url, n=40, spc_a=1, spc_b=8)
+    geoms = open_geometries(obstore_store(url))
+    manifest = split_by_chunk(geoms["labels"], fractions=(1.0, 0.0, 0.0))  # anchor grid spc=8
+    ds = InSituDataset(
+        obstore_store(url), manifest, geometries=geoms, batch_size=6, block_chunks=2, shuffle=False
+    )
+    assert _check_values(ds, srcs) == 40
+    ds.close()
+
+
+def test_uneven_chunking_shuffled(tmp_path) -> None:
+    url = f"file://{tmp_path}/c.zarr"
+    srcs = _write_two(url, n=48, spc_a=2, spc_b=12)
+    geoms = open_geometries(obstore_store(url))
+    manifest = split_by_chunk(geoms["raw"], fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(
+        obstore_store(url), manifest, geometries=geoms, batch_size=5, block_chunks=3, shuffle=True
+    )
+    # shuffle still pairs each anchor's raw+labels correctly and covers every sample once.
+    anchors: list[int] = []
+    for b in ds.all if False else ds.train:
+        for i, anchor in enumerate(b.sample_indices):
+            for name, src in srcs.items():
+                np.testing.assert_array_equal(b.arrays[name][i], src[anchor])
+            anchors.append(int(anchor))
+    assert sorted(anchors) == list(range(48))
+    ds.close()

--- a/tests/test_uneven_chunking.py
+++ b/tests/test_uneven_chunking.py
@@ -10,7 +10,9 @@ import numpy as np
 import zarr
 
 from insitubatch import ensure_local_dir, obstore_store, open_geometries, split_by_chunk
+from insitubatch.plan import _read_chunks
 from insitubatch.source import InSituDataset
+from insitubatch.types import ArrayGeometry
 
 
 def _write_two(url: str, n: int, spc_a: int, spc_b: int, inner=(3, 3)):
@@ -79,6 +81,62 @@ def test_windowed_target_on_coarser_variable(tmp_path) -> None:
             np.testing.assert_array_equal(b.arrays["y"][i], srcs["labels"][anchor + 1])
             seen += 1
     assert seen == 39  # shift(1) drops the last anchor (no sample at n)
+    ds.close()
+
+
+def test_read_chunks_partial_tail_and_empty_span_guard() -> None:
+    # A coarse variable spc=4 over N=10: chunks [0-3], [4-7], [8-9] -- the last runs out at 2.
+    g = ArrayGeometry(path="c", shape=(10, 2), chunks=(4, 2), dtype=np.dtype("f4"))
+    assert g.n_chunks == 3  # ceil(10 / 4) -- the tail is a partial chunk, not dropped
+    assert list(_read_chunks(g, anchor_chunk=8, ref_spc=1)) == [2]  # sample 8 -> partial chunk 2
+    assert list(_read_chunks(g, anchor_chunk=9, ref_spc=1)) == [2]  # sample 9 -> partial chunk 2
+    assert list(_read_chunks(g.shift(1), anchor_chunk=8, ref_spc=1)) == [2]  # sample 9 -> chunk 2
+    # The empty-span guard (lo > hi -> range(0)): reachable only if an off-array anchor were
+    # NOT dropped upstream, which the pipeline always does -- so we call it directly. Anchor
+    # chunk 9 shifted +2 reads sample 11, off the end of the 10-sample axis.
+    assert list(_read_chunks(g.shift(2), anchor_chunk=9, ref_spc=1)) == []
+
+
+def test_uneven_tail_partial_coarse_chunk_with_shift(tmp_path) -> None:
+    # N=10 is not divisible by the coarse chunk (spc=8): the last labels chunk holds only
+    # samples [8, 9]. The shifted target reads into that partial tail chunk; verify values.
+    url = f"file://{tmp_path}/tail.zarr"
+    srcs = _write_two(url, n=10, spc_a=1, spc_b=8)
+    opened = open_geometries(obstore_store(url))
+    geoms = {"x": opened["raw"], "y": opened["labels"].shift(1)}
+    manifest = split_by_chunk(opened["raw"], fractions=(1.0, 0.0, 0.0))  # ref grid spc=1
+    ds = InSituDataset(
+        obstore_store(url), manifest, geometries=geoms, batch_size=4, block_chunks=3, shuffle=False
+    )
+    seen = 0
+    for b in ds.all:
+        for i, anchor in enumerate(b.sample_indices):
+            np.testing.assert_array_equal(b.arrays["x"][i], srcs["raw"][anchor])
+            np.testing.assert_array_equal(b.arrays["y"][i], srcs["labels"][anchor + 1])
+            seen += 1
+    assert seen == 9  # anchor 9 dropped by shift(1); anchor 8 reads labels[9] from the tail chunk
+    ds.close()
+
+
+def test_uneven_tail_coarse_reference_partial_anchor_chunk(tmp_path) -> None:
+    # The *reference* grid is coarse and uneven: labels spc=4 over N=10 gives 3 anchor chunks,
+    # the last (anchors 8, 9) partial. Verify those tail anchors are still drawn and every
+    # variable -- including the fine raw -- fetches them correctly (the larger chunk runs out).
+    url = f"file://{tmp_path}/tailref.zarr"
+    srcs = _write_two(url, n=10, spc_a=1, spc_b=4)
+    opened = open_geometries(obstore_store(url))
+    manifest = split_by_chunk(opened["labels"], fractions=(1.0, 0.0, 0.0))  # ref grid spc=4
+    assert manifest.n_chunks == 3  # last anchor chunk is partial
+    ds = InSituDataset(
+        obstore_store(url), manifest, geometries=opened, batch_size=3, block_chunks=2, shuffle=False
+    )
+    anchors: list[int] = []
+    for b in ds.all:
+        for i, anchor in enumerate(b.sample_indices):
+            for name, src in srcs.items():
+                np.testing.assert_array_equal(b.arrays[name][i], src[anchor])
+            anchors.append(int(anchor))
+    assert sorted(anchors) == list(range(10))  # the partial tail anchor chunk yields 8 and 9
     ds.close()
 
 


### PR DESCRIPTION
Variables may now chunk the sample axis differently while sharing its length
(the OME-NGFF pairing: raw image Z-chunk 1 + label mask Z-chunk 30). The
manifest's sample-chunk size defines the reference anchor grid; each variable
maps global anchors onto its own chunk grid in the planner (build_stored_chunk_reads
/_read_chunks take ref_spc), pool.gather (per-variable spc for read_cid/within),
and source._block_read_keys. The shared-chunk-size guard is dropped; only the
sample-axis length must match (samples are paired row-for-row), and the manifest
length is validated against the variables.

Residency budget generalized for non-uniform chunking: the uniform path is
byte-identical to before; the non-uniform path sizes per variable to the chunks a
2-block read-ahead window touches (and holds the train split resident under shuffle,
like the windowed spill case). A tighter bound is future work.

Validated end-to-end against the real IDR OME-NGFF store: raw + label mask streamed
together over Z (spc 1 vs 30, different inner chunking) with byte-exact reads.

Docs: docs/architecture.md gains a use-case support table (supported now / reserved
additive / out of scope) across microscopy, astronomy, and earth science.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
