### PR TITLE
feat(api): expose InSituDataset + framework adapters at the package root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.1.0 — 2026-07-06
+
+**The sample-geometry generalization + a stable public API.** insitubatch is no longer
+weather-only: the sample axis is now a *role*, not a fixed dimension, validated cross-domain
+against a real bio-imaging store — and the headline classes are exposed at the package root
+so the surface is exactly `insitubatch.__all__`.
+
+- **Arbitrary sample axis** — `open_geometries(store, sample_axis=k)` lets *any single*
+  physical axis be the sample axis (e.g. sample over `Z` of an OME-NGFF `(T,C,Z,Y,X)` stack),
+  by keeping `shape`/`chunks` in physical order and confining one physical↔logical permutation
+  to the scheduler. The common (axis-0) path is unchanged.
+- **Per-variable sample-axis chunk size** — co-registered variables may chunk the sample axis
+  *differently* (the OME-NGFF raw image Z-chunk 1 + label mask Z-chunk 30 pairing) as long as
+  they share its *length*. The manifest defines a reference anchor grid; each variable maps
+  global anchors onto its own chunk grid. Composes with windowing and arbitrary axes; covered
+  including the uneven-tail case where a coarse chunk runs out at the end of the axis.
+- **Cross-domain example** — `examples/microscopy/`: OME-NGFF cell segmentation streamed from
+  the public IDR store, raw + mask co-batched over `Z` with no reshard, a tiny CNN beating an
+  Otsu-threshold baseline. Proves the geometry generalizes beyond weather.
+- **Public API surface** — `InSituDataset` and the framework adapters (`to_torch`, `to_jax`,
+  `to_tf`, `as_torch`, `as_tf_dataset`) are now re-exported from the top-level package (added
+  to `__all__`); import them from `insitubatch`, not submodules. Re-exports are identity and
+  the adapters still import their framework lazily, so importing `insitubatch` pulls in none.
+- **Advection GPU benchmark** — a stall/ceiling sweep (`bench/advection_sweep.py`) and results:
+  the loader holds 94–98% of the in-memory compute ceiling on the advection forecast, i.e. it
+  keeps a GPU fed; two-regime framing and figures on the benchmarks page.
+- **Docs** — the sample-geometry *axis-role contract* (architecture) and *how the ladder
+  evolved* (DESIGN); cross-domain use-case tables; a radio-astronomy (xradio MSv4) mapping for
+  astrophysics readers.
+
 ## 0.0.3 — 2026-06-29
 
 First **Alpha** release. Headline: the V2 decoupled fetch scheduler + the `ChunkPool`

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Jax and TensorFlow. It turns an existing Zarr archive into a shuffled,
 split-aware data source built to **keep the GPU fed** — **with no reshard**
 — and a Python hot path that scales with **chunks, not samples**.
 
+It is **domain-general**: the sample axis is a *role*, not a fixed dimension. The same engine
+trains on ERA5/weather over time, segments **OME-NGFF microscopy** volumes over `Z`
+([runnable example](examples/microscopy/) — raw image + label mask co-batched with no reshard),
+and maps cleanly onto **radio-astronomy** visibilities — one contract, *any* single sample axis,
+variables that chunk it differently.
+
 > The IO race is over (obstore/icechunk saturate the NIC). The *loader* race is
 > open. `insitubatch` builds the layer that projects like light-speed-io and
 > hypergrib stopped one step short of. See [DESIGN.md](DESIGN.md).
@@ -149,11 +155,11 @@ The core `InSituDataset` is a **framework-neutral source of numpy `Batch` object
 inherits nothing framework-specific. You iterate its split *views* (`ds.train` shuffled,
 `ds.val` / `ds.test` / `ds.all` deterministic), which all share **one** pool, so a chunk
 two splits both read decodes once. Handoff to torch / JAX / TF is a thin, optional DLPack
-adapter layer in `insitubatch.frameworks`; the core imports no framework.
+adapter (re-exported from the package root; defined in `insitubatch.frameworks`) — the core
+imports no framework, and importing `insitubatch` pulls none in.
 
 ```python
-from insitubatch import obstore_store, open_geometries, split_by_chunk
-from insitubatch.source import InSituDataset
+from insitubatch import InSituDataset, obstore_store, open_geometries, split_by_chunk
 
 # The engine reads a zarr Store; build one per backend. obstore_store covers
 # file://, s3://, gs://, az://. (fsspec_store reaches GCS Rapid/requester-pays;
@@ -180,7 +186,7 @@ differ — torch needs a `Dataset` subclass, JAX iterates directly, TF wraps via
 `from_generator`:
 
 ```python
-from insitubatch.frameworks import as_torch, to_jax, as_tf_dataset
+from insitubatch import as_tf_dataset, as_torch, to_jax
 from torch.utils.data import DataLoader
 
 # torch: parallelism is in our event loop, so num_workers=0, batch_size=None

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,8 +1,10 @@
 # API reference
 
-The public surface is everything re-exported from the top-level `insitubatch`
-package (its `__all__`), plus the framework-neutral `InSituDataset` source from
-`insitubatch.source` and the optional DLPack adapters in `insitubatch.frameworks`.
+The public surface is the top-level `insitubatch` package — **everything in its
+`__all__`**. `InSituDataset` and the framework adapters are re-exported there, so
+import them from the package root (`from insitubatch import InSituDataset, to_torch`),
+not from submodules. The adapters are optional: they import torch / JAX / TF **lazily**,
+only when called, so importing `insitubatch` never pulls a framework in.
 
 ## `insitubatch`
 
@@ -10,11 +12,11 @@ package (its `__all__`), plus the framework-neutral `InSituDataset` source from
     options:
       show_root_heading: false
 
-## `insitubatch.source`
+## `InSituDataset`
 
-::: insitubatch.source.InSituDataset
+::: insitubatch.InSituDataset
 
-## `insitubatch.frameworks`
+## Framework adapters
 
 ::: insitubatch.frameworks
     options:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -189,6 +189,7 @@ reserved (additive) extension, and what is deliberately out of scope.
 | Train over a time/sample axis | ERA5/HRRR reanalysis; astronomy light curves | `sample_axis=0` (default) |
 | Sample over *any* single axis | OME-NGFF 2D segmentation over `Z`; `T`-frame or volumetric stacks | `open_geometries(store, sample_axis=2)` |
 | Paired inputs+targets with *different* sample-axis chunking | microscopy raw image + label mask (Z-chunk 1 vs 30) | two variables, one manifest |
+| Multiple co-registered variables at one anchor (data + mask + weight) | radio astronomy MSv4 visibilities: `VISIBILITY` + `FLAG` + `WEIGHT`, sampled over `time` | variables share one manifest |
 | Forecasting input/target windows | weather: input@`t`, target@`t+h` | `g.shift(h)` views (decode-once) |
 | Whole inner field per sample, spatial grid fetched decode-once | ARCO/ERA5 `721×1440` fields; microscopy planes | inner (field) chunking |
 | Cross-variable derived fields & per-sample random augmentation | `windspeed=√(u²+v²)`; random crop of the whole field | `batch_transform` |
@@ -211,6 +212,19 @@ reserved (additive) extension, and what is deliberately out of scope.
 | General compute graph / cross-chunk reductions | lazy dask-style evaluation | dask is off the hot path by design; reductions run *over* the loader |
 | Resharding into a sample-per-file format | MDS/tar/WebDataset ETL | we train **in place**, no reshard |
 | Scattered / boolean sample selection for splits | arbitrary index masks | splits are chunk-contiguous (leakage-safe) |
+
+**Mapping a new domain onto the contract — worked example: radio astronomy (MSv4).** The
+[xradio](https://github.com/casangi/xradio) MeasurementSet-v4 visibility dataset stores
+`VISIBILITY` `(time, baseline_id, frequency, polarization)` (complex) alongside `FLAG`
+(same shape, boolean) and `WEIGHT`. This is the same shape as the shipped microscopy case:
+pick the **sample axis** (`time` for per-integration samples, or `frequency`/`baseline_id`),
+carry the rest as the inner field, and gather `VISIBILITY` + `FLAG` + `WEIGHT` at one anchor
+from **one manifest** — no reshard. The natural task, **RFI-flag detection** (predict `FLAG`
+from `|VISIBILITY|`), is the segmentation pattern with an amplitude-threshold baseline in
+place of Otsu. Complex data needs no special support: take `np.abs()` in a `batch_transform`
+(or at the model boundary), so the numpy `Batch` and the DLPack adapters only ever see real
+arrays. This is a schema-level mapping, not yet a shipped example — but every capability it
+needs is validated today.
 
 ## Prefetch
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,8 @@
 # Architecture: loaders, parallelism, and prefetch
 
 This doc contrasts the classic worker-based data loader with insitubatch's
-async-driven engine, then specifies the prefetch pipeline and the Earth2Studio
-integration surfaces. For the why behind the project see
+async-driven engine, then specifies the prefetch pipeline, the sample-geometry contract, and
+how downstream frameworks integrate. For the why behind the project see
 [DESIGN.md](https://github.com/emfdavid/insitubatch/blob/main/DESIGN.md).
 
 ## The inversion in one line
@@ -704,81 +704,27 @@ experimentation) and the kvikio/GDS NVMe→GPU feed off the persistent `.npy` ti
 on the roadmap
 ([DESIGN.md](https://github.com/emfdavid/insitubatch/blob/main/DESIGN.md)).
 
-## Earth2Studio integration
+## Downstream integration — tensors, not xarray
 
-A raw `zarr.storage.ObjectStore(obstore ...)` swap in their ARCO source delivers
-*faster bytes* — that's an **obstore** win, not an insitubatch one. insitubatch
-earns its place by adding what obstore alone does not:
+insitubatch delivers **tensor batches** and never builds `xr.DataArray`. That decides how it
+plugs into an xarray-native inference framework such as
+[Earth2Studio](https://github.com/NVIDIA/earth2studio): **around the models, not inside their
+xarray loop.** A raw `ObjectStore(obstore)` store-swap in such a framework's ARCO source buys
+*faster bytes* — but that is an **obstore** win, not ours. insitubatch earns its place for
+batched training / fine-tuning / hindcast scoring: read the ARCO/zarr store → DLPack →
+`(torch.Tensor, coords)` and drive the model directly (the `coords` we supply is a light
+`OrderedDict` of coordinate arrays — metadata, not the xarray machinery), instead of routing
+every `(time, variable)` through the framework's per-request xarray `DataSource`. What that
+adds over the store-swap is the **loader**:
 
-1. **Bounded fan-out** — their `gather(*tasks)` is *unbounded*; a hindcast /
-   scoring request over thousands of timesteps spawns thousands of concurrent
-   getitems. `max_inflight` sustains throughput at bounded memory.
-2. **Read-plan dedup across a request** — ensembles (many members), multiple lead
-   times, and overlapping verification windows touch the same chunks repeatedly;
-   their per-`(time, var)` task model re-reads them, our plan collapses to one
-   read each.
-3. **Prefetch overlap** — for sequential inference (rolling through init times;
-   autoregressive rollout pulling forcings each step), prefetch the next step's
-   inputs *during* the current step's compute. This hides the IO time observed in
-   real ensemble runs (e.g. StormCast).
-4. **For training on big hindcasts (the real target)** — the whole loader: split,
-   shuffle, prefetch, bounded memory.
+- **Bounded fan-out** — one `max_inflight` budget vs an unbounded `gather` over thousands of
+  timesteps; sustained throughput at bounded memory.
+- **Read-plan dedup across a request** — ensembles, lead times, and overlapping verification
+  windows touch the same chunks repeatedly; the plan collapses them to one read each.
+- **Prefetch overlap** for sequential/autoregressive rollout, and split + shuffle for training.
 
-### Where tensors are born (grounded in `run.py` / `data/utils.py`)
-
-```
-DataSource.__call__ ──► xr.DataArray         # ARCO: zarr-async + fsspec/gcsfs
-        ▼
-fetch_data(source, time, variable, lead_time, device)
-        ▼
-prep_data_array(da, device) ──► (torch.Tensor, coords)
-        ▼
-prognostic.create_iterator(x, coords) ──► rollout yields (torch.Tensor, coords)
-```
-
-xarray is **load-bearing all the way down to `prep_data_array`** — it carries
-their lexicon/vocabulary, lat/lon coords, and optional regridding (`interp_to`).
-The torch tensor only materializes at the end. So inside their inference loop
-there is **no public "give me a torch batch from cloud" hook**; the only clean
-public seam is the `xr.DataArray` DataSource.
-
-### Two integration philosophies — only one is ours
-
-- **Inside their inference loop → obstore store-swap (NOT insitubatch).** Keep
-  their xarray DataSource; swap `FsspecStore(gcsfs/MSC)` → `ObjectStore(obstore)`
-  for faster bytes. Having insitubatch *build* `xr.DataArray` would add a
-  conversion and force us to reimplement their lexicon/coords/regrid machinery.
-  That is an **obstore** contribution, not an insitubatch one.
-
-- **Around their models → insitubatch delivers tensor batches (the real play).**
-  For training, fine-tuning, and big batched hindcast/scoring, skip
-  `DataSource`/`fetch_data`/xarray entirely: insitubatch reads ARCO / your zarr →
-  DLPack → `(torch.Tensor, coords)` and feeds `prognostic.create_iterator(x,
-  coords)` directly. The `coords` we supply is a light `OrderedDict` of
-  coordinate arrays (variable names, lat/lon, lead/time) — metadata, not the
-  xarray machinery. This is "closer to the GPU," many-samples-through-the-GPU, and
-  exactly what our infra does.
-
-> insitubatch never builds xarray. Stay-in-their-loop = obstore store-swap;
-> batched workloads = insitubatch drives their *model* with tensor batches.
-
-(Tell: `fetch_data(legacy=False)` already returns a **cupy-backed** `xr.DataArray`
-for CUDA — NVIDIA themselves reaching for GPU-resident arrays. A fully
-tensor-native fast path in E2S is conceivable later, but it is a larger change to
-their framework, and out of scope today.)
-
-### Positioning vs NVIDIA MSC and GDS
-
-- **MSC (Multi-Storage Client)** is an `fsspec` client (integrates with
-  Zarr/Xarray via `msc://`). Its value is multi-backend access + caching (incl.
-  local NVMe) + observability — not a faster cold-read primitive. Because it
-  routes through fsspec, obstore can still beat it on **cold raw-read
-  throughput**. MSC shines with big infra + a warm NVMe cache; insitubatch's
-  niche is **cold-cache / streaming / commodity-infra / bounded-memory**.
-- **GDS (GPUDirect Storage / cuFile)** is a separate path — direct DMA from
-  NVMe/NVMe-oF into GPU memory. No evidence MSC uses GDS. GDS is where our
-  **Phase 2 kvikio path** lives — a GPU-direct route MSC doesn't natively
-  provide. (From docs, not MSC source — confirm before using in a public claim.)
+A reference integration — an Earth2Studio `DataSource` backed by `InSituDataset` — is in
+[emfdavid/earth2studio#1](https://github.com/emfdavid/earth2studio/pull/1).
 
 ## What this does NOT do (scope boundaries)
 
@@ -812,13 +758,13 @@ pretending to be a general compute graph.
 - **Shuffle is approximate**, not global — chunk permutation + shuffle-block
   (`block_chunks` is the quality↔memory knob). Exact global shuffle is
   incompatible with chunk-aligned, low-copy reads.
-- **Variables must share the sample-axis length and chunk size** — an enforced
-  invariant; `InSituDataset` raises `ValueError` otherwise. The draw order and gather
-  use one chunk size for all variables, so pairing e.g. an OME-NGFF raw array
-  (Z-chunk 1) with its label mask (Z-chunk 30) is **not yet supported**; lifting the
-  shared-chunk-size half to per-variable chunkings is the next increment. (Which
-  *physical* axis is the sample axis is now free per the axis-role contract; only the
-  chunk *size* along it must currently match.)
+- **Variables must share the sample-axis *length*** — an enforced invariant;
+  `InSituDataset` raises `ValueError` otherwise (samples are paired row-for-row across
+  variables). They **may** chunk that axis *differently*: the manifest defines a reference
+  anchor grid and each variable maps global anchors onto its own chunk grid, so an OME-NGFF
+  raw array (Z-chunk 1) pairs with its label mask (Z-chunk 30) with no reshard. Which
+  *physical* axis is the sample axis is also free (the axis-role contract) — only the
+  *length* along it must match.
 
 Rule of thumb: **per-variable, per-chunk, deterministic → chunk stage (cacheable).
 Cross-variable or per-sample-random → batch stage (not cached). Cross-chunk →

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -516,8 +516,7 @@ used only for this off-hot-path planning step; the engine itself never touches x
 
 ```python
 import xarray as xr
-from insitubatch import obstore_store, open_geometries, split_by_chunk
-from insitubatch.source import InSituDataset
+from insitubatch import InSituDataset, obstore_store, open_geometries, split_by_chunk
 
 store = obstore_store(url)                 # one Store, reused for planning + the engine
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,12 @@ and TensorFlow. It turns an existing Zarr archive into a shuffled, split-aware
 data source built to **keep the GPU fed** — **with no reshard** — and a Python
 hot path that scales with **chunks, not samples**.
 
+It is **domain-general**: the sample axis is a *role*, not a fixed dimension. The same engine
+trains on ERA5/weather over time, segments **OME-NGFF microscopy** volumes over `Z`
+([runnable example](https://github.com/emfdavid/insitubatch/blob/main/examples/microscopy) —
+raw image + label mask co-batched with no reshard), and maps cleanly onto **radio-astronomy**
+visibilities. See the [use-case tables](architecture.md#use-case-support).
+
 !!! quote
     The IO race is over (obstore/icechunk saturate the NIC). The *loader* race is
     open. `insitubatch` builds the layer that projects like light-speed-io and
@@ -48,9 +54,15 @@ The core `InSituDataset` is a framework-neutral iterable of numpy `Batch` object
 torch / JAX / TF handoff is a thin optional DLPack adapter in `insitubatch.frameworks`.
 
 ```python
-from insitubatch import obstore_store, open_geometries, split_by_chunk
-from insitubatch.source import InSituDataset
-from insitubatch.frameworks import as_torch, to_jax, as_tf_dataset
+from insitubatch import (
+    InSituDataset,
+    as_tf_dataset,
+    as_torch,
+    obstore_store,
+    open_geometries,
+    split_by_chunk,
+    to_jax,
+)
 from torch.utils.data import DataLoader
 
 # The engine reads a zarr Store; obstore_store builds one for file://, s3://, gs://.

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,8 +50,9 @@ diagrams, and the read-plan abstraction;
 
 ## Shape of the API
 
-The core `InSituDataset` is a framework-neutral iterable of numpy `Batch` objects;
-torch / JAX / TF handoff is a thin optional DLPack adapter in `insitubatch.frameworks`.
+The core `InSituDataset` is a framework-neutral iterable of numpy `Batch` objects; torch /
+JAX / TF handoff is a thin optional DLPack adapter, re-exported from the package root (defined
+in `insitubatch.frameworks`) — importing `insitubatch` pulls in no framework.
 
 ```python
 from insitubatch import (

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -8,10 +8,11 @@ the engine behaves this way — the read plan, the pool, the prefetch pipeline �
 
 Hold these two sentences and the rest follows:
 
-- A **sample** is one slice of the outer (sample) axis — a timestep, an observation, a
-  model state, whatever your rows are — spanning the whole inner extent of its chunk.
-- A **batch** draws `batch_size` shuffled samples from a **window** of `block_chunks` outer
-  chunks that the loader keeps decoded in memory at once.
+- A **sample** is one slice of the **sample axis** — a timestep, an observation, a model
+  state, a microscopy `Z`-plane, whatever your rows are (it can be *any* single physical axis,
+  not just axis 0) — spanning the whole inner extent of its chunk.
+- A **batch** draws `batch_size` shuffled samples from a **window** of `block_chunks`
+  sample-axis chunks that the loader keeps decoded in memory at once.
 
 So the loader reads each chunk once, holds a rolling window of them, and serves shuffled
 batches out of that window — concurrency fills the window, the window bounds memory.

--- a/examples/advection/data.py
+++ b/examples/advection/data.py
@@ -29,14 +29,14 @@ import zarr
 from zarr.abc.store import Store
 
 from insitubatch import (
+    Batch,
+    InSituDataset,
     arraylake_store,
     ensure_local_dir,
     obstore_store,
     open_geometries,
     split_by_chunk,
 )
-from insitubatch.source import InSituDataset
-from insitubatch.types import Batch
 
 # The public WeatherBench2 ERA5 (6-hourly) ARCO store the wb2_* examples use.
 WB2_URL = (

--- a/examples/advection/train_jax.py
+++ b/examples/advection/train_jax.py
@@ -16,9 +16,7 @@ import jax.numpy as jnp
 import numpy as np
 import optax
 
-from insitubatch.frameworks import to_jax
-from insitubatch.source import InSituDataset
-from insitubatch.types import Batch
+from insitubatch import Batch, InSituDataset, to_jax
 
 from .data import build_datasets, cli, evaluate
 

--- a/examples/advection/train_tf.py
+++ b/examples/advection/train_tf.py
@@ -12,9 +12,7 @@ import numpy as np
 import tensorflow as tf
 from tensorflow import keras
 
-from insitubatch.frameworks import to_tf
-from insitubatch.source import InSituDataset
-from insitubatch.types import Batch
+from insitubatch import Batch, InSituDataset, to_tf
 
 from .data import build_datasets, cli, evaluate
 

--- a/examples/advection/train_torch.py
+++ b/examples/advection/train_torch.py
@@ -17,9 +17,7 @@ from __future__ import annotations
 import torch
 from torch import nn
 
-from insitubatch.frameworks import to_torch
-from insitubatch.source import InSituDataset
-from insitubatch.types import Batch
+from insitubatch import Batch, InSituDataset, to_torch
 
 from .data import build_datasets, cli, evaluate
 

--- a/examples/advection/train_torch_metrics.py
+++ b/examples/advection/train_torch_metrics.py
@@ -21,9 +21,7 @@ from collections.abc import Callable, Iterable
 import torch
 from torch import nn
 
-from insitubatch.frameworks import to_torch
-from insitubatch.source import InSituDataset
-from insitubatch.types import Batch
+from insitubatch import Batch, InSituDataset, to_torch
 
 from .._forecast_metrics import MetricsLog, StallTimer, preload_epoch
 from .data import build_datasets, build_parser, evaluate

--- a/examples/microscopy/data.py
+++ b/examples/microscopy/data.py
@@ -31,13 +31,13 @@ import zarr
 from zarr.abc.store import Store
 
 from insitubatch import (
+    Batch,
+    InSituDataset,
     ensure_local_dir,
     obstore_store,
     open_geometries,
     split_by_chunk,
 )
-from insitubatch.source import InSituDataset
-from insitubatch.types import Batch
 
 # A public OME-NGFF (zarr v0.1) image in the EMBL-EBI Image Data Repository: a 3D two-channel
 # confocal stack with an expert instance-segmentation label. Read anonymously off the IDR S3.

--- a/examples/microscopy/train_torch.py
+++ b/examples/microscopy/train_torch.py
@@ -16,9 +16,7 @@ from __future__ import annotations
 import torch
 from torch import nn
 
-from insitubatch.frameworks import to_torch
-from insitubatch.source import InSituDataset
-from insitubatch.types import Batch
+from insitubatch import Batch, InSituDataset, to_torch
 
 from .data import build_datasets, cli, evaluate, inputs_and_targets
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "insitubatch"
-version = "0.0.3"
+version = "0.1.0"
 description = "Train in place on n-dimensional cloud tensors: the data-loader orchestration layer on top of solved async IO (obstore / zarr v3 / icechunk)."
 readme = "README.md"
 license = "MIT"

--- a/src/insitubatch/__init__.py
+++ b/src/insitubatch/__init__.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 
+from .frameworks import as_tf_dataset, as_torch, to_jax, to_tf, to_torch
 from .plan import build_stored_chunk_reads
 from .pool import ChunkPool
 from .scheduler import Scheduler, SchedulerConfig
@@ -21,6 +22,7 @@ from .shuffle import (
     sequential_order,
     shuffle_quality,
 )
+from .source import InSituDataset
 from .split import SplitManifest, split_by_chunk, valid_anchor_range
 from .store import (
     arraylake_store,
@@ -53,6 +55,7 @@ __all__ = [
     "ChunkRead",
     "ChunkTransform",
     "DecodedChunk",
+    "InSituDataset",
     "Scheduler",
     "SchedulerConfig",
     "SplitManifest",
@@ -60,6 +63,8 @@ __all__ = [
     "StandardScaler",
     "StoredChunkRead",
     "arraylake_store",
+    "as_tf_dataset",
+    "as_torch",
     "close_store",
     "block_shuffled_order",
     "build_stored_chunk_reads",
@@ -71,5 +76,8 @@ __all__ = [
     "sequential_order",
     "shuffle_quality",
     "split_by_chunk",
+    "to_jax",
+    "to_tf",
+    "to_torch",
     "valid_anchor_range",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1250,7 +1250,7 @@ wheels = [
 
 [[package]]
 name = "insitubatch"
-version = "0.0.3"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
The two headline user-facing APIs were reachable only through submodules
(`insitubatch.source.InSituDataset`, `insitubatch.frameworks.to_torch`), so any
integration — including the Earth2Studio data source — reached into internals.
Re-export them from the package root and add to `__all__`:

- InSituDataset, to_torch, to_jax, to_tf, as_torch, as_tf_dataset.

Re-exports are identity (same objects), and frameworks still imports torch/JAX/TF
lazily, so importing `insitubatch` pulls in no framework — verified. This makes the
public surface exactly `insitubatch.__all__`; api.md drops the "plus private
submodules" language. Both example packages now model the public import path.

Also (v0.1.0 docs): add a radio-astronomy (xradio MSv4) row + worked mapping to the
use-case tables — VISIBILITY+FLAG+WEIGHT sampled over time is the shipped microscopy
pattern; RFI-flag detection with an amplitude-threshold baseline; complex handled by
np.abs() at the boundary. Schema-level mapping (no shipped example), honestly flagged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
