### PR TITLE
Dogfood zarr-indexing v0.1.0: parity oracle, thesis guard, patching note

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -565,15 +565,49 @@ capabilities already under design there. This section records **the design depen
 what we would build versus what we would inherit. It deliberately does *not* track issue
 status, reviewers, or dates; that state lives outside this repo and goes stale here.
 
-- **Lazy indexing / `IndexTransform`** (zarr-python
-  [#3906](https://github.com/zarr-developers/zarr-python/pull/3906)) — a composable,
-  serializable description of "which elements of an array do I want", resolved lazily
-  rather than materialized. That is the same object our planner builds by hand, so a
-  shared upstream primitive is the natural foundation for `plan.py`: we would dogfood
-  their resolver against our planner and contribute the serialization-performance and
-  multi-window requirements. **What stays ours regardless:** the *batched* union of many
-  per-anchor windows into one deduplicated read set, in draw/priority order — that is
-  loader orchestration, not indexing, and it is the thing this project exists to do.
+- **Lazy indexing / `IndexTransform`** (the `zarr-indexing` package, zarr-python
+  [#4196](https://github.com/zarr-developers/zarr-python/pull/4196), split out of the
+  [#3906](https://github.com/zarr-developers/zarr-python/pull/3906) work) — a standalone,
+  NumPy-only implementation of TensorStore-style index transforms plus chunk resolution
+  against a `DimensionGridLike` protocol. We have **dogfooded it as a correctness oracle**:
+  with `ArrayGeometry` supplying a `DimensionGridLike` per axis, `iter_chunk_transforms`
+  resolves the *exact* stored-chunk set `plan.py` produces, across offset windows,
+  coarser/finer variable grids, short final chunks, inner grids, and a non-zero sample axis
+  (`tests/test_zarr_indexing_parity.py`). But an oracle is not an engine, and the honest
+  scope of the fit is small: our overlapping logic is `range(lo//spc, hi//spc+1)` — trivial
+  integer arithmetic, not complexity worth outsourcing — and consuming `iter_chunk_transforms`
+  on the hot path would *add* surface (a `DimensionGridLike` adapter, a per-selection
+  transform allocation) while forcing us to discard its `out_indices` scatter map, which is
+  the exact thing our scatter-into-slots design removes. So today it changes nothing.
+
+  **There is no adoption trigger from sample indexing — the fancy path is the anti-pattern,
+  not a future engine.** It is tempting to read the package's `ArrayMap` `oindex`/`vindex`
+  resolver as the thing we would inherit once sample geometry generalizes to *scattered*
+  (arbitrary, cross-chunk) sample indices. It is not, and the reason is the whole thesis:
+  `iter_chunk_transforms` resolves *which chunks a selection touches and how it scatters*, but
+  does nothing about **read amplification**. "One sample from every chunk" destroys TTFB
+  because you fetch and decode every touched chunk to use one row — an IO-locality property
+  the index math sits upstream of. Making the coordinate math free buys nothing on the axis
+  that hurts; the coordinate math was never our bottleneck. That access pattern is precisely
+  the reshard/random-access mode we traded away for the block-shuffle approximation
+  (`tests/test_zarr_indexing_parity.py::test_scattered_sample_read_amplification` quantifies
+  it: 5 wanted samples force reading all 12 in the touched chunks). Every legitimate sampling
+  feature we do want — block shuffle, weighted/stratified draws — resolves to *a set of whole
+  chunks* (our union-of-windows planner already owns this) followed by *in-memory numpy row
+  selection of already-decoded data* (no chunk resolution needed). The fancy per-sample
+  machinery has no home here.
+
+  The only `zarr-indexing` pieces that could ever touch us are the *cheap* ones, and they
+  stay conveniences, not engines: **irregular/varying chunk grids** (`index_to_chunk` becomes
+  a `searchsorted` rather than a `//`, and the `DimensionGridLike` abstraction saves us
+  writing/testing it) and **inner-axis patch/box crops** (the deferred sliding-window
+  feature — but that is `box`/`slice` resolution, the trivial-arithmetic part again, and the
+  hard part of patching is the draw space, not the index resolution). Both are the box/grid
+  surface, never the fancy `ArrayMap` path.
+
+  **What stays ours regardless:** the *batched* union of many per-anchor windows into one
+  deduplicated read set, in draw/priority order — that is loader orchestration, not indexing,
+  and it is the thing this project exists to do.
 - **Batched zero-copy `out=` decode** (zarr-python
   [#3060](https://github.com/zarr-developers/zarr-python/issues/3060), under the
   codec-pipeline umbrella [#2904](https://github.com/zarr-developers/zarr-python/issues/2904))

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -582,11 +582,13 @@ capabilities already under design there. This section records **the design depen
 what we would build versus what we would inherit. It deliberately does *not* track issue
 status, reviewers, or dates; that state lives outside this repo and goes stale here.
 
-- **Lazy indexing / `IndexTransform`** (the `zarr-indexing` package, zarr-python
-  [#4196](https://github.com/zarr-developers/zarr-python/pull/4196), split out of the
-  [#3906](https://github.com/zarr-developers/zarr-python/pull/3906) work) — a standalone,
-  NumPy-only implementation of TensorStore-style index transforms plus chunk resolution
-  against a `DimensionGridLike` protocol. We have **dogfooded it as a correctness oracle**:
+- **Lazy indexing / `IndexTransform`** (the
+  [`zarr-indexing`](https://github.com/zarr-developers/zarr-python/releases/tag/zarr_indexing-v0.1.0)
+  package, zarr-python [#4196](https://github.com/zarr-developers/zarr-python/pull/4196),
+  split out of the [#3906](https://github.com/zarr-developers/zarr-python/pull/3906) work) —
+  a standalone, NumPy-only implementation of TensorStore-style index transforms plus chunk
+  resolution against a `DimensionGridLike` protocol. We **dogfood it as a correctness oracle**
+  (a test-only dependency; nothing under `src/` imports it):
   with `ArrayGeometry` supplying a `DimensionGridLike` per axis, `iter_chunk_transforms`
   resolves the *exact* stored-chunk set `plan.py` produces, across offset windows,
   coarser/finer variable grids, short final chunks, inner grids, and a non-zero sample axis

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -212,6 +212,23 @@ on the synthetic store, and running the *same code* against WeatherBench2 ARCO E
   ERA5/radio field needs the pool to hold only a crop's tiles. That is a residency change,
   not a `Batch`-contract change — which is what keeps it an *additive* future.
 
+  Mechanics (worked through, so the shape is known when a real issue arrives). The omission
+  is **chunk-granular**: tiles fully outside the crop are never fetched or decoded; a tile
+  straddling the crop edge is decoded *whole* then clipped (zarr's IO/decode unit is the
+  chunk). `tile_placement` generalizes from full-field to a clamped box — `crop[dst] =
+  tile[src]` with `dst` crop-relative, `src` chunk-local, both the `chunk ∩ crop` rectangle;
+  the crop buffer stays dense/rectangular and partial zero-copy holds. **Deterministic /
+  strided origins are the honest win**: adjacent patches share inner tiles, so the batched
+  union + **decode-once dedup across patch footprints is exactly the planner primitive that
+  stays ours** — the sampler emits origins, the planner unions and dedups their tile sets.
+  **Random origins are the trap**: pushed into the read, scattered footprints degrade toward
+  the whole field again (the sample-axis read-amplification, now on the inner dims), so
+  random crop stays an in-memory `batch_transform` — over a *bounded* read window if we want
+  to cap IO — never unbounded random origins in the read. `zarr-indexing`'s box path can
+  resolve one patch's `(tiles, chunk_sel, out_sel)` (a modest placement convenience, not the
+  engine — see "Upstream capabilities"). **Gate: build this only when a concrete user issue
+  demands it** — a giant-field crop workload with real numbers, not a speculative rung.
+
 GRIB / NetCDF are consumed via a **virtual-zarr** view (virtualizarr / kerchunk /
 icechunk) so the engine only ever speaks zarr-async — we never parse GRIB.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,10 @@ dev = [
     "ruff>=0.6",
     "mypy>=1.11",
     "pre-commit>=3.7",
+    # Test-only: the parity oracle in tests/test_zarr_indexing_parity.py checks our
+    # read planner against zarr's standalone index-transform package. Pure Python
+    # (numpy only), never imported by src/ -- it is not a runtime dependency.
+    "zarr-indexing>=0.1",
 ]
 
 [build-system]

--- a/tests/test_zarr_indexing_parity.py
+++ b/tests/test_zarr_indexing_parity.py
@@ -1,7 +1,8 @@
 """Dogfood parity: our read planner vs zarr's new ``zarr-indexing`` package.
 
-`zarr-indexing` (zarr-developers/zarr-python#4196, the leaf split of the #3906
-IndexTransform work) is a standalone, NumPy-only package implementing
+`zarr-indexing` (released as ``zarr_indexing-v0.1.0`` from zarr-python#4196, the
+leaf split of the #3906 IndexTransform work) is a standalone, NumPy-only package
+implementing
 TensorStore-style index transforms + chunk resolution against a
 ``DimensionGridLike`` protocol. This test dogfoods it as a *correctness oracle*
 for :func:`insitubatch.plan.build_stored_chunk_reads`: it asserts that
@@ -31,9 +32,8 @@ the waste (5 samples wanted -> all 12 in the touched chunks read), so the bounda
 stays visible if anyone is later tempted to read the fancy resolver as a "future
 engine" for insitubatch. It is not one -- see DESIGN.md, "Upstream capabilities".
 
-The package is not a dependency; the test skips unless it is importable. To run it::
-
-    uv run --with path/to/packages/zarr-indexing pytest tests/test_zarr_indexing_parity.py
+``zarr-indexing`` is a *test-only* dependency (the ``dev`` group), never a runtime
+one: nothing under ``src/`` imports it. It runs in every CI job.
 """
 
 from __future__ import annotations
@@ -43,11 +43,10 @@ from dataclasses import dataclass
 import numpy as np
 import numpy.typing as npt
 import pytest
+import zarr_indexing as zi
 
-zi = pytest.importorskip("zarr_indexing")
-
-from insitubatch.plan import _read_chunks, build_stored_chunk_reads  # noqa: E402
-from insitubatch.types import ArrayGeometry  # noqa: E402
+from insitubatch.plan import _read_chunks, build_stored_chunk_reads
+from insitubatch.types import ArrayGeometry
 
 
 @dataclass(frozen=True)

--- a/tests/test_zarr_indexing_parity.py
+++ b/tests/test_zarr_indexing_parity.py
@@ -1,0 +1,211 @@
+"""Dogfood parity: our read planner vs zarr's new ``zarr-indexing`` package.
+
+`zarr-indexing` (zarr-developers/zarr-python#4196, the leaf split of the #3906
+IndexTransform work) is a standalone, NumPy-only package implementing
+TensorStore-style index transforms + chunk resolution against a
+``DimensionGridLike`` protocol. This test dogfoods it as a *correctness oracle*
+for :func:`insitubatch.plan.build_stored_chunk_reads`: it asserts that
+``zarr_indexing.iter_chunk_transforms`` resolves the exact same set of stored
+chunks our hand-rolled planner produces, once :class:`ArrayGeometry` supplies a
+``DimensionGridLike`` per (logical, sample-first) axis.
+
+It is deliberately *not* a hot-path swap. Our planner resolves the UNION of many
+disjoint sample windows in draw order, deduped across variables, into a
+scatter-into-slots plan with no gather map -- none of which ``iter_chunk_transforms``
+(single selection, mandatory ``out_indices`` scatter map) covers. What the parity
+proves is narrower and real: our per-selection chunk math is reproducible at the
+package's contract boundary, so ``ArrayGeometry`` is a valid ``DimensionGridLike``
+consumer.
+
+The parity tests answer "does it match what we do today?". The second test
+(:func:`test_scattered_sample_read_amplification`) is a *thesis guard*, not an
+adoption pitch: it demonstrates why we do **not** expose arbitrary per-sample
+random access. ``zarr_indexing`` can resolve a scattered, cross-chunk sample
+selection into a per-chunk scatter map -- but resolving the coordinates does
+nothing about **read amplification**: "one sample from every chunk" still fetches
+and decodes every touched chunk to use one row each, which is the reshard/
+random-access cost we traded away for the block-shuffle approximation. The index
+math was never the bottleneck; making it free changes nothing on the axis that
+hurts. The test drives such a gather through the package and puts a hard number on
+the waste (5 samples wanted -> all 12 in the touched chunks read), so the boundary
+stays visible if anyone is later tempted to read the fancy resolver as a "future
+engine" for insitubatch. It is not one -- see DESIGN.md, "Upstream capabilities".
+
+The package is not a dependency; the test skips unless it is importable. To run it::
+
+    uv run --with path/to/packages/zarr-indexing pytest tests/test_zarr_indexing_parity.py
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+
+zi = pytest.importorskip("zarr_indexing")
+
+from insitubatch.plan import _read_chunks, build_stored_chunk_reads  # noqa: E402
+from insitubatch.types import ArrayGeometry  # noqa: E402
+
+
+@dataclass(frozen=True)
+class AxisGrid:
+    """A regular chunk grid on one axis; satisfies ``zarr_indexing.DimensionGridLike``."""
+
+    size: int
+    chunk: int
+
+    def index_to_chunk(self, idx: int) -> int:
+        return idx // self.chunk
+
+    def chunk_offset(self, chunk_ix: int) -> int:
+        return chunk_ix * self.chunk
+
+    def chunk_size(self, chunk_ix: int) -> int:
+        return min(self.chunk, self.size - chunk_ix * self.chunk)
+
+    def indices_to_chunks(self, indices: npt.NDArray[np.intp]) -> npt.NDArray[np.intp]:
+        return indices // self.chunk
+
+
+def _logical_shape(geom: ArrayGeometry) -> tuple[int, ...]:
+    return (geom.n_samples, *geom.inner_shape)
+
+
+def _logical_grids(geom: ArrayGeometry) -> list[AxisGrid]:
+    """One ``AxisGrid`` per logical (sample-first) axis -- ``StoredChunkRead.coords`` order."""
+    shape = _logical_shape(geom)
+    chunks = (geom.sample_chunk_size, *geom.inner_chunks)
+    return [AxisGrid(s, c) for s, c in zip(shape, chunks, strict=True)]
+
+
+def _read_window(geom: ArrayGeometry, anchor: int, ref_spc: int) -> tuple[int, int]:
+    """Inclusive ``[lo, hi]`` sample window an anchor reads (mirrors ``plan._read_chunks``)."""
+    start = anchor * ref_spc
+    stop = min(start + ref_spc, geom.n_samples)
+    lo = max(0, start + geom.offset)
+    hi = min(geom.n_samples - 1, stop - 1 + geom.offset)
+    return lo, hi
+
+
+def _zi_chunk_coords(geom: ArrayGeometry, lo: int, hi: int) -> set[tuple[int, ...]]:
+    """Chunk set ``zarr_indexing`` resolves for the logical box ``[lo, hi] x (all inner)``."""
+    shape = _logical_shape(geom)
+    mins = (lo, *([0] * (len(shape) - 1)))
+    maxs = (hi + 1, *shape[1:])
+    transform = zi.IndexTransform.identity(zi.IndexDomain(inclusive_min=mins, exclusive_max=maxs))
+    resolved = zi.iter_chunk_transforms(transform, _logical_grids(geom))
+    return {coords for coords, _sub, _out in resolved}
+
+
+def _planner_chunk_coords(geom: ArrayGeometry, anchor: int, ref_spc: int) -> set[tuple[int, ...]]:
+    """Chunk set our planner produces for one anchor (logical, sample-first coords)."""
+    return {
+        (cid, *inner)
+        for cid in _read_chunks(geom, anchor, ref_spc)
+        for inner in geom.inner_coords()
+    }
+
+
+def _n_ref_chunks(geom: ArrayGeometry, ref_spc: int) -> int:
+    return -(-geom.n_samples // ref_spc)
+
+
+f4 = np.dtype("f4")
+
+# (id, geometry, ref_spc) -- exercises offset windows (incl. running off both ends),
+# coarser/finer-than-ref variable grids, short final chunks, inner grids, sample_axis != 0.
+CASES: list[tuple[str, ArrayGeometry, int]] = [
+    ("baseline-1d", ArrayGeometry("a", (100,), (10,), f4), 10),
+    ("inner-grid-3d", ArrayGeometry("a", (100, 90, 45), (10, 32, 32), f4), 10),
+    ("offset-plus1", ArrayGeometry("a", (100, 90, 45), (10, 32, 32), f4, offset=1), 10),
+    ("offset-plus5", ArrayGeometry("a", (100, 8), (10, 8), f4, offset=5), 10),
+    ("offset-minus3", ArrayGeometry("a", (100, 8), (10, 8), f4, offset=-3), 10),
+    ("coarser-than-ref", ArrayGeometry("a", (100, 8), (20, 8), f4), 10),
+    ("finer-than-ref", ArrayGeometry("a", (100, 8), (5, 8), f4), 10),
+    ("short-final-chunk", ArrayGeometry("a", (95, 45), (10, 32), f4), 10),
+    (
+        "sample-axis-2",
+        ArrayGeometry("a", (4, 3, 100, 90, 45), (4, 3, 10, 32, 32), f4, sample_axis=2),
+        10,
+    ),
+    ("offset-short-inner", ArrayGeometry("a", (95, 90, 45), (10, 32, 32), f4, offset=3), 10),
+    ("offset-off-tail", ArrayGeometry("a", (100, 8), (10, 8), f4, offset=10), 10),
+    ("offset-off-head", ArrayGeometry("a", (100, 8), (10, 8), f4, offset=-10), 10),
+]
+
+
+@pytest.mark.parametrize("geom,ref_spc", [(g, r) for _, g, r in CASES], ids=[c[0] for c in CASES])
+def test_planner_matches_zarr_indexing_per_anchor(geom: ArrayGeometry, ref_spc: int) -> None:
+    """Every anchor's resolved chunk set matches ``iter_chunk_transforms`` exactly."""
+    saw_nonempty = False
+    for anchor in range(_n_ref_chunks(geom, ref_spc)):
+        lo, hi = _read_window(geom, anchor, ref_spc)
+        planner = _planner_chunk_coords(geom, anchor, ref_spc)
+        if lo > hi:  # window reads entirely off the array (edge) -> both empty
+            assert not planner
+            assert len(_read_chunks(geom, anchor, ref_spc)) == 0
+            continue
+        assert _zi_chunk_coords(geom, lo, hi) == planner
+        saw_nonempty = True
+    assert saw_nonempty
+
+
+@pytest.mark.parametrize("geom,ref_spc", [(g, r) for _, g, r in CASES], ids=[c[0] for c in CASES])
+def test_build_stored_chunk_reads_matches_zarr_indexing(geom: ArrayGeometry, ref_spc: int) -> None:
+    """The full planner entry point resolves the same stored-chunk set over all anchors."""
+    anchors = list(range(_n_ref_chunks(geom, ref_spc)))
+    got = {r.coords for r in build_stored_chunk_reads(anchors, {geom.path: geom}, ref_spc)}
+    expected: set[tuple[int, ...]] = set()
+    for anchor in anchors:
+        expected |= _planner_chunk_coords(geom, anchor, ref_spc)
+    assert got == expected
+
+
+# --- thesis guard: why we do NOT expose arbitrary per-sample random access -----
+
+
+def test_scattered_sample_read_amplification() -> None:
+    """Resolving a scattered selection is cheap; *serving* it is the cost we reject.
+
+    ``zarr_indexing`` happily resolves an arbitrary, cross-chunk sample selection
+    (``oindex``) into a per-chunk scatter map -- the gather ``out[out_sel] =
+    tile[chunk_sel]`` reconstructs ``data[picks]`` exactly, including a cross-chunk
+    spread and a repeated index. But resolving the coordinates does nothing about
+    **read amplification**: every touched chunk is fetched and decoded in full to
+    yield a handful of rows. Here 5 distinct wanted samples force reading all 12 in
+    the touched chunks. Scale that to "one sample per chunk" and TTFB collapses --
+    which is exactly the reshard/random-access pattern insitubatch trades away for
+    the block-shuffle approximation (see DESIGN.md). The index math was never the
+    bottleneck, so a free resolver does not make this pattern viable. This test
+    stands as the boundary marker, not a feature request.
+    """
+    n, spc, inner = 12, 4, 3
+    data = np.arange(n * inner).reshape(n, inner).astype(np.float32)
+    picks = np.array([0, 3, 4, 4, 9, 11], dtype=np.intp)  # scattered, cross-chunk, with a repeat
+    grids = [AxisGrid(n, spc), AxisGrid(inner, inner)]
+
+    # The package resolves + scatters the selection correctly -- the math is not the issue.
+    transform = zi.IndexTransform.from_shape((n, inner)).oindex[picks]
+    out = np.zeros((picks.size, inner), dtype=np.float32)
+    touched: set[int] = set()
+    for chunk_coords, sub_t, out_idx in zi.iter_chunk_transforms(transform, grids):
+        chunk_sel, out_sel, _drop = zi.sub_transform_to_selections(sub_t, out_idx)
+        tile = data[chunk_coords[0] * spc : (chunk_coords[0] + 1) * spc]  # one stored chunk
+        out[out_sel] = tile[chunk_sel]
+        touched.add(chunk_coords[0])
+    np.testing.assert_array_equal(out, data[picks])
+
+    # ...but the cost is IO, not indices: serving those picks reads every touched
+    # chunk whole -- a strict superset of the samples actually wanted.
+    geom = ArrayGeometry("a", (n, inner), (spc, inner), f4)
+    reads = build_stored_chunk_reads(sorted(touched), {geom.path: geom}, spc)
+    read_samples: set[int] = set()
+    for r in reads:
+        read_samples |= set(geom.samples_in_chunk(r.chunk_index))
+    distinct_picks = {int(p) for p in picks}
+    assert distinct_picks < read_samples  # strict subset: the archetypal over-read
+    assert len(distinct_picks) == 5  # wanted
+    assert len(read_samples) == 12  # actually read (all of the 3 touched chunks)

--- a/uv.lock
+++ b/uv.lock
@@ -1311,6 +1311,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "zarr-indexing" },
 ]
 
 [package.metadata]
@@ -1350,6 +1351,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "ruff", specifier = ">=0.6" },
+    { name = "zarr-indexing", specifier = ">=0.1" },
 ]
 
 [[package]]
@@ -3960,6 +3962,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/93/8d/aeb164004f87543b06ef54f885d02c342c31ceb274e2bbec470a98927621/zarr-3.2.1.tar.gz", hash = "sha256:71565b738a0e7e8ed226f0516eba8c6bb53440ad7669a8c48ebb3534a161d035", size = 675161, upload-time = "2026-05-05T12:37:22.383Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/0a/469e2bd01be1490336e6c8707386845655d59261543315778a3ccc7e8019/zarr-3.2.1-py3-none-any.whl", hash = "sha256:f78cdd3d9687ad0e9f9cba2c5683b64f0c52589c19f685eeabe872e93cc0d2c7", size = 319617, upload-time = "2026-05-05T12:37:20.66Z" },
+]
+
+[[package]]
+name = "zarr-indexing"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/9b/ce8e30e46deb0ba9e6c481d7e9e39d3cf5e7bc84bfd82431dfaaa39f7d3d/zarr_indexing-0.1.0.tar.gz", hash = "sha256:672675a53a32d12e31007e6852f1d59a79b7d2993205af7568e8a0c50c2a2f3a", size = 124622, upload-time = "2026-07-31T09:28:40.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/d8/1288d04953b75ad63bfd2c18ce894b17bc2143841af69ace0872e37b0e77/zarr_indexing-0.1.0-py3-none-any.whl", hash = "sha256:cb21425a69bdf4ef33ec0cf9ab9ac4fcfe1e2a7a0a8a9c1752d39791ee1fdc9a", size = 39891, upload-time = "2026-07-31T09:28:38.754Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Dogfoods the [`zarr-indexing`](https://github.com/zarr-developers/zarr-python/releases/tag/zarr_indexing-v0.1.0) package (the leaf split of the [#3906](https://github.com/zarr-developers/zarr-python/pull/3906) IndexTransform work, shipped from [#4196](https://github.com/zarr-developers/zarr-python/pull/4196)) against our read planner, and records the design conclusions.

### `tests/test_zarr_indexing_parity.py`

- **Parity oracle** — with `ArrayGeometry` supplying a `DimensionGridLike` per (logical, sample-first) axis, `zarr_indexing.iter_chunk_transforms` reproduces `build_stored_chunk_reads`' stored-chunk set **exactly**, across offset/windowed views, coarser/finer-than-reference grids, short final chunks, gridded inner axes, and a non-zero sample axis (both empty-window edges included). Confirms our per-selection chunk math is correct against an independent TensorStore-derived implementation, and that the `DimensionGridLike` protocol is consumable from outside zarr.
- **Thesis guard** (`test_scattered_sample_read_amplification`) — a scattered per-sample gather resolves fine through the package but reads whole touched chunks (5 wanted → 12 read). Demonstrates why we don't expose arbitrary per-sample random access: the index math was never the bottleneck; read amplification is, and the resolver sits upstream of it. The fancy resolver is the anti-pattern, not a future engine.

### DESIGN.md

- **"Upstream capabilities"** — the `IndexTransform` bullet reframed: `zarr-indexing` is an **oracle + minor grid convenience, never an engine** for us. No adoption trigger from sample indexing (that's the anti-pattern); the only cheap touchpoints are irregular chunk grids and inner-axis box crops. The batched multi-window union with cross-selection dedup stays ours.
- **Patching rung** — folds in the crop read mechanics: chunk-granular omission, `tile_placement` generalizing to a clamped box, deterministic/strided origins as the honest win (cross-patch decode-once dedup is our primitive), random origins as the read-amplification trap. Gated on a concrete user issue.

## Dependency

`zarr-indexing` **0.1.0 is now a tagged release on PyPI**, so the original `pytest.importorskip`/skip-in-CI arrangement is gone: it is pinned in the `dev` dependency group (`zarr-indexing>=0.1`) and the 25 parity cases **run in every CI job** rather than silently skipping. The released API needed no test changes — it passes as written. It is **test-only**: nothing under `src/` imports it, and the wheel is pure Python (numpy only), so it installs everywhere the suite runs.

No production code changed — tests + design docs + dev-dep pin only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)