### PR TITLE
Reuse batch output buffers; opt-in page-locked H2D path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bench/figures/
 
 # Generated example stores (virtual-reference Icechunk repos, rebuilt from committed URI lists)
 examples/hubble/hubble_store/
+examples/sdss/sdss_store/
 
 # MkDocs build output (docs/figures/ is committed for the published site)
 site/

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -429,11 +429,15 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   **Priority pending user feedback** — no correctness impact, so we hold until someone hits it.
 
 - ✅ **SHIPPED — batch buffer reuse + pinning** (`buffers.BatchBuffers`,
-  `frameworks.as_torch(device=...)`; branch `batch-buffer-ring`). `pool.gather` lends a
-  reused, 128-byte-aligned buffer per variable and reclaims it once the consumer's view is
-  unreferenced; `as_torch(device=...)` swaps in page-locked buffers *and* owns the H2D copy.
-  Kept here as the record of what was measured and why it is shaped this way. **Profiled**
-  with
+  `frameworks.as_torch(device=...)` / `pin_host_buffers`; branch `batch-buffer-ring`).
+  `pool.gather` lends a reused, 128-byte-aligned buffer per variable and reclaims it once the
+  consumer's view is unreferenced; `as_torch(device=...)` swaps in page-locked buffers *and*
+  owns the H2D copy. **End-to-end results and how to read them:
+  [docs/benchmarks.md](docs/benchmarks.md#batch-buffers--reuse-removes-a-cliff-pinning-buys-24).**
+  Headline: reuse removes a payload-size cliff (+16% at 32 MiB) and costs 2–3% below it, which
+  does not surface in a compute-bound GPU loop; pinning is worth **+2–4%** end to end at
+  0.5–8 MiB payloads and rises with payload. Kept here as the record of what was measured and
+  why the design is shaped this way. **Profiled** with
   `bench/probe_batch_buffers.py` (L4, PCIe Gen4 x8 — a wider link makes the pinned column
   better, so read these as a floor):
 
@@ -467,7 +471,23 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
 
   So this removes a cliff rather than adding speed, and **small batches pay ~2–3%** — a real
   trade-off, not noise (reproduced in both arms at both sizes). Weather sits in the losing
-  region; it is a fraction of a percent of a WB2 step, but it is a cost, not a wash. *Pinning* is a smooth gradient that helps at every size, and up to ~37 MiB it hides
+  region; it is a fraction of a percent of a WB2 step, but it is a cost, not a wash.
+
+  That cost does **not** reach a real training loop: in the advection GPU benchmark, four
+  alternating runs (with/without the pool, 5 epochs × 7 repeats) held the 128² geometry at
+  99.2 / 99.3 / 99.4 / 99.3 % of ceiling — 0.2 points of spread and no arm signal. Producer-side
+  work is what prefetch exists to hide. **Pinning, measured the same way, is worth +5.0 / +3.9 /
+  +2.3% absolute throughput at 0.5 / 2 / 8 MiB payloads**, with the compute ceiling rising by
+  the same amount (the ceiling loop issues the same per-step copy) — which is what identifies
+  the transfer as the thing that changed.
+
+  Two metric traps, both of which caught us: `% of ceiling` is right for the *reuse* check
+  (it normalizes away a compute ceiling that drifted up to 9.7% between sessions on unchanged
+  code) and wrong for *pinning* (which speeds up a copy both sides perform, so it barely
+  moves); and the ceiling is sampled once per geometry per run, so `% of ceiling` resolves
+  only ~1 point no matter how many repeats. See the benchmarks page for the full caveats.
+
+  In isolation, *pinning* is a smooth gradient that helps at every size, and up to ~37 MiB it hides
   the copy **completely** — the pinned arm sits on the compute floor. A pageable copy costs
   more than its own transfer time (1.5 MiB transfers in 0.4 ms but adds 1.5 ms of wall)
   because it cannot overlap at all: it stages through a driver bounce buffer and stalls the

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -473,19 +473,37 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   trade-off, not noise (reproduced in both arms at both sizes). Weather sits in the losing
   region; it is a fraction of a percent of a WB2 step, but it is a cost, not a wash.
 
-  That cost does **not** reach a real training loop: in the advection GPU benchmark, four
-  alternating runs (with/without the pool, 5 epochs × 7 repeats) held the 128² geometry at
-  99.2 / 99.3 / 99.4 / 99.3 % of ceiling — 0.2 points of spread and no arm signal. Producer-side
-  work is what prefetch exists to hide. **Pinning, measured the same way, is worth +5.0 / +3.9 /
-  +2.3% absolute throughput at 0.5 / 2 / 8 MiB payloads**, with the compute ceiling rising by
-  the same amount (the ceiling loop issues the same per-step copy) — which is what identifies
-  the transfer as the thing that changed.
+  **Both figures above are the top of a range whose bottom is zero**, and how compute-bound a
+  loop is decides where in that range it lands. The isolated sweeps measure loader cost fully
+  exposed; a step that already hides the loader collects none of it. That is not a
+  disappointment, it is prefetch working — so the numbers to publish are the bounds and the
+  rule for predicting a point between them, never a single headline.
 
-  Two metric traps, both of which caught us: `% of ceiling` is right for the *reuse* check
-  (it normalizes away a compute ceiling that drifted up to 9.7% between sessions on unchanged
-  code) and wrong for *pinning* (which speeds up a copy both sides perform, so it barely
-  moves); and the ceiling is sampled once per geometry per run, so `% of ceiling` resolves
-  only ~1 point no matter how many repeats. See the benchmarks page for the full caveats.
+  The GPU training loop is the bottom of reuse's range, and measurably so. Sweeping batch size
+  over one 256² store, each arm against its own in-session ceiling, reuse vs no-reuse comes in
+  at **+0.21 / +0.20 / −0.18 / −0.29 points** at 8 / 16 / 32 / 64 MiB per buffer: inside ±0.3,
+  sign flipping twice, across an 8× range spanning the threshold, with the two arms agreeing to
+  0.04% absolute at 64 MiB. (An earlier "four alternating runs" null was taken at 128²/2 MiB —
+  *below* the cliff — so it tested nothing.) **Pinning lands in the middle of its own range at
+  +1 to +2%**, bracketed against drift; an earlier +5.0 / +3.9 / +2.3% came from runs since
+  voided, measured under the double-lend bug *and* doubled H2D traffic.
+
+  The asymmetry is structural, not luck: reuse saves **producer-thread** time, which is exactly
+  what prefetch is built to hide, while pinning shortens a copy on the **consumer's** critical
+  path, which prefetch cannot touch. So reuse is worth most where the loader is not already
+  free — inference rather than training, shallow compute per byte, cold caches, IO-bound epochs
+  — and its floor value is the guarantee that growing a batch past 32 MiB cannot walk you off
+  a cliff.
+
+  Three metric traps, all of which caught us. `% of ceiling` is right for the *reuse* check —
+  it normalizes away session drift — and wrong for *pinning*, because `--pin` reaches the
+  ceiling too (`pin_host_buffers` precedes `preload_epoch`, which is `list(ds.train)`), so the
+  ceiling moves in lockstep and the metric cancels the effect. The ceiling is sampled once per
+  geometry per run, so `% of ceiling` resolves only ~1 point however many repeats you take.
+  And **drift is the dominant error term**: an A/B/A on an unchanged checkout read 145.4 /
+  146.6 / 143.4 samples/s, so two *identical* unpinned blocks differed 1.4% twenty minutes
+  apart — half the size of the effect being measured. Run the control arm twice, bracketing the
+  treatment, and interpolate; a single back-to-back pair is not enough. See the benchmarks page.
 
   In isolation, *pinning* is a smooth gradient that helps at every size, and up to ~37 MiB it hides
   the copy **completely** — the pinned arm sits on the compute floor. A pageable copy costs
@@ -494,7 +512,7 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   stream. Past ~512 MiB even pinned is exposed, but only because the copy (43 ms) now
   exceeds the step (25 ms) — that residue is arithmetic, not a pinning failure.
 
-  So **weather gains nothing from reuse, and ~3% from pinning** — real but small, and the
+  So **weather gains nothing from reuse, and +1–2% from pinning** — real but small, and the
   wb2 row is near this harness's resolution (stream-context overhead is comparable to the
   effect). Validate on microscopy/ViT; do not expect the advection numbers to move. The
   percentages are all against a synthetic 25 ms step, so the transferable quantity is the
@@ -508,10 +526,22 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   pays on its own above the allocator cliff.
 
   Pool design: own the base allocations permanently, hand out **views** (`base[:k]`, which
-  is also the ragged-tail answer), keep a `weakref` per lent view, and **poll liveness at the
-  next `__next__`** — a dead view is nobody's, so it returns to the free list; a live one
-  (a retained batch, an exported DLPack tensor — `torch.from_dlpack` holds a strong
-  reference to the source) stays out. A miss allocates. Consequences: releasing
+  is also the ragged-tail answer), and **poll liveness at the next hand-out** — an
+  unreferenced buffer is nobody's, so it is reused; a live one (a retained batch, an exported
+  DLPack tensor — `torch.from_dlpack` holds a strong reference to the source) stays out. A
+  miss allocates.
+
+  *As built, liveness is a refcount on the buffer's data **owner**, not a `weakref` on the
+  lent view.* The plan above said weakref; implementation showed it cannot work. numpy
+  collapses base chains to the owning array rather than chaining them, so a crop taken from a
+  lent view does **not** reference that view — a consumer who keeps `batch["x"][:, :2]` and
+  drops the batch would have its memory recycled underneath it. Every array viewing the
+  memory does reference the owner, so `sys.getrefcount(owner)` against a calibrated idle
+  baseline sees derived views, DLPack exports and retained batches alike. The baseline is the
+  load-bearing part: it must be recorded after the allocation's own transient references are
+  gone, or every buffer looks permanently free and the pool lends one allocation to every
+  batch at once — which is exactly the bug that shipped and was caught by a persistence-RMSE
+  drift, not by throughput or forecast skill. Consequences: releasing
   unconditionally at the yield point would be *less* safe than today (it would overwrite a
   batch the consumer legitimately kept), holding a reference is already the way to retain
   one so no `retain()` API is needed, and **there is no depth parameter** — allocate-on-miss
@@ -547,8 +577,11 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   does *not* require M2's `device_transform`, which is a pipeline stage (user GPU callables,
   composition, a third entry in the transform contract); it requires only
   `to_torch(batch, device=...)` issuing the copy itself. And the guard needs no new
-  machinery: the adapter holds the source arrays until `event.query()`, which keeps their
-  weakrefs alive, so the pool's existing liveness poll defers reclaim on its own. No event
+  machinery: the adapter holds the source arrays until `event.query()`, which keeps them
+  referencing the owner, so the pool's existing liveness poll defers reclaim on its own. That
+  hold set is process-wide (CUDA streams are), so retiring landed copies and taking a new hold
+  must be one locked step — unlocked, a thread can overwrite a hold another appended and free
+  a buffer mid-DMA. No event
   crosses into the core, `Batch` is unchanged, and `to_torch(batch)` without a device is
   exactly today's behaviour.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -446,9 +446,25 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
 
   **The two halves do *not* share a crossover** — an earlier reading said they did, off a
   drifting compute baseline. Only *reuse* has one, at ~32 MiB, and it is an allocator
-  artifact: below it glibc recycles the freed block on the heap so the fresh allocation
-  re-faults nothing; above it every batch is `mmap`/`munmap`'d and re-faults its whole page
-  set. *Pinning* is a smooth gradient that helps at every size, and up to ~37 MiB it hides
+  artifact: below it glibc recycles the freed block on the heap; above it every batch is
+  `mmap`/`munmap`'d, paying a fresh page set plus `munmap`'s TLB work. Confirmed by syscall
+  trace rather than inferred — a 12-batch epoch of 128 MiB batches issues **12** full-buffer
+  `mmap`/`munmap` pairs without the pool and **2** with it, the count tracking batches rather
+  than dataset size.
+
+  End to end (`bench/batch_buffer_sweep.py`, L4, `--inner 256,256`, ABBA-ordered arms), the
+  shape matters more than any single number — **the pool holds throughput flat across a 16×
+  payload range while fresh allocation falls off a cliff:**
+
+  | MiB/batch | 8 | 16 | 32 | 64 | 128 |
+  |---|---|---|---|---|---|
+  | no pool (samples/s) | 5404 | 5186 | 4435 | 4585 | 4765 |
+  | pool | 5240 | 5060 | 5148 | 5173 | 5266 |
+  | delta | −3.0% | −2.4% | **+16.1%** | **+12.8%** | **+10.5%** |
+
+  So this removes a cliff rather than adding speed, and **small batches pay ~2–3%** — a real
+  trade-off, not noise (reproduced in both arms at both sizes). Weather sits in the losing
+  region; it is a fraction of a percent of a WB2 step, but it is a cost, not a wash. *Pinning* is a smooth gradient that helps at every size, and up to ~37 MiB it hides
   the copy **completely** — the pinned arm sits on the compute floor. A pageable copy costs
   more than its own transfer time (1.5 MiB transfers in 0.4 ms but adds 1.5 ms of wall)
   because it cannot overlap at all: it stages through a driver bounce buffer and stalls the

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -476,6 +476,21 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   converges to the true in-flight count on its own. A `batch_transform` returning new arrays
   (e.g. `_subregion_crop`) drops its pooled view immediately and gets no benefit.
 
+  **The pool is sound for every adapter, for three different reasons.** torch and JAX both
+  alias pool memory through `from_dlpack` *and* hold a strong reference to the source, so
+  the poll defers reclaim while a tensor is live (verified). TF never touches pool memory at
+  all — `to_tf` copies, because its experimental DLPack double-frees the exported buffer
+  under the decode threads — so it is safe by construction and gains nothing from either
+  half. A JAX detail worth a test: `jax.Array` is advertised as **immutable**, and a host
+  write through an aliased buffer *is* visible through it, so for JAX the poll is not an
+  optimization guard but what stops a documented-immutable array changing underneath.
+
+  An aligned pool is also a small **win** for JAX. XLA:CPU zero-copies only from a 128-byte
+  boundary and silently copies otherwise; numpy guarantees 16, so today's per-batch
+  `np.empty` is zero-copy by luck — measured 20/40, versus 40/40 from a 128-aligned
+  allocation. Pool buffers should be aligned, which makes `to_jax` reliably zero-copy for
+  the first time. (Pinned host memory is page-aligned, so the pinned path gets this free.)
+
   Pinning needs us to **own the transfer** — refcounts cannot see an in-flight
   `non_blocking` DMA, so recycling a buffer whose copy is still draining corrupts it. That
   does *not* require M2's `device_transform`, which is a pipeline stage (user GPU callables,
@@ -493,8 +508,14 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   1.5 GB), so pinning needs a cap the reuse-only pool does not, interacting with the memory
   budget. **Gate: the `roundtrip` arm** — pinning must survive `pinned tensor → .numpy() →
   base[:k] → DLPack → .to(cuda)`, or `non_blocking` silently degrades to a synchronous
-  pageable copy and the whole win evaporates with no error. If it fails, pinning needs a
-  torch-owned buffer instead of an injected allocator.
+  pageable copy and the whole win evaporates with no error. **That gate passed** on an L4:
+  `is_pinned()` survives, the ragged `base[:k]` prefix too, and the H2D time through the
+  full path matches a native pinned tensor to three decimals (43.502 vs 43.501 ms at
+  512 MiB) — the round-trip is the same memory at no cost. Pinning stays **torch-only**
+  regardless: `to_torch(device=...)` gives us `Event.query()` to guard reuse against, and
+  JAX's `device_put` exposes no equivalent, so we would be handing JAX pinned memory with no
+  way to know when recycling it is safe. Left out of scope until measured (the `jax` arm's
+  race check needs a GPU-backend JAX to run).
 
 - **`window_factor` sizes residency by span, not by the offset set.** `source.py` sizes the
   shuffle/residency working set with `window_factor = 2 + ceil(span/spc)` where

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -429,17 +429,48 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   **Priority pending user feedback** — no correctness impact, so we hold until someone hits it.
 
 - **Batch buffers are fresh per batch, and host memory is not pinned.** `pool.gather`
-  allocates a new array per batch rather than reusing one — the DLPack export aliases the
-  buffer into the consumer's tensor, so reuse needs lifetime tracking against the
-  `prefetch_depth` window — and nothing pins host memory for GPU transfer, so H2D copies
-  are pageable. The unified fix is a small **ring of pre-pinned buffers** (depth
-  ≈ `prefetch_depth`+1) handed out round-robin (a buffer is safe to reuse once its batch
-  has left the prefetch window): it removes the per-batch allocation *and* enables
-  `non_blocking` H2D transfer in one change — pinning fresh per batch would be worse
-  (`cudaHostAlloc` is expensive). Value scales with payload: negligible for small weather
-  fields (µs transfers, already hidden by prefetch), real for ViT/microscopy batches — so
-  **profile the H2D ceiling first** (pinned vs pageable bandwidth; is the copy on the
-  critical path or already overlapped?). Ties into the GPU `device_transform` stage (M2).
+  allocates a new array per batch rather than reusing one, and nothing pins host memory
+  for GPU transfer, so H2D copies are pageable. **Profiled** with
+  `bench/probe_batch_buffers.py` (L4, PCIe Gen4 x8 — a wider link makes the pinned column
+  better, so read these as a floor):
+
+  | payload | reuse saves | pinned vs pageable H2D | copy hidden behind ~20 ms compute? |
+  |---|---|---|---|
+  | wb2 `16×3×128×64` (1.5 MiB) | 2% | 3.8 → 10.3 GB/s | fully — pinning saves nothing |
+  | vit `32×3×224×224` (18 MiB) | 2% | 5.8 → 11.4 GB/s | mostly — 4.7% |
+  | vit `64×3×224×224` (37 MiB) | 33% | 6.3 → 11.4 GB/s | no — 16% |
+  | microscopy `8×2×32×512×512` (512 MiB) | 22% | 6.4 → 11.5 GB/s | no — 53% |
+
+  Both halves have the same **~32 MiB crossover**, for unrelated reasons: below it glibc
+  recycles the freed block on the heap (so the fresh allocation re-faults nothing) and the
+  copy disappears into the step. Above it every batch is `mmap`/`munmap`'d and re-faults its
+  whole page set, and the transfer surfaces on the critical path. **Weather gains nothing
+  from either half** — validate this work on microscopy/ViT payloads, and do not expect the
+  advection numbers to move.
+
+  They are **two fixes, not one.** Reuse saves producer-thread time, which is hidden
+  whenever the pipeline is IO-bound; pinning's win is consumer-side wall time by
+  construction, and is the larger of the two above the crossover. Build the **buffer pool
+  first** anyway — it is the prerequisite for pinning (`cudaHostAlloc` per batch is worse
+  than not pinning, so a fixed set of buffers must exist to pre-pin) and it pays on its own.
+
+  Pool design: own the base allocations permanently, hand out **views** (`base[:k]`, which
+  is also the ragged-tail answer), keep a `weakref` per lent view, and **poll liveness at the
+  next `__next__`** — a dead view is nobody's, so it returns to the free list; a live one
+  (a retained batch, an exported DLPack tensor — `torch.from_dlpack` holds a strong
+  reference to the source) stays out. A miss allocates. Consequences: releasing
+  unconditionally at the yield point would be *less* safe than today (it would overwrite a
+  batch the consumer legitimately kept), holding a reference is already the way to retain
+  one so no `retain()` API is needed, and **there is no depth parameter** — allocate-on-miss
+  converges to the true in-flight count on its own. A `batch_transform` returning new arrays
+  (e.g. `_subregion_crop`) drops its pooled view immediately and gets no benefit.
+
+  Pinning waits on M2's GPU `device_transform`, and not just for sequencing: refcounts cannot
+  see an in-flight `non_blocking` DMA, so recycling a buffer whose copy is still draining
+  corrupts it. Owning the transfer (`as_torch(device=...)`) closes that by making the reclaim
+  predicate two-part — *view dead **and** recorded H2D event complete*. Pinning also needs a
+  cap the pool otherwise does not: page-locked memory is a scarce global resource (512 MiB
+  buffers at depth 3 lock 1.5 GB), so it interacts with the memory budget.
 
 - **`window_factor` sizes residency by span, not by the offset set.** `source.py` sizes the
   shuffle/residency working set with `window_factor = 2 + ceil(span/spc)` where

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -481,9 +481,18 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   the poll defers reclaim while a tensor is live (verified). TF never touches pool memory at
   all — `to_tf` copies, because its experimental DLPack double-frees the exported buffer
   under the decode threads — so it is safe by construction and gains nothing from either
-  half. A JAX detail worth a test: `jax.Array` is advertised as **immutable**, and a host
-  write through an aliased buffer *is* visible through it, so for JAX the poll is not an
-  optimization guard but what stops a documented-immutable array changing underneath.
+  half.
+
+  The JAX case is the one that needed proving, and it is **not** a nicety: JAX documents that
+  a `from_dlpack` buffer mutated in place by an external process is **undefined behaviour**
+  (dlpack buffers cannot be marked immutable), so the poll is what keeps a recycled pool
+  buffer out of UB. `jax.device_put` is documented as always asynchronous, and the probe
+  reproduces an async read of our buffer after it returns — but only with the GPU under load
+  from the other arms, which is why the `jax` arm is only meaningful run as `--arms all`.
+  JAX nevertheless keeps the source **referenced** across that transfer (deterministic check,
+  no race involved), so the poll cannot reclaim mid-DMA. That last part is an observed XLA
+  implementation detail, not a documented guarantee — assert it in a test so a regression
+  surfaces here rather than as corrupted training data.
 
   An aligned pool is also a small **win** for JAX. XLA:CPU zero-copies only from a 128-byte
   boundary and silently copies otherwise; numpy guarantees 16, so today's per-batch
@@ -511,11 +520,17 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   pageable copy and the whole win evaporates with no error. **That gate passed** on an L4:
   `is_pinned()` survives, the ragged `base[:k]` prefix too, and the H2D time through the
   full path matches a native pinned tensor to three decimals (43.502 vs 43.501 ms at
-  512 MiB) — the round-trip is the same memory at no cost. Pinning stays **torch-only**
-  regardless: `to_torch(device=...)` gives us `Event.query()` to guard reuse against, and
-  JAX's `device_put` exposes no equivalent, so we would be handing JAX pinned memory with no
-  way to know when recycling it is safe. Left out of scope until measured (the `jax` arm's
-  race check needs a GPU-backend JAX to run).
+  512 MiB) — the round-trip is the same memory at no cost.
+
+  Pinning stays **torch-only**, for a documented reason rather than a measured one:
+  [jax#22346](https://github.com/jax-ml/jax/issues/22346) — JAX's DLPack path rejects pinned
+  host memory (`KeyError: kDLCPUPinned`), blocked upstream on both sides
+  ([pytorch#136250](https://github.com/pytorch/pytorch/issues/136250)). We dodge it in
+  practice, since we export from numpy and numpy reports `kDLCPU` however the pages were
+  allocated — verified, `jnp.from_dlpack` accepts a view of a pinned torch buffer — so a
+  pinned pool stays consumable by JAX. But JAX has no way to *use* the pinning and no event
+  to guard recycling against, so `to_torch(device=...)` remains the only path that owns its
+  transfer.
 
 - **`window_factor` sizes residency by span, not by the offset set.** `source.py` sizes the
   shuffle/residency working set with `window_factor = 2 + ceil(span/spc)` where

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -434,25 +434,36 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   `bench/probe_batch_buffers.py` (L4, PCIe Gen4 x8 — a wider link makes the pinned column
   better, so read these as a floor):
 
-  | payload | reuse saves | pinned vs pageable H2D | copy hidden behind ~20 ms compute? |
+  | payload | reuse saves | H2D page → pin | cost added to a 25 ms step: pageable → pinned |
   |---|---|---|---|
-  | wb2 `16×3×128×64` (1.5 MiB) | 2% | 3.8 → 10.3 GB/s | fully — pinning saves nothing |
-  | vit `32×3×224×224` (18 MiB) | 2% | 5.8 → 11.4 GB/s | mostly — 4.7% |
-  | vit `64×3×224×224` (37 MiB) | 33% | 6.3 → 11.4 GB/s | no — 16% |
-  | microscopy `8×2×32×512×512` (512 MiB) | 22% | 6.4 → 11.5 GB/s | no — 53% |
+  | wb2 `16×3×128×64` (1.5 MiB) | 2% | 3.8 → 10.3 GB/s | +1.5 ms → +0.7 ms |
+  | vit `32×3×224×224` (18 MiB) | 2% | 5.8 → 11.4 GB/s | +1.6 ms → **+0.0 ms** |
+  | vit `64×3×224×224` (37 MiB) | 33% | 6.3 → 11.4 GB/s | +4.0 ms → **+0.3 ms** |
+  | microscopy `8×2×32×512×512` (512 MiB) | 22% | 6.4 → 11.5 GB/s | +71.7 ms → +18.3 ms |
 
-  Both halves have the same **~32 MiB crossover**, for unrelated reasons: below it glibc
-  recycles the freed block on the heap (so the fresh allocation re-faults nothing) and the
-  copy disappears into the step. Above it every batch is `mmap`/`munmap`'d and re-faults its
-  whole page set, and the transfer surfaces on the critical path. **Weather gains nothing
-  from either half** — validate this work on microscopy/ViT payloads, and do not expect the
-  advection numbers to move.
+  **The two halves do *not* share a crossover** — an earlier reading said they did, off a
+  drifting compute baseline. Only *reuse* has one, at ~32 MiB, and it is an allocator
+  artifact: below it glibc recycles the freed block on the heap so the fresh allocation
+  re-faults nothing; above it every batch is `mmap`/`munmap`'d and re-faults its whole page
+  set. *Pinning* is a smooth gradient that helps at every size, and up to ~37 MiB it hides
+  the copy **completely** — the pinned arm sits on the compute floor. A pageable copy costs
+  more than its own transfer time (1.5 MiB transfers in 0.4 ms but adds 1.5 ms of wall)
+  because it cannot overlap at all: it stages through a driver bounce buffer and stalls the
+  stream. Past ~512 MiB even pinned is exposed, but only because the copy (43 ms) now
+  exceeds the step (25 ms) — that residue is arithmetic, not a pinning failure.
+
+  So **weather gains nothing from reuse, and ~3% from pinning** — real but small, and the
+  wb2 row is near this harness's resolution (stream-context overhead is comparable to the
+  effect). Validate on microscopy/ViT; do not expect the advection numbers to move. The
+  percentages are all against a synthetic 25 ms step, so the transferable quantity is the
+  millisecond column, not the ratio.
 
   They are **two fixes, not one.** Reuse saves producer-thread time, which is hidden
   whenever the pipeline is IO-bound; pinning's win is consumer-side wall time by
-  construction, and is the larger of the two above the crossover. Build the **buffer pool
-  first** anyway — it is the prerequisite for pinning (`cudaHostAlloc` per batch is worse
-  than not pinning, so a fixed set of buffers must exist to pre-pin) and it pays on its own.
+  construction, and it is the larger and more certain of the two nearly everywhere. Build
+  the **buffer pool first** anyway — it is the prerequisite for pinning (`cudaHostAlloc` per
+  batch is worse than not pinning, so a fixed set of buffers must exist to pre-pin) and it
+  pays on its own above the allocator cliff.
 
   Pool design: own the base allocations permanently, hand out **views** (`base[:k]`, which
   is also the ragged-tail answer), keep a `weakref` per lent view, and **poll liveness at the
@@ -465,12 +476,25 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   converges to the true in-flight count on its own. A `batch_transform` returning new arrays
   (e.g. `_subregion_crop`) drops its pooled view immediately and gets no benefit.
 
-  Pinning waits on M2's GPU `device_transform`, and not just for sequencing: refcounts cannot
-  see an in-flight `non_blocking` DMA, so recycling a buffer whose copy is still draining
-  corrupts it. Owning the transfer (`as_torch(device=...)`) closes that by making the reclaim
-  predicate two-part — *view dead **and** recorded H2D event complete*. Pinning also needs a
-  cap the pool otherwise does not: page-locked memory is a scarce global resource (512 MiB
-  buffers at depth 3 lock 1.5 GB), so it interacts with the memory budget.
+  Pinning needs us to **own the transfer** — refcounts cannot see an in-flight
+  `non_blocking` DMA, so recycling a buffer whose copy is still draining corrupts it. That
+  does *not* require M2's `device_transform`, which is a pipeline stage (user GPU callables,
+  composition, a third entry in the transform contract); it requires only
+  `to_torch(batch, device=...)` issuing the copy itself. And the guard needs no new
+  machinery: the adapter holds the source arrays until `event.query()`, which keeps their
+  weakrefs alive, so the pool's existing liveness poll defers reclaim on its own. No event
+  crosses into the core, `Batch` is unchanged, and `to_torch(batch)` without a device is
+  exactly today's behaviour.
+
+  Two costs specific to pinning. The core cannot call `torch.empty(pin_memory=True)`, so the
+  buffers arrive from a **host allocator injected by the adapter** (default `np.empty`);
+  `as_torch(view, device=...)` implies pinning, so there is no separate flag to get wrong.
+  And page-locked memory is a scarce global resource (512 MiB buffers at depth 3 lock
+  1.5 GB), so pinning needs a cap the reuse-only pool does not, interacting with the memory
+  budget. **Gate: the `roundtrip` arm** — pinning must survive `pinned tensor → .numpy() →
+  base[:k] → DLPack → .to(cuda)`, or `non_blocking` silently degrades to a synchronous
+  pageable copy and the whole win evaporates with no error. If it fails, pinning needs a
+  torch-owned buffer instead of an injected allocator.
 
 - **`window_factor` sizes residency by span, not by the offset set.** `source.py` sizes the
   shuffle/residency working set with `window_factor = 2 + ceil(span/spc)` where

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -428,9 +428,11 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   mixes chunks across block boundaries, diluting the block-local residency guarantee).
   **Priority pending user feedback** — no correctness impact, so we hold until someone hits it.
 
-- **Batch buffers are fresh per batch, and host memory is not pinned.** `pool.gather`
-  allocates a new array per batch rather than reusing one, and nothing pins host memory
-  for GPU transfer, so H2D copies are pageable. **Profiled** with
+- **Host memory is not pinned** (batch buffer *reuse* ✅ shipped — `buffers.BatchBuffers`,
+  branch `batch-buffer-ring`; pinning is what remains). `pool.gather` now lends a reused,
+  128-byte-aligned buffer per variable and reclaims it once the consumer's view is
+  unreferenced, but nothing page-locks that memory, so H2D copies are still pageable.
+  **Profiled** with
   `bench/probe_batch_buffers.py` (L4, PCIe Gen4 x8 — a wider link makes the pinned column
   better, so read these as a floor):
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -428,11 +428,12 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   mixes chunks across block boundaries, diluting the block-local residency guarantee).
   **Priority pending user feedback** — no correctness impact, so we hold until someone hits it.
 
-- **Host memory is not pinned** (batch buffer *reuse* ✅ shipped — `buffers.BatchBuffers`,
-  branch `batch-buffer-ring`; pinning is what remains). `pool.gather` now lends a reused,
-  128-byte-aligned buffer per variable and reclaims it once the consumer's view is
-  unreferenced, but nothing page-locks that memory, so H2D copies are still pageable.
-  **Profiled** with
+- ✅ **SHIPPED — batch buffer reuse + pinning** (`buffers.BatchBuffers`,
+  `frameworks.as_torch(device=...)`; branch `batch-buffer-ring`). `pool.gather` lends a
+  reused, 128-byte-aligned buffer per variable and reclaims it once the consumer's view is
+  unreferenced; `as_torch(device=...)` swaps in page-locked buffers *and* owns the H2D copy.
+  Kept here as the record of what was measured and why it is shaped this way. **Profiled**
+  with
   `bench/probe_batch_buffers.py` (L4, PCIe Gen4 x8 — a wider link makes the pinned column
   better, so read these as a floor):
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -447,10 +447,13 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   **The two halves do *not* share a crossover** — an earlier reading said they did, off a
   drifting compute baseline. Only *reuse* has one, at ~32 MiB, and it is an allocator
   artifact: below it glibc recycles the freed block on the heap; above it every batch is
-  `mmap`/`munmap`'d, paying a fresh page set plus `munmap`'s TLB work. Confirmed by syscall
-  trace rather than inferred — a 12-batch epoch of 128 MiB batches issues **12** full-buffer
-  `mmap`/`munmap` pairs without the pool and **2** with it, the count tracking batches rather
-  than dataset size.
+  `mmap`/`munmap`'d. Confirmed by syscall trace on two hosts rather than inferred — a 12-batch
+  epoch of 128 MiB batches issues **12** full-buffer `mmap`/`munmap` pairs without the pool and
+  **2** with it, the count tracking batches rather than dataset size. The cost is the kernel
+  **re-zeroing** each fresh anonymous mapping: 1.5 GiB per epoch that the pool never pays,
+  predicting ~125 ms against a measured 122 ms gap. Page-fault *counts* are a bad proxy for
+  this — the same 1.5 GiB reads as a 360k-fault delta on a 6.8 kernel and 3.7k on 6.17, where
+  larger folios change the unit but not the work.
 
   End to end (`bench/batch_buffer_sweep.py`, L4, `--inner 256,256`, ABBA-ordered arms), the
   shape matters more than any single number — **the pool holds throughput flat across a 16×

--- a/bench/advection_report.py
+++ b/bench/advection_report.py
@@ -16,8 +16,10 @@ docs/benchmarks.md).
 The figure metric is chosen **per sweep**, because they don't share a signal (if plotly is
 present, one interactive HTML each):
 
-* ``size`` -- a *compute* knob (field size sets the conv cost), so it moves **steady
-  throughput**: bars = samples/s (+IQR), line = steady stall %.
+* ``size`` / ``payload`` -- *compute* knobs (field size and batch size both set the conv cost
+  per step), so they move **steady throughput**: bars = samples/s (+IQR), line = steady stall %.
+  ``payload`` carries the batch-buffer claims, and each of its batch sizes is its own ``geom``
+  precisely so it is scored against a ceiling measured at that same step size.
 * ``inflight`` / ``chunk`` / ``inner`` -- *IO* knobs. Once the cross-epoch cache is warm every
   read is served from RAM, so steady throughput is flat **by construction**; the knob only
   acts on the **cold first-fill**. So these plot bars = epoch-0 time-to-first-batch (ms), line
@@ -38,9 +40,16 @@ _KNOB = {
     "size": "size",
     "chunk": "sample_chunk",
     "inner": "inner_chunk",
+    "payload": "batch_size",
 }
 # Which signal the figure follows: steady throughput vs the cold first-fill (see module docstring).
-_FIG_KIND = {"size": "throughput", "inflight": "cold", "chunk": "cold", "inner": "cold"}
+_FIG_KIND = {
+    "size": "throughput",
+    "payload": "throughput",
+    "inflight": "cold",
+    "chunk": "cold",
+    "inner": "cold",
+}
 
 
 def load(path: str | Path) -> pd.DataFrame:

--- a/bench/advection_report.py
+++ b/bench/advection_report.py
@@ -195,7 +195,7 @@ def main() -> None:
     args = p.parse_args()
 
     df = load(args.inp)
-    for sweep in ["inflight", "size", "chunk", "inner"]:
+    for sweep in _KNOB:  # every registered sweep; adding one to _KNOB is all it takes
         if not (df["cfg_sweep"] == sweep).any():
             continue
         agg = summarize(df, sweep)

--- a/bench/advection_sweep.py
+++ b/bench/advection_sweep.py
@@ -24,9 +24,19 @@ The sweeps, and the claim each one confirms:
 * **payload** -- bytes per batch (``batch_size`` over one 256^2 store: 8 -> 64 MiB per variable
   buffer, 4x that per step). The axis the batch-buffer work acts on, and the one the ``size``
   sweep cannot reach: reuse only pays above glibc's 32 MiB ``mmap`` threshold, which applies
-  per allocation, and pinning's saved transfer time scales with bytes moved. Run it twice, back
-  to back, with and without ``--pin`` -- absolute throughput is only comparable within a
-  session (see the metric warning in docs/benchmarks.md).
+  per allocation, and pinning's saved transfer time scales with bytes moved.
+
+**Comparing arms across sessions: use the ceilings, not samples/s.** Absolute throughput
+drifts with the box -- measured, two unpinned sessions 14 h apart differed by 0.6%. The
+ceiling is the instrument that survives that, because it replays RAM batches through the same
+model with no IO at all, so across arms it varies only by what the arm changed. Two readings
+back that up: the pinned ceiling ran 2.0-2.3% above both unpinned ones (8 minutes apart, so
+drift cannot explain it -- pinning is real at ~2.2%), while reuse vs no-reuse came out within
++-0.2 pp of ceiling with the sign flipping (a null: the loop is at 99.5-100% of compute
+ceiling, so allocation cost has nowhere to show up). Score each arm against **its own**
+in-session ceiling and the drift divides out; compare raw samples/s across sessions and it
+does not. The earlier "+2.3% from pinning" was first read off raw samples/s and was not
+established until the third session bracketed the drift.
 
 The compute-only ceiling depends only on the field geometry (the conv cost), not on
 inflight / chunking / cache, so ``--ceiling`` is run exactly once per distinct ``geom`` and the
@@ -365,7 +375,9 @@ def main() -> None:
     p.add_argument(
         "--pin",
         action="store_true",
-        help="page-lock batch buffers in the insitu runs (not the ceiling); A/B for pinning",
+        help="page-lock the batch buffers; A/B for pinning. Applies to the ceiling too -- it "
+        "preloads through the same pool -- which is what makes the ceiling the cleanest "
+        "pinning contrast (RAM replay, no IO) and what pins a whole epoch of host memory",
     )
     p.add_argument(
         "--child-package",

--- a/bench/advection_sweep.py
+++ b/bench/advection_sweep.py
@@ -253,6 +253,58 @@ def _check_arm(out: Path, arm: dict[str, Any], p: argparse.ArgumentParser) -> No
             break  # one row settles it; the guard above keeps a file single-armed
 
 
+class PersistenceCheck:
+    """Assert that persistence RMSE stays constant per store -- the corruption detector.
+
+    Persistence RMSE is ``rmse(t2m(t), t2m(t+24h))`` over the val split: **no model, no
+    training, no batch size**. It is a property of the bytes the loader delivered, so every
+    run over one store must produce the same number. Measured, it is bit-identical --
+    ``0.588030696`` across batch sizes 32/64/128, pinned and unpinned, every repeat.
+
+    That is what makes it a loader test. A double-lend bug in the batch-buffer pool was
+    invisible in throughput (the same bytes still moved) and invisible in forecast skill (the
+    corrupt run scored +13.6%, above real ERA5's honest +11.4%), but it moved persistence
+    0.682 -> 0.934 and made it vary +-0.307 between repeats of one config. Nothing else in
+    the sweep would have caught it, and nothing did -- for a night.
+
+    Drift warns loudly and immediately but does not abort: the rows are still worth having
+    for diagnosis, and a raise mid-sweep would throw away hours of a long run. :meth:`report`
+    is what makes it non-ignorable, and the caller exits non-zero on it.
+    """
+
+    RTOL = 1e-6  # observed drift was 22%; observed jitter on healthy runs was exactly zero
+
+    def __init__(self) -> None:
+        self.expected: dict[str, float] = {}
+        self.drifted: list[str] = []
+
+    def observe(self, store: str, value: float, label: str) -> None:
+        first = self.expected.setdefault(store, value)
+        if abs(value - first) <= self.RTOL * abs(first):
+            return
+        msg = f"{label}: persistence RMSE {value:.9f} != {first:.9f} (first seen for {store!r})"
+        self.drifted.append(msg)
+        print(
+            f"\n*** LOADER WARNING *** {msg}\n*** persistence is model-independent: the "
+            f"batches differ, not the training ***\n",
+            flush=True,
+        )
+
+    def report(self) -> bool:
+        """Print the verdict; True when every store held its baseline."""
+        if not self.drifted:
+            baselines = ", ".join(f"{s}={v:.6f}" for s, v in sorted(self.expected.items()))
+            print(f"persistence invariant held: {baselines or '(no val rows)'}")
+            return True
+        print(
+            f"\nPERSISTENCE INVARIANT VIOLATED ({len(self.drifted)} runs) -- the loader "
+            f"returned different bytes for the same store:"
+        )
+        for msg in self.drifted:
+            print(f"  {msg}")
+        return False
+
+
 def _run_config(
     cmd: list[str],
     cfg: dict[str, Any],
@@ -260,6 +312,7 @@ def _run_config(
     out_fh: Any,
     env: dict[str, str] | None = None,
     arm: dict[str, Any] | None = None,
+    check: PersistenceCheck | None = None,
 ) -> None:
     """Run one child, tag its rows with the config + repeat, append to the combined file."""
     with tempfile.NamedTemporaryFile("r+", suffix=".jsonl") as tmp:
@@ -275,6 +328,16 @@ def _run_config(
             # afterwards otherwise, and mixing them up is silent.
             row.update(arm or {})
             out_fh.write(json.dumps(row) + "\n")
+            persistence = row.get("val_persistence_rmse")
+            # Only the final row of each run carries it; NaN elsewhere (NaN != NaN filters).
+            if check is not None and isinstance(persistence, float) and persistence == persistence:
+                # Keyed by the store, not the geom: batch size does not change the val set, so
+                # every payload config over one store must agree too.
+                check.observe(
+                    str(cfg.get("store") or cfg["geom"]),
+                    persistence,
+                    f"{cfg['geom']} repeat {repeat} [{row.get('run', '?')}]",
+                )
     out_fh.flush()
 
 
@@ -366,6 +429,7 @@ def main() -> None:
     ).stdout.strip()
     print(f"children import insitubatch from: {which}\n")
     seen_geom: set[str] = set()
+    check = PersistenceCheck()
     with args.out.open("a") as out_fh:
         for i, cfg in enumerate(configs):
             # One ceiling per geom (compute identity); the report joins every config to it.
@@ -391,9 +455,12 @@ def main() -> None:
                     extra["MiB/buffer"] = round(buffer_mib(cfg["size"], cfg["batch_size"]), 1)
                     extra["MiB/step"] = round(step_mib(cfg["size"], cfg["batch_size"]), 1)
                 print(f"=== {label} repeat {r + 1}/{args.repeats} {extra} ceiling={do_ceiling} ===")
-                _run_config(cmd, cfg, r, out_fh, env=env, arm=arm)
+                _run_config(cmd, cfg, r, out_fh, env=env, arm=arm, check=check)
     print(f"\nwrote sweep rows -> {args.out}")
     print(f"aggregate with: uv run python -m bench.advection_report --in {args.out}")
+    if not check.report():
+        # Non-zero so an unattended sweep cannot hand back numbers measured on bad batches.
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/bench/advection_sweep.py
+++ b/bench/advection_sweep.py
@@ -31,6 +31,21 @@ The sweeps, and the claim each one confirms:
 The compute-only ceiling depends only on the field geometry (the conv cost), not on
 inflight / chunking / cache, so ``--ceiling`` is run exactly once per distinct ``geom`` and the
 report matches every insitu config to its geom's ceiling.
+
+``--child-package`` A/Bs a change to the *library* by putting another checkout's ``src/`` ahead
+of the installed one, so both arms share this checkout's example code, interpreter and torch --
+only insitubatch differs. **Point it at a checkout that differs solely in the change under
+test.** Pointing it at ``main`` does not work and is not what it is for: main predates the
+examples' own API (``to_torch(..., device=...)``, ``pin_host_buffers``), so the child fails to
+import, and even where it imports, main differs in several changes at once. For the batch-buffer
+reuse arm, branch off this checkout and revert only the ``gather`` call site::
+
+    git worktree add -b bench/no-reuse-arm ../ib-noreuse batch-buffer-ring
+    # in that worktree, pool.gather: out = np.empty((n, *out_geom.inner_shape), ...)
+    uv run python -m bench.advection_sweep --sweeps payload --child-package ../ib-noreuse ...
+
+Every row records ``child_package``, so the two files an A/B produces cannot be confused after
+the fact.
 """
 
 from __future__ import annotations
@@ -38,6 +53,7 @@ from __future__ import annotations
 import argparse
 import inspect
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -191,10 +207,63 @@ def _command(
     return cmd
 
 
-def _run_config(cmd: list[str], cfg: dict[str, Any], repeat: int, out_fh: Any) -> None:
+def child_env(child_package: str | None) -> dict[str, str] | None:
+    """Environment for the child, optionally importing insitubatch from another checkout.
+
+    Swapping the library by ``PYTHONPATH`` rather than by running the child in its own uv
+    environment (which is how ``batch_buffer_sweep.py`` does it) is deliberate: the arms of an
+    A/B differ *only* in insitubatch. An ephemeral environment would resolve its own torch, and
+    a benchmark whose two arms ran different torch builds would be measuring that instead. Here
+    the interpreter, torch, numpy and the example code are all shared; ``src/`` simply precedes
+    site-packages, so ``import insitubatch`` finds the other checkout.
+    """
+    if not child_package:
+        return None
+    src = Path(child_package).expanduser().resolve() / "src"
+    if not (src / "insitubatch" / "__init__.py").exists():
+        raise SystemExit(f"--child-package {child_package}: no insitubatch package under {src}")
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(p for p in (str(src), env.get("PYTHONPATH", "")) if p)
+    return env
+
+
+def _check_arm(out: Path, arm: dict[str, Any], p: argparse.ArgumentParser) -> None:
+    """Refuse to append one arm's rows onto another's.
+
+    Output is opened in append mode so a sweep can be resumed or extended, which also means two
+    arms written to one path silently merge -- and because both number their repeats from zero,
+    the report then medians across arms and prints a blend that looks like a clean result. That
+    happened once; the cost was a full A/B. An arm is identified by what distinguishes it
+    (``--pin``, ``--child-package``), and rows carry it, so the mismatch is detectable.
+    """
+    if not out.exists() or out.stat().st_size == 0:
+        return
+    with out.open() as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            existing = {"pin": row.get("pin", False), "child_package": row.get("child_package", "")}
+            if existing != arm:
+                p.error(
+                    f"{out} already holds rows from a different arm ({existing}); this run is "
+                    f"{arm}. Two arms in one file merge on repeat index and the report medians "
+                    f"across them. Write this arm to its own --out."
+                )
+            break  # one row settles it; the guard above keeps a file single-armed
+
+
+def _run_config(
+    cmd: list[str],
+    cfg: dict[str, Any],
+    repeat: int,
+    out_fh: Any,
+    env: dict[str, str] | None = None,
+    arm: dict[str, Any] | None = None,
+) -> None:
     """Run one child, tag its rows with the config + repeat, append to the combined file."""
     with tempfile.NamedTemporaryFile("r+", suffix=".jsonl") as tmp:
-        subprocess.run([*cmd, "--metrics-out", tmp.name], check=True)
+        subprocess.run([*cmd, "--metrics-out", tmp.name], check=True, env=env)
         tmp.seek(0)
         for line in tmp:
             if not line.strip():
@@ -202,6 +271,9 @@ def _run_config(cmd: list[str], cfg: dict[str, Any], repeat: int, out_fh: Any) -
             row = json.loads(line)
             row["config"] = cfg
             row["repeat"] = repeat
+            # Stamped on every row: an A/B lives in two files that are indistinguishable
+            # afterwards otherwise, and mixing them up is silent.
+            row.update(arm or {})
             out_fh.write(json.dumps(row) + "\n")
     out_fh.flush()
 
@@ -231,6 +303,15 @@ def main() -> None:
         "--pin",
         action="store_true",
         help="page-lock batch buffers in the insitu runs (not the ceiling); A/B for pinning",
+    )
+    p.add_argument(
+        "--child-package",
+        default=None,
+        metavar="PATH",
+        help="run the children against another insitubatch checkout by putting its src/ ahead of "
+        "the installed one. The A/B arm for changes to the library itself -- identical example "
+        "code, interpreter and torch on both sides. Point it at a checkout differing only in the "
+        "change under test, NOT at main (whose API predates the examples' calls)",
     )
     p.add_argument(
         "--payload-batch-sizes",
@@ -270,6 +351,20 @@ def main() -> None:
                 f"would be clipped to {block_rows} and land on another config's payload"
             )
     args.out.parent.mkdir(parents=True, exist_ok=True)
+    arm = {"pin": bool(args.pin), "child_package": args.child_package or ""}
+    _check_arm(args.out, arm, p)
+    env = child_env(args.child_package)
+    # Print which insitubatch the children will actually import, before spending an hour on
+    # runs. A PYTHONPATH swap that silently did not take would produce two identical arms and
+    # an A/B that reads as "no effect".
+    which = subprocess.run(
+        [sys.executable, "-c", "import insitubatch; print(insitubatch.__file__)"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    print(f"children import insitubatch from: {which}\n")
     seen_geom: set[str] = set()
     with args.out.open("a") as out_fh:
         for i, cfg in enumerate(configs):
@@ -296,7 +391,7 @@ def main() -> None:
                     extra["MiB/buffer"] = round(buffer_mib(cfg["size"], cfg["batch_size"]), 1)
                     extra["MiB/step"] = round(step_mib(cfg["size"], cfg["batch_size"]), 1)
                 print(f"=== {label} repeat {r + 1}/{args.repeats} {extra} ceiling={do_ceiling} ===")
-                _run_config(cmd, cfg, r, out_fh)
+                _run_config(cmd, cfg, r, out_fh, env=env, arm=arm)
     print(f"\nwrote sweep rows -> {args.out}")
     print(f"aggregate with: uv run python -m bench.advection_report --in {args.out}")
 

--- a/bench/advection_sweep.py
+++ b/bench/advection_sweep.py
@@ -21,6 +21,12 @@ The sweeps, and the claim each one confirms:
   does the loader stay ahead as chunks shrink toward one-sample-per-read?
 * **inner** -- spatial fan-out (``inner_chunk``: one fat chunk -> a tiled grid). The ARCO norm;
   restores concurrency *within* a fat sample chunk.
+* **payload** -- bytes per batch (``batch_size`` over one 256^2 store: 8 -> 64 MiB per variable
+  buffer, 4x that per step). The axis the batch-buffer work acts on, and the one the ``size``
+  sweep cannot reach: reuse only pays above glibc's 32 MiB ``mmap`` threshold, which applies
+  per allocation, and pinning's saved transfer time scales with bytes moved. Run it twice, back
+  to back, with and without ``--pin`` -- absolute throughput is only comparable within a
+  session (see the metric warning in docs/benchmarks.md).
 
 The compute-only ceiling depends only on the field geometry (the conv cost), not on
 inflight / chunking / cache, so ``--ceiling`` is run exactly once per distinct ``geom`` and the
@@ -30,6 +36,7 @@ report matches every insitu config to its geom's ceiling.
 from __future__ import annotations
 
 import argparse
+import inspect
 import json
 import subprocess
 import sys
@@ -38,25 +45,67 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+from insitubatch import InSituDataset
+
 DEFAULT_OUT = Path(__file__).parent / "results" / "advection_sweep.jsonl"
 
 # n_steps for the synthetic sweep stores: enough chunks to split/shuffle and to make cloud IO
 # non-trivial, small enough to generate quickly. Overridable for a heavier run.
 SYNTH_STEPS = 4000
 
+# Payload sweep: batch sizes over the 256^2 store -> 8 / 16 / 32 / 64 MiB **per variable
+# buffer** (4x that per step across the four variables). Two points below glibc's 32 MiB mmap
+# threshold and two at or above it, since that threshold applies per allocation and the pool
+# lends one buffer per variable. Capped at 256 because the 0.8 train split of a 4000-step store
+# gives only 12 batches there -- fewer still and an epoch is too short to time.
+PAYLOAD_BATCH_SIZES = (32, 64, 128, 256)
+
+# Read from the engine rather than restated here, so the batch-clipping guard below cannot go
+# stale against it (the examples do not pass block_chunks, so they get this default).
+_BLOCK_CHUNKS: int = inspect.signature(InSituDataset).parameters["block_chunks"].default
+
 
 def _synth(size: int, sample_chunk: int, inner_chunk: int | None) -> dict[str, Any]:
-    """A synthetic-store config: its geom (compute identity) is the field size alone."""
+    """A synthetic-store config: its geom (compute identity) is the field size alone.
+
+    ``store`` is the *dataset* identity (which zarr store to read) and ``geom`` the *compute*
+    identity (which ceiling to score against). They coincide everywhere except the payload
+    sweep, which varies batch size over one store -- and a bigger batch is a different compute
+    step, so it needs its own ceiling while reading the same bytes.
+    """
     return {
         "source": "synthetic",
         "size": size,
         "sample_chunk": sample_chunk,
         "inner_chunk": inner_chunk,
+        "store": f"synth{size}",
         "geom": f"synth{size}",
     }
 
 
-def _configs(sweeps: set[str], *, wb2_range: str) -> Iterator[dict[str, Any]]:
+def buffer_mib(size: int, batch_size: int) -> float:
+    """MiB in **one variable's** batch buffer -- what the reuse cliff keys on.
+
+    The pool lends one buffer per variable per batch, so it is this number, not the step total,
+    that glibc compares against its 32 MiB ``mmap`` threshold. Matches the per-variable payload
+    column in docs/benchmarks.md.
+    """
+    return batch_size * size * size * 4 / 2**20
+
+
+def step_mib(size: int, batch_size: int, n_variables: int = 4) -> float:
+    """MiB crossing PCIe per step -- what pinning acts on.
+
+    All four f4 variables (t2m/u10/v10/target), which is what one ``to_torch(..., device=...)``
+    moves. Four times :func:`buffer_mib`, and the two axes are worth keeping apart: reuse is a
+    per-allocation effect, pinning a per-transfer one.
+    """
+    return n_variables * buffer_mib(size, batch_size)
+
+
+def _configs(
+    sweeps: set[str], *, wb2_range: str, payload_batch_sizes: tuple[int, ...] = PAYLOAD_BATCH_SIZES
+) -> Iterator[dict[str, Any]]:
     """Yield the insitu configs for the requested sweeps (ceiling is added per geom later).
 
     Each config is a dict of the knobs that vary; fixed knobs take the store/CLI defaults.
@@ -82,6 +131,16 @@ def _configs(sweeps: set[str], *, wb2_range: str) -> Iterator[dict[str, Any]]:
         # Spatial fan-out: one fat 128-chunk -> 64 (4 tiles) -> 32 (16 tiles), field size fixed.
         for ic in (128, 64, 32):
             yield {"sweep": "inner", **_synth(128, 64, ic)}
+    if "payload" in sweeps:
+        # Bytes per step, over ONE store (256^2) so only the batch changes: 8 -> 64 MiB, which
+        # straddles glibc's 32 MiB mmap threshold. This is the axis both batch-buffer changes
+        # act on -- reuse removes the re-zeroing cliff above the threshold, and pinning's saved
+        # transfer time scales with bytes -- and the only one the 0.5-8 MiB size sweep cannot
+        # reach. Each batch size gets its own geom: a bigger step is a different compute
+        # ceiling, so they must not share one.
+        for bs in payload_batch_sizes:
+            cfg = _synth(256, 64, None)
+            yield {**cfg, "sweep": "payload", "batch_size": bs, "geom": f"{cfg['store']}b{bs}"}
 
 
 def _command(
@@ -109,11 +168,15 @@ def _command(
     ]
     if cfg["source"] == "synthetic":
         inner = cfg["inner_chunk"] or cfg["size"]
-        url = f"{url_prefix}_{cfg['geom']}_c{cfg['sample_chunk']}_i{inner}.zarr"
+        # Keyed on `store`, not `geom`: the payload sweep gives each batch size its own geom
+        # (its own ceiling) while they all read the one store.
+        url = f"{url_prefix}_{cfg['store']}_c{cfg['sample_chunk']}_i{inner}.zarr"
         cmd += ["--url", url, "--n-steps", str(n_steps)]
         cmd += ["--size", str(cfg["size"]), "--sample-chunk", str(cfg["sample_chunk"])]
         if cfg["inner_chunk"] is not None:
             cmd += ["--inner-chunk", str(cfg["inner_chunk"])]
+    if cfg.get("batch_size") is not None:
+        cmd += ["--batch-size", str(cfg["batch_size"])]
     if cfg.get("sample_range"):
         cmd += ["--sample-range", cfg["sample_range"]]
     if cfg.get("max_inflight") is not None:
@@ -169,15 +232,25 @@ def main() -> None:
         action="store_true",
         help="page-lock batch buffers in the insitu runs (not the ceiling); A/B for pinning",
     )
+    p.add_argument(
+        "--payload-batch-sizes",
+        type=lambda s: tuple(int(x) for x in s.split(",")),
+        default=PAYLOAD_BATCH_SIZES,
+        metavar="N,N,...",
+        help=f"batch sizes for the payload sweep (default {','.join(map(str, PAYLOAD_BATCH_SIZES))}"
+        "); bigger needs a longer --n-steps to keep an epoch worth timing",
+    )
     p.add_argument("--out", type=Path, default=DEFAULT_OUT)
     args = p.parse_args()
 
     sweeps = {s.strip() for s in args.sweeps.split(",") if s.strip()}
-    unknown = sweeps - {"inflight", "size", "chunk", "inner"}
+    unknown = sweeps - {"inflight", "size", "chunk", "inner", "payload"}
     if unknown:
         p.error(f"unknown sweeps: {sorted(unknown)}")
 
-    configs = list(_configs(sweeps, wb2_range=args.wb2_range))
+    configs = list(
+        _configs(sweeps, wb2_range=args.wb2_range, payload_batch_sizes=args.payload_batch_sizes)
+    )
     # A 0.8/0.1/0.1 split needs >=3 sample-axis chunks, so the synthetic trajectory must be a
     # few chunks long; catch a too-short --n-steps here rather than as an empty-val crash later.
     for cfg in configs:
@@ -185,6 +258,16 @@ def main() -> None:
             p.error(
                 f"--n-steps {args.n_steps} too short for sample_chunk {cfg['sample_chunk']} "
                 f"(need >= 3 chunks to split; use --n-steps >= {3 * cfg['sample_chunk']})"
+            )
+        # A batch never crosses a shuffle block, so an oversized batch_size is silently clipped
+        # to the block -- which on the payload sweep would collapse two payload points onto one
+        # while still labelling them apart. Fail instead.
+        block_rows = _BLOCK_CHUNKS * cfg.get("sample_chunk", 0)
+        if cfg.get("batch_size") is not None and cfg["batch_size"] > block_rows:
+            p.error(
+                f"batch_size {cfg['batch_size']} exceeds the shuffle block "
+                f"({_BLOCK_CHUNKS} chunks x {cfg['sample_chunk']} = {block_rows} rows); it "
+                f"would be clipped to {block_rows} and land on another config's payload"
             )
     args.out.parent.mkdir(parents=True, exist_ok=True)
     seen_geom: set[str] = set()
@@ -209,6 +292,9 @@ def main() -> None:
                 extra = {
                     k: cfg[k] for k in ("max_inflight", "sample_chunk", "inner_chunk") if k in cfg
                 }
+                if cfg.get("batch_size") is not None:
+                    extra["MiB/buffer"] = round(buffer_mib(cfg["size"], cfg["batch_size"]), 1)
+                    extra["MiB/step"] = round(step_mib(cfg["size"], cfg["batch_size"]), 1)
                 print(f"=== {label} repeat {r + 1}/{args.repeats} {extra} ceiling={do_ceiling} ===")
                 _run_config(cmd, cfg, r, out_fh)
     print(f"\nwrote sweep rows -> {args.out}")

--- a/bench/advection_sweep.py
+++ b/bench/advection_sweep.py
@@ -26,17 +26,35 @@ The sweeps, and the claim each one confirms:
   sweep cannot reach: reuse only pays above glibc's 32 MiB ``mmap`` threshold, which applies
   per allocation, and pinning's saved transfer time scales with bytes moved.
 
-**Comparing arms across sessions: use the ceilings, not samples/s.** Absolute throughput
-drifts with the box -- measured, two unpinned sessions 14 h apart differed by 0.6%. The
-ceiling is the instrument that survives that, because it replays RAM batches through the same
-model with no IO at all, so across arms it varies only by what the arm changed. Two readings
-back that up: the pinned ceiling ran 2.0-2.3% above both unpinned ones (8 minutes apart, so
-drift cannot explain it -- pinning is real at ~2.2%), while reuse vs no-reuse came out within
-+-0.2 pp of ceiling with the sign flipping (a null: the loop is at 99.5-100% of compute
-ceiling, so allocation cost has nowhere to show up). Score each arm against **its own**
-in-session ceiling and the drift divides out; compare raw samples/s across sessions and it
-does not. The earlier "+2.3% from pinning" was first read off raw samples/s and was not
-established until the third session bracketed the drift.
+**Drift is the dominant error term -- bracket it or do not quote the number.** Absolute
+throughput moves with the box on an unchanged checkout: an A/B/A at batch 128 (unpinned,
+pinned, unpinned, back to back) read 145.4 / 146.6 / 143.4 samples/s, so the two *identical*
+unpinned blocks differed by 1.4% about 20 minutes apart -- systematically, since each block's
+own repeats agreed to +-0.3. Any single back-to-back pair therefore carries roughly +-0.7% of
+drift, which is the same size as the effects being measured. Run the control arm **twice,
+before and after**, and read the treatment against their interpolation.
+
+That is how the two published numbers were arrived at, and it is worth seeing what it costs:
+
+* **Pinning: +1 to +2%.** The A/B/A above fits a 1.0 samples/s per-block decline, putting the
+  unpinned baseline at 144.4 in the pinned slot against an actual 146.6 -- **+1.5%**, with the
+  drift-model bounds running +0.8% (``b-a``) to +2.2% (``b-c``). A separate cross-session
+  ceiling comparison read +2.0-2.3%. Both agree on the sign and disagree on magnitude by about
+  1.5x, which is what an uncontrolled 0.7% drift term buys you. Quote the range.
+* **Reuse: null.** Scored against each arm's own in-session ceiling, reuse and no-reuse came in
+  at 99.69/99.92/99.74% versus 99.49/99.72/99.92% for 8/16/32 MiB per buffer -- inside +-0.2 pp
+  with the sign flipping. The loop sits at 99.5-100% of compute ceiling, so allocation cost has
+  nowhere to surface, *including* at 32 MiB where the ``mmap`` path demonstrably engages.
+
+Note the two use different instruments, and the reason matters. Reuse changes only the loader,
+so ``% of ceiling`` isolates it and divides the drift out. Pinning changes a copy **both** the
+loader and the ceiling perform -- ``--pin`` reaches the ceiling too, since ``pin_host_buffers``
+runs before ``preload_epoch`` -- so ``% of ceiling`` cancels the very effect being measured and
+only bracketed absolute throughput will do.
+
+The no-reuse arm no longer needs ``--child-package`` and a hand-reverted checkout: set
+``INSITUBATCH_NO_BUFFER_REUSE=1`` on the run instead. Identical code both sides, and the epoch
+log stamps ``REUSE OFF`` so the rows cannot be mistaken for a normal run later.
 
 The compute-only ceiling depends only on the field geometry (the conv cost), not on
 inflight / chunking / cache, so ``--ceiling`` is run exactly once per distinct ``geom`` and the

--- a/bench/advection_sweep.py
+++ b/bench/advection_sweep.py
@@ -346,7 +346,7 @@ def main() -> None:
     p.add_argument(
         "--sweeps",
         default="inflight,size,chunk",
-        help="comma list of: inflight,size,chunk,inner",
+        help="comma list of: inflight,size,chunk,inner,payload",
     )
     p.add_argument(
         "--url-prefix",

--- a/bench/advection_sweep.py
+++ b/bench/advection_sweep.py
@@ -187,6 +187,26 @@ def _configs(
             yield {**cfg, "sweep": "payload", "batch_size": bs, "geom": f"{cfg['store']}b{bs}"}
 
 
+def store_key(cfg: dict[str, Any]) -> str:
+    """Which zarr a config reads -- the identity both the URL and the persistence check use.
+
+    Deliberately one function rather than two expressions. It is keyed on ``store`` rather than
+    ``geom`` because the payload sweep gives each batch size its own geom (hence its own
+    ceiling) while they all read one store; and it carries ``sample_chunk`` / ``inner_chunk``
+    because those are written into the store, so configs differing in them are *different
+    data*, not the same data read differently.
+
+    That last part was a bug. The check keyed on ``store`` alone while the URL included the
+    chunking, so ``--sweeps chunk`` collapsed four stores onto one baseline. Splits are
+    chunk-aligned, so a different ``sample_chunk`` gives a different val set and a legitimately
+    different persistence RMSE -- the run would have been failed for reading exactly the data
+    it was asked to read. A false alarm is expensive on a check whose only value is being
+    trusted, so URL and key now come from here and cannot drift apart again.
+    """
+    inner = cfg["inner_chunk"] or cfg["size"]
+    return f"{cfg['store']}_c{cfg['sample_chunk']}_i{inner}"
+
+
 def _command(
     cfg: dict[str, Any],
     *,
@@ -211,10 +231,7 @@ def _command(
         str(epochs),
     ]
     if cfg["source"] == "synthetic":
-        inner = cfg["inner_chunk"] or cfg["size"]
-        # Keyed on `store`, not `geom`: the payload sweep gives each batch size its own geom
-        # (its own ceiling) while they all read the one store.
-        url = f"{url_prefix}_{cfg['store']}_c{cfg['sample_chunk']}_i{inner}.zarr"
+        url = f"{url_prefix}_{store_key(cfg)}.zarr"
         cmd += ["--url", url, "--n-steps", str(n_steps)]
         cmd += ["--size", str(cfg["size"]), "--sample-chunk", str(cfg["sample_chunk"])]
         if cfg["inner_chunk"] is not None:
@@ -359,10 +376,12 @@ def _run_config(
             persistence = row.get("val_persistence_rmse")
             # Only the final row of each run carries it; NaN elsewhere (NaN != NaN filters).
             if check is not None and isinstance(persistence, float) and persistence == persistence:
-                # Keyed by the store, not the geom: batch size does not change the val set, so
-                # every payload config over one store must agree too.
+                # The same identity the URL is built from, so configs that read one zarr are
+                # held to one baseline and configs that read different zarrs are not compared.
+                # Batch size is absent from it on purpose: it does not change the val set, so
+                # every payload config over one store must agree.
                 check.observe(
-                    str(cfg.get("store") or cfg["geom"]),
+                    store_key(cfg) if cfg["source"] == "synthetic" else str(cfg["geom"]),
                     persistence,
                     f"{cfg['geom']} repeat {repeat} [{row.get('run', '?')}]",
                 )

--- a/bench/advection_sweep.py
+++ b/bench/advection_sweep.py
@@ -92,6 +92,7 @@ def _command(
     epochs: int,
     n_steps: int,
     ceiling: bool,
+    pin: bool = False,
 ) -> list[str]:
     """Build the child ``train_torch_metrics`` command for one config (``--metrics-out`` is
     appended per run by :func:`_run_config`)."""
@@ -119,6 +120,11 @@ def _command(
         cmd += ["--max-inflight", str(cfg["max_inflight"])]
     if ceiling:
         cmd += ["--ceiling"]
+    if pin:
+        # Unconditional, including on the runs that also collect the ceiling: `--ceiling`
+        # *adds* a second fit rather than replacing the insitu one, so gating on it would
+        # leave the first repeat of every geom unpinned while the rest were pinned.
+        cmd += ["--pin"]
     return cmd
 
 
@@ -158,6 +164,11 @@ def main() -> None:
     p.add_argument(
         "--wb2-range", default="0,4000", metavar="START,STOP", help="WB2 time window for --inflight"
     )
+    p.add_argument(
+        "--pin",
+        action="store_true",
+        help="page-lock batch buffers in the insitu runs (not the ceiling); A/B for pinning",
+    )
     p.add_argument("--out", type=Path, default=DEFAULT_OUT)
     args = p.parse_args()
 
@@ -188,6 +199,7 @@ def main() -> None:
                 cmd = _command(
                     cfg,
                     url_prefix=args.url_prefix,
+                    pin=args.pin,
                     device=args.device,
                     epochs=args.epochs,
                     n_steps=args.n_steps,

--- a/bench/batch_buffer_sweep.py
+++ b/bench/batch_buffer_sweep.py
@@ -11,11 +11,16 @@ surfaces end to end depends on whether IO is hiding it.
 fresh allocation falls off a cliff at 32 MiB. A single headline percentage hides that the
 small-batch end is a ~2-3% *regression*, which is a real trade-off rather than noise.
 
-``minor_faults`` is here because faulting a fresh page set is part of what a per-batch
-``mmap`` costs, but treat it as **environment-dependent**: it matched prediction closely on
-one host (678k vs 1039k for a 12-batch epoch of 128 MiB batches, ~328k predicted) and did not
-separate at all on another under the same nominal config. If it stays flat while throughput
-moves, believe the throughput and check the syscalls directly::
+What the cliff actually costs is the kernel **re-zeroing** the buffer: a fresh anonymous
+mapping arrives zeroed, so 12 batches of 128 MiB means 1.5 GiB zeroed per epoch that the pool
+never pays. On an L4 that predicted ~125 ms against a measured 122 ms gap -- consistent from
+an independent direction, and it scales with payload as observed.
+
+``minor_faults`` is recorded in the JSONL but **not printed**, because it counts *faults* and
+the kernel's folio size is host-dependent: the same 1.5 GiB read as a 360k-fault difference on
+a 6.8 kernel (4 KiB pages) and a 3.7k one on 6.17 (~512 KiB folios), with identical syscalls
+in both. Presenting it beside throughput is how this benchmark's mechanism was first
+misdiagnosed. To measure the mechanism, trace the syscalls::
 
     strace -f -e trace=mmap,munmap -o t.txt <child cmd>
     grep -c 'mmap(NULL, <batch_bytes+4096>, PROT_READ|PROT_WRITE' t.txt
@@ -230,16 +235,19 @@ def main() -> None:
             row = _run_child(_child_cmd(args, batch_size, ""), cfg, repeat, out_path)
             rows.append((batch_size, mib, row))
 
-    print(f"\n{'batch':>7}{'MiB':>9}{'samples/s':>12}{'minor faults':>14}{'rss anon MB':>13}")
+    # minor_faults stays in the JSONL but is deliberately *not* printed: it counts faults, and
+    # the kernel's folio size varies by host, so the same work reads as 393k faults on one
+    # machine and 4k on another. Presenting it next to throughput invited exactly the wrong
+    # mechanism conclusion once already. Use the strace recipe above to measure the mechanism.
+    print(f"\n{'batch':>7}{'MiB':>9}{'samples/s':>12}{'rss anon MB':>13}")
     for batch_size in args.batch_sizes:
         got = [r for bs, _m, r in rows if bs == batch_size and r]
         if not got:
             continue
         mib = batch_mib(batch_size, args.inner)
         sps = float(np.median([r["samples_per_s"] for r in got]))
-        flt = float(np.median([r.get("minor_faults", 0) for r in got]))
         rss = float(np.median([r.get("rss_anon_mb", 0.0) for r in got]))
-        print(f"{batch_size:>7}{mib:>9.1f}{sps:>12.1f}{flt:>14.0f}{rss:>13.1f}")
+        print(f"{batch_size:>7}{mib:>9.1f}{sps:>12.1f}{rss:>13.1f}")
     print(f"\n{len(rows)} rows -> {out_path}")
     if tmpdir is not None:
         tmpdir.cleanup()

--- a/bench/batch_buffer_sweep.py
+++ b/bench/batch_buffer_sweep.py
@@ -128,7 +128,13 @@ def _child(args: argparse.Namespace) -> None:
 
 def main() -> None:
     p = argparse.ArgumentParser(description="batch-buffer reuse sweep (payload-size crossover)")
-    p.add_argument("--url", default=None, help="existing store; omitted -> a temp one is built")
+    p.add_argument("--url", default=None, help="existing store; omitted -> one is built")
+    p.add_argument(
+        "--data-dir",
+        default=None,
+        help="where to build the store (point at NVMe). Reused across runs if the geometry "
+        "matches; omitted -> a temp dir, rebuilt every run",
+    )
     p.add_argument("--batch-sizes", type=_ints, default=list(DEFAULT_BATCH_SIZES))
     p.add_argument("--inner", type=_inner, default=DEFAULT_INNER, help="per-sample shape")
     p.add_argument("--n-samples", type=int, default=4096)
@@ -156,15 +162,29 @@ def main() -> None:
 
     tmpdir: tempfile.TemporaryDirectory[str] | None = None
     if args.url is None:
-        tmpdir = tempfile.TemporaryDirectory()
-        args.url = f"file://{tmpdir.name}/bb.zarr"
-        make_dataset(
-            args.url,
-            n_samples=args.n_samples,
-            inner=args.inner,
-            sample_chunk=args.sample_chunk,
-            variables=["t2m"],
-        )
+        # Name the store after its geometry so a rerun reuses it rather than rewriting GBs.
+        # Reuse is what makes an A/B valid, not merely fast: both arms must read the *same*
+        # store, or the comparison also contains whatever differs between two datasets.
+        shape = "x".join(str(x) for x in args.inner)
+        name = f"bb_n{args.n_samples}_{shape}_c{args.sample_chunk}.zarr"
+        if args.data_dir:
+            directory = Path(args.data_dir)
+            directory.mkdir(parents=True, exist_ok=True)
+        else:
+            tmpdir = tempfile.TemporaryDirectory()
+            directory = Path(tmpdir.name)
+        store = directory / name
+        args.url = f"file://{store}"
+        if store.exists():
+            print(f"reusing {args.url}")
+        else:
+            make_dataset(
+                args.url,
+                n_samples=args.n_samples,
+                inner=args.inner,
+                sample_chunk=args.sample_chunk,
+                variables=["t2m"],
+            )
 
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/bench/batch_buffer_sweep.py
+++ b/bench/batch_buffer_sweep.py
@@ -1,0 +1,197 @@
+"""Benchmark: what batch-buffer reuse is worth, as a function of payload size.
+
+``pool.gather`` lends a reused buffer per variable instead of allocating one per batch. The
+saving is not the allocation -- ``np.empty`` only reserves address space -- but the
+**first-touch page faults** on the scatter-write that follows. glibc recycles a freed block on
+the heap below its 32 MiB dynamic ``mmap`` threshold and ``mmap``/``munmap``s above it, so
+reuse is worth nothing for small batches and a third of assembly time for large ones. This
+sweeps batch size across that boundary on a real pipeline, which the isolated measurement in
+``probe_batch_buffers.py`` cannot do: reuse saves *producer-thread* time, and whether that
+shows up end to end depends on whether IO is hiding it.
+
+Two columns matter, and the second is the sensitive one. ``samples_per_s`` is the headline but
+goes quiet whenever the pipeline is IO-bound; ``minor_faults`` measures the mechanism directly
+and moves whether or not the time is visible. A run where faults drop sharply and throughput
+does not is not a null result -- it means this workload's assembly was already hidden behind
+IO, which is worth knowing and is *not* what a wall-clock-only benchmark would report.
+
+**One child process per config, always.** ``ru_minflt`` is cumulative, and glibc's threshold
+is itself stateful -- it rises once a large block has been freed -- so configs sharing a
+process would contaminate each other in exactly the dimension under measurement.
+
+    # local smoke test: seconds, well under the threshold, proves the plumbing
+    uv run python -m bench.batch_buffer_sweep --inner 32,32 --batch-sizes 8,32 \
+        --n-samples 512 --repeats 1
+
+    # the real run: 8 MiB -> 128 MiB per batch, crossing the cliff
+    uv run python -m bench.batch_buffer_sweep
+
+An A/B against a checkout without the pool needs no change here -- point ``--child-package``
+at another worktree and the same sweep measures it (see ``docs/benchmarks.md``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .engines import Cfg, run
+from .result import append_jsonl
+
+DEFAULT_OUT = Path(__file__).parent / "results" / "batch_buffers.jsonl"
+# 256x256 f4 = 256 KiB per sample, so these span ~8 MiB to ~128 MiB per batch -- two points
+# below glibc's 32 MiB threshold and three above, which is where the effect should appear.
+DEFAULT_BATCH_SIZES = (32, 64, 128, 256, 512)
+DEFAULT_INNER = (256, 256)
+
+
+def batch_mib(batch_size: int, inner: tuple[int, ...], itemsize: int = 4) -> float:
+    """MiB per batch -- the axis that actually decides whether reuse pays."""
+    return batch_size * int(np.prod(inner)) * itemsize / 2**20
+
+
+def _inner(text: str) -> tuple[int, ...]:
+    return tuple(int(x) for x in text.split(","))
+
+
+def _ints(text: str) -> list[int]:
+    return [int(x) for x in text.split(",")]
+
+
+def _child_cmd(args: argparse.Namespace, batch_size: int, out: str) -> list[str]:
+    """One config, one fresh interpreter. ``--child-package`` selects which insitubatch the
+    child imports, which is what lets the same sweep measure another worktree."""
+    cmd = [sys.executable]
+    if args.child_package:
+        cmd = ["uv", "run", "--no-project", "--with-editable", args.child_package, "python"]
+    return [
+        *cmd,
+        "-m",
+        "bench.batch_buffer_sweep",
+        "--child",
+        "--url",
+        args.url,
+        "--batch-sizes",
+        str(batch_size),
+        "--sample-chunk",
+        str(args.sample_chunk),
+        "--block-chunks",
+        str(args.block_chunks),
+        "--prefetch-depth",
+        str(args.prefetch_depth),
+        "--compute-ms",
+        str(args.compute_ms),
+        "--epochs",
+        str(args.epochs),
+        "--child-out",
+        out,
+    ]
+
+
+def _run_child(cmd: list[str], cfg: dict[str, Any], repeat: int, out_path: Path) -> dict[str, Any]:
+    """Run one child, tag its rows with the sweep config, append them, return the last row."""
+    with tempfile.NamedTemporaryFile("r+", suffix=".jsonl") as tmp:
+        subprocess.run([*cmd[:-1], tmp.name], check=True)
+        tmp.seek(0)
+        rows = [json.loads(line) for line in tmp if line.strip()]
+    for row in rows:
+        row["config"] = cfg
+        row["repeat"] = repeat
+        with out_path.open("a") as fh:
+            fh.write(json.dumps(row) + "\n")
+    return rows[-1] if rows else {}
+
+
+def _child(args: argparse.Namespace) -> None:
+    """Measure one config in this (fresh) process and write its rows."""
+    cfg = Cfg(
+        engine="insitu",
+        url=args.url,
+        storage="file",
+        sample_chunk=args.sample_chunk,
+        batch_size=args.batch_sizes[0],
+        block_chunks=args.block_chunks,
+        prefetch_depth=args.prefetch_depth,
+        compute_ms=args.compute_ms,
+        epochs=args.epochs,
+    )
+    for result in run(cfg):
+        append_jsonl(args.child_out, result)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="batch-buffer reuse sweep (payload-size crossover)")
+    p.add_argument("--url", default=None, help="existing store; omitted -> a temp one is built")
+    p.add_argument("--batch-sizes", type=_ints, default=list(DEFAULT_BATCH_SIZES))
+    p.add_argument("--inner", type=_inner, default=DEFAULT_INNER, help="per-sample shape")
+    p.add_argument("--n-samples", type=int, default=4096)
+    p.add_argument("--sample-chunk", type=int, default=8)
+    p.add_argument("--block-chunks", type=int, default=16)
+    p.add_argument("--prefetch-depth", type=int, default=2)
+    p.add_argument("--compute-ms", type=float, default=0.0)
+    p.add_argument("--epochs", type=int, default=1)
+    p.add_argument("--repeats", type=int, default=3)
+    p.add_argument("--out", default=str(DEFAULT_OUT))
+    p.add_argument(
+        "--child-package",
+        default=None,
+        help="path to another insitubatch checkout for the child to import (A/B vs main)",
+    )
+    p.add_argument("--child", action="store_true", help=argparse.SUPPRESS)
+    p.add_argument("--child-out", default=None, help=argparse.SUPPRESS)
+    args = p.parse_args()
+
+    if args.child:
+        _child(args)
+        return
+
+    from .make_dataset import make_dataset
+
+    tmpdir: tempfile.TemporaryDirectory[str] | None = None
+    if args.url is None:
+        tmpdir = tempfile.TemporaryDirectory()
+        args.url = f"file://{tmpdir.name}/bb.zarr"
+        make_dataset(
+            args.url,
+            n_samples=args.n_samples,
+            inner=args.inner,
+            sample_chunk=args.sample_chunk,
+            variables=["t2m"],
+        )
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    rows: list[tuple[int, float, dict[str, Any]]] = []
+    # Repeat-major so a slow drift in the machine spreads across batch sizes instead of
+    # landing entirely on the ones measured last.
+    for repeat in range(args.repeats):
+        for batch_size in args.batch_sizes:
+            mib = batch_mib(batch_size, args.inner)
+            cfg = {"inner": list(args.inner), "batch_size": batch_size, "batch_mib": mib}
+            row = _run_child(_child_cmd(args, batch_size, ""), cfg, repeat, out_path)
+            rows.append((batch_size, mib, row))
+
+    print(f"\n{'batch':>7}{'MiB':>9}{'samples/s':>12}{'minor faults':>14}{'rss anon MB':>13}")
+    for batch_size in args.batch_sizes:
+        got = [r for bs, _m, r in rows if bs == batch_size and r]
+        if not got:
+            continue
+        mib = batch_mib(batch_size, args.inner)
+        sps = float(np.median([r["samples_per_s"] for r in got]))
+        flt = float(np.median([r.get("minor_faults", 0) for r in got]))
+        rss = float(np.median([r.get("rss_anon_mb", 0.0) for r in got]))
+        print(f"{batch_size:>7}{mib:>9.1f}{sps:>12.1f}{flt:>14.0f}{rss:>13.1f}")
+    print(f"\n{len(rows)} rows -> {out_path}")
+    if tmpdir is not None:
+        tmpdir.cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/batch_buffer_sweep.py
+++ b/bench/batch_buffer_sweep.py
@@ -1,19 +1,28 @@
 """Benchmark: what batch-buffer reuse is worth, as a function of payload size.
 
-``pool.gather`` lends a reused buffer per variable instead of allocating one per batch. The
-saving is not the allocation -- ``np.empty`` only reserves address space -- but the
-**first-touch page faults** on the scatter-write that follows. glibc recycles a freed block on
-the heap below its 32 MiB dynamic ``mmap`` threshold and ``mmap``/``munmap``s above it, so
-reuse is worth nothing for small batches and a third of assembly time for large ones. This
-sweeps batch size across that boundary on a real pipeline, which the isolated measurement in
+``pool.gather`` lends a reused buffer per variable instead of allocating one per batch. Above
+glibc's 32 MiB dynamic ``mmap`` threshold a fresh batch is ``mmap``ed and ``munmap``ed *every
+batch*; below it the freed block is recycled on the heap and reuse buys nothing. This sweeps
+batch size across that boundary on a real pipeline, which the isolated measurement in
 ``probe_batch_buffers.py`` cannot do: reuse saves *producer-thread* time, and whether that
-shows up end to end depends on whether IO is hiding it.
+surfaces end to end depends on whether IO is hiding it.
 
-Two columns matter, and the second is the sensitive one. ``samples_per_s`` is the headline but
-goes quiet whenever the pipeline is IO-bound; ``minor_faults`` measures the mechanism directly
-and moves whether or not the time is visible. A run where faults drop sharply and throughput
-does not is not a null result -- it means this workload's assembly was already hidden behind
-IO, which is worth knowing and is *not* what a wall-clock-only benchmark would report.
+**Read the shape, not one number.** Reuse holds throughput flat across payload size while
+fresh allocation falls off a cliff at 32 MiB. A single headline percentage hides that the
+small-batch end is a ~2-3% *regression*, which is a real trade-off rather than noise.
+
+``minor_faults`` is here because faulting a fresh page set is part of what a per-batch
+``mmap`` costs, but treat it as **environment-dependent**: it matched prediction closely on
+one host (678k vs 1039k for a 12-batch epoch of 128 MiB batches, ~328k predicted) and did not
+separate at all on another under the same nominal config. If it stays flat while throughput
+moves, believe the throughput and check the syscalls directly::
+
+    strace -f -e trace=mmap,munmap -o t.txt <child cmd>
+    grep -c 'mmap(NULL, <batch_bytes+4096>, PROT_READ|PROT_WRITE' t.txt
+
+That count scales with batch count without the pool and stays flat with it, which is the
+mechanism measured rather than inferred. Ignore same-sized ``PROT_NONE ... MAP_NORESERVE``
+mappings -- those are allocator arena reservations and track thread count, not batches.
 
 **One child process per config, always.** ``ru_minflt`` is cumulative, and glibc's threshold
 is itself stateful -- it rises once a large block has been freed -- so configs sharing a

--- a/bench/batch_buffer_sweep.py
+++ b/bench/batch_buffer_sweep.py
@@ -40,8 +40,12 @@ process would contaminate each other in exactly the dimension under measurement.
     # the real run: 8 MiB -> 128 MiB per batch, crossing the cliff
     uv run python -m bench.batch_buffer_sweep
 
-An A/B against a checkout without the pool needs no change here -- point ``--child-package``
-at another worktree and the same sweep measures it (see ``docs/benchmarks.md``).
+**Run the no-reuse arm with** ``INSITUBATCH_NO_BUFFER_REUSE=1``, which switches ``take`` to a
+fresh allocation per call. That is the better control than the ``--child-package`` worktree
+this used to need: identical code on both sides, only the reuse decision differing, so a
+second checkout cannot silently drift from the one under test. Rows taken that way are
+identifiable afterwards -- the epoch log stamps ``REUSE OFF``. ``--child-package`` stays for
+what it is actually for, A/B-ing a *different* version of the library.
 """
 
 from __future__ import annotations

--- a/bench/batch_buffer_sweep.py
+++ b/bench/batch_buffer_sweep.py
@@ -52,6 +52,17 @@ DEFAULT_BATCH_SIZES = (32, 64, 128, 256, 512)
 DEFAULT_INNER = (256, 256)
 
 
+def effective_batch(batch_size: int, block_chunks: int, sample_chunk: int) -> int:
+    """Rows a batch actually gets: a batch never crosses a shuffle-block boundary.
+
+    ``source.py`` draws ``order[start : min(start + bs, rstop)]`` within one block, so a
+    ``batch_size`` larger than ``block_chunks * sample_chunk`` is silently clipped to it --
+    and this sweep's whole axis is batch *bytes*, so an unnoticed clip would collapse several
+    configs onto the same point while still labelling them apart.
+    """
+    return min(batch_size, block_chunks * sample_chunk)
+
+
 def batch_mib(batch_size: int, inner: tuple[int, ...], itemsize: int = 4) -> float:
     """MiB per batch -- the axis that actually decides whether reuse pays."""
     return batch_size * int(np.prod(inner)) * itemsize / 2**20
@@ -139,7 +150,9 @@ def main() -> None:
     p.add_argument("--inner", type=_inner, default=DEFAULT_INNER, help="per-sample shape")
     p.add_argument("--n-samples", type=int, default=4096)
     p.add_argument("--sample-chunk", type=int, default=8)
-    p.add_argument("--block-chunks", type=int, default=16)
+    # Must cover the largest batch: a batch never crosses a shuffle block, so a small value
+    # here silently clips the sweep's biggest configs onto one another.
+    p.add_argument("--block-chunks", type=int, default=64)
     p.add_argument("--prefetch-depth", type=int, default=2)
     p.add_argument("--compute-ms", type=float, default=0.0)
     p.add_argument("--epochs", type=int, default=1)
@@ -185,6 +198,16 @@ def main() -> None:
                 sample_chunk=args.sample_chunk,
                 variables=["t2m"],
             )
+
+    block_rows = args.block_chunks * args.sample_chunk
+    clipped = [b for b in args.batch_sizes if b > block_rows]
+    if clipped:
+        raise SystemExit(
+            f"--batch-sizes {clipped} exceed the shuffle block ({args.block_chunks} chunks x "
+            f"{args.sample_chunk} = {block_rows} rows). A batch never crosses a block, so these "
+            f"would all be clipped to {block_rows} rows and land on one point in the sweep. "
+            f"Raise --block-chunks to at least {max(args.batch_sizes) // args.sample_chunk}."
+        )
 
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/bench/engines.py
+++ b/bench/engines.py
@@ -34,7 +34,7 @@ from insitubatch.source import InSituDataset
 from insitubatch.types import ArrayGeometry
 
 from .backend import build_store
-from .result import Result, peak_rss_mb, rss_breakdown_mb
+from .result import Result, minor_faults, peak_rss_mb, rss_breakdown_mb
 
 
 @dataclass
@@ -113,6 +113,7 @@ def _result(
         peak_rss_mb=peak_rss_mb(),
         rss_anon_mb=anon,
         rss_file_mb=file,
+        minor_faults=minor_faults(),
     )
 
 

--- a/bench/ops_gcp.md
+++ b/bench/ops_gcp.md
@@ -401,7 +401,7 @@ gcloud compute instances create "$GPU_INSTANCE" \
   --machine-type=g2-standard-16 \
   --accelerator=type=nvidia-l4,count=1 \
   --maintenance-policy=TERMINATE \
-  --image-family=common-cu123-debian-11 --image-project=deeplearning-platform-release \
+  --image-family=common-cu129-ubuntu-2404-nvidia-580 --image-project=deeplearning-platform-release \
   --local-ssd=interface=NVME \
   --scopes=cloud-platform \
   --boot-disk-size=100GB

--- a/bench/probe_batch_buffers.py
+++ b/bench/probe_batch_buffers.py
@@ -150,14 +150,41 @@ def probe_h2d(case: Case, iters: int) -> tuple[float, float]:
     return timed(pageable), timed(pinned)
 
 
-def probe_overlap(case: Case, iters: int, compute_ms: float) -> tuple[float, float]:
-    """``(pageable_ms, pinned_ms)`` wall time for a copy *issued alongside compute*.
+class Load(NamedTuple):
+    """A fixed synthetic training step: ``reps`` matmuls of ``a @ b`` on the GPU.
 
-    The copy goes on a side stream while a matmul occupies the default stream, sized to
-    roughly ``compute_ms`` -- a stand-in for the training step the loader is meant to
-    hide behind. A pinned source DMAs straight off the page-locked pages and overlaps; a
-    pageable one is staged through a driver bounce buffer and serializes. If both arms
-    land at the compute time alone, the transfer is already hidden and pinning is moot.
+    Built **once** and shared by every case so the compute baseline is identical across
+    rows. Sizing it per case would let the measured single-matmul time jitter change
+    ``reps`` between rows, drifting the baseline and making the absolute wall times
+    incomparable (the within-row page-vs-pin delta would stay valid, but nothing else).
+    """
+
+    a: torch.Tensor
+    b: torch.Tensor
+    reps: int
+
+
+def make_load(compute_ms: float) -> Load:
+    """Size the synthetic compute load to roughly ``compute_ms`` per step."""
+    import torch
+
+    a = torch.randn(2048, 2048, device="cuda")
+    b = torch.randn(2048, 2048, device="cuda")
+    return Load(a, b, max(1, round(compute_ms / _gpu_ms(lambda: a @ b))))
+
+
+def probe_overlap(case: Case, iters: int, load: Load) -> tuple[float, float, float]:
+    """``(compute_only_ms, pageable_ms, pinned_ms)`` wall time for a copy *issued
+    alongside compute*.
+
+    The copy goes on a side stream while ``load``'s matmuls occupy the default stream --
+    a stand-in for the training step the loader is meant to hide behind. A pinned source
+    DMAs straight off the page-locked pages and overlaps; a pageable one is staged
+    through a driver bounce buffer and serializes.
+
+    ``compute_only_ms`` is the floor: the same step with no copy at all. An arm sitting
+    at the floor has its transfer fully hidden, so pinning cannot help it -- that
+    comparison is the point of the arm, and it needs the floor reported, not assumed.
     """
     import torch
 
@@ -166,17 +193,13 @@ def probe_overlap(case: Case, iters: int, compute_ms: float) -> tuple[float, flo
     pinned = torch.empty(case.shape, dtype=dtype, pin_memory=True)
     stream = torch.cuda.Stream()
 
-    # Size the synthetic load once so both arms contend with the same compute.
-    a = torch.randn(2048, 2048, device="cuda")
-    b = torch.randn(2048, 2048, device="cuda")
-    reps = max(1, round(compute_ms / _gpu_ms(lambda: a @ b)))
-
-    def run(src: torch.Tensor) -> float:
+    def run(src: torch.Tensor | None) -> float:
         def once() -> None:
-            with torch.cuda.stream(stream):
-                src.to("cuda", non_blocking=True)
-            for _ in range(reps):
-                a @ b
+            if src is not None:
+                with torch.cuda.stream(stream):
+                    src.to("cuda", non_blocking=True)
+            for _ in range(load.reps):
+                load.a @ load.b
             torch.cuda.synchronize()
 
         torch.cuda.synchronize()
@@ -184,7 +207,7 @@ def probe_overlap(case: Case, iters: int, compute_ms: float) -> tuple[float, flo
 
     run(pageable)
     run(pinned)
-    return run(pageable), run(pinned)
+    return run(None), run(pageable), run(pinned)
 
 
 def _gpu_ms(fn: Callable[[], object]) -> float:
@@ -287,17 +310,20 @@ def main() -> None:
         )
 
     if "overlap" in arms:
+        load = make_load(args.compute_ms)  # once, so every row shares one baseline
         rows = []
         for case in CASES:
-            page_ms, pin_ms = probe_overlap(case, max(10, args.iters // 5), args.compute_ms)
+            base_ms, page_ms, pin_ms = probe_overlap(case, max(10, args.iters // 5), load)
             pct = 100 * (page_ms - pin_ms) / page_ms if page_ms else 0.0
             rows.append(
-                f"{case.name:<28}{case.mib:>9.1f}{page_ms:>10.3f}{pin_ms:>10.3f}"
-                f"{page_ms - pin_ms:>10.3f}{pct:>7.1f}%"
+                f"{case.name:<28}{case.mib:>9.1f}{base_ms:>10.3f}{page_ms:>10.3f}"
+                f"{pin_ms:>10.3f}{page_ms - pin_ms:>10.3f}{pct:>7.1f}%"
             )
         _report(
-            f"overlap -- copy issued against ~{args.compute_ms:.0f}ms of compute (wall time)",
-            f"{'case':<28}{'MiB':>9}{'page ms':>10}{'pin ms':>10}{'saved':>10}{'saved':>8}",
+            f"overlap -- copy issued against ~{args.compute_ms:.0f}ms of compute (wall time);"
+            " an arm at 'compute' has its copy fully hidden",
+            f"{'case':<28}{'MiB':>9}{'compute':>10}{'page ms':>10}{'pin ms':>10}"
+            f"{'saved':>10}{'saved':>8}",
             rows,
         )
 

--- a/bench/probe_batch_buffers.py
+++ b/bench/probe_batch_buffers.py
@@ -258,7 +258,15 @@ class JaxCheck(NamedTuple):
     aligned_zero_copy: int  # ...and of `trials` 128-byte-aligned ones
     keeps_alive: bool  # when it DOES alias, JAX holds the source alive (what the poll needs)
     race_observed: bool | None  # device_put still reading our buffer after it returned
-    poll_insufficient: bool | None  # ...*and* the weakref already dead -> reuse unsafe
+    holds_source: bool | None  # JAX itself keeps the source referenced across the transfer
+
+    @property
+    def poll_insufficient(self) -> bool | None:
+        """An async transfer JAX does *not* hold the source across -> the poll can hand a
+        buffer back mid-DMA, and the JAX path must opt out of reuse entirely."""
+        if self.race_observed is None or self.holds_source is None:
+            return None
+        return self.race_observed and not self.holds_source
 
 
 def probe_jax(trials: int) -> JaxCheck:
@@ -284,13 +292,14 @@ def probe_jax(trials: int) -> JaxCheck:
     never proof of safety.
 
     An async copy alone only rules out *pinning*. What decides whether **reuse** is safe is
-    whether JAX holds the source alive for the duration of its own transfer: the trial drops
-    every reference the consumer would have dropped and checks the weakref *before* forcing
-    the copy to finish. Racing while the weakref is already dead (``poll_insufficient``) means
-    the pool's liveness poll can hand a buffer back mid-DMA, and the JAX path must opt out of
-    reuse entirely rather than merely skip pinning.
+    whether JAX holds the source itself across its transfer -- and that is asked separately,
+    because it needs no race: drop every reference the consumer would drop and see whether the
+    buffer is now unreferenced. Keeping the two in one loop is what broke an earlier version
+    of this probe, where a ``gc.collect()`` added for the second question let the DMA drain
+    and silently hid the first. An async transfer JAX does *not* hold across
+    (``poll_insufficient``) means the pool's poll can hand a buffer back mid-DMA, and the JAX
+    path must opt out of reuse entirely rather than merely skip pinning.
     """
-    import gc
     import weakref
 
     try:
@@ -326,34 +335,42 @@ def probe_jax(trials: int) -> JaxCheck:
 
     gpus = [d for d in jax.devices() if d.platform == "gpu"]
     race: bool | None = None
-    poll_insufficient: bool | None = None
+    holds_source: bool | None = None
     if gpus:
         # Big buffer: the wider the copy, the wider the window a race can be seen in.
         big = Case("jax-race", 8, (2, 32, 512, 512), np.dtype("f4"))
-        race = poll_insufficient = False
+
+        # (1) Is the transfer async? Nothing between `device_put` and the scribble but the
+        # scribble -- any bookkeeping here (a gc pass especially) lets the DMA drain first
+        # and hides the very thing being measured.
+        race = False
         for _ in range(trials):
             host = aligned_empty(big.shape, big.dtype)
             host.fill(0.0)
-            src = host[: big.batch]
-            ref = weakref.ref(src)
-            on_device = jax.device_put(jnp.from_dlpack(src), gpus[0])
-
-            # Drop every reference *we* hold, exactly as the consumer loop does when it
-            # moves on. If JAX keeps the source alive for the duration of its own transfer,
-            # the weakref survives here and the pool's poll is sound; if it dies while the
-            # copy is still reading, the poll would hand the buffer back mid-DMA.
-            del src
-            gc.collect()
-            released_early = ref() is None
-
-            host.fill(7.0)  # scribble the source the instant device_put returned
+            on_device = jax.device_put(jnp.from_dlpack(host[: big.batch]), gpus[0])
+            host.fill(7.0)
             # ravel: the case is (batch, *inner) and so rank 5 -- read element 0 without
             # having to spell every axis. The read is what forces the transfer to finish.
-            raced = float(on_device.ravel()[0]) == 7.0
-            race |= raced
-            poll_insufficient |= raced and released_early
-            if poll_insufficient:
+            if float(on_device.ravel()[0]) == 7.0:
+                race = True
                 break
+
+        # (2) Does JAX hold the source itself? This is the question that decides whether the
+        # pool's poll is sound, and it needs no race at all: drop every reference the
+        # consumer would drop and ask whether the buffer is now unreferenced. CPython frees
+        # non-cyclic objects on the last decref, so a surviving weakref means JAX is holding
+        # it -- deterministic, where racing the DMA is not.
+        holds_source = True
+        for _ in range(trials):
+            host = aligned_empty(big.shape, big.dtype)
+            src = host[: big.batch]
+            ref = weakref.ref(src)
+            keep = jax.device_put(jnp.from_dlpack(src), gpus[0])
+            del src
+            if ref() is None:  # nobody but us was holding it
+                holds_source = False
+                break
+            del keep
     return JaxCheck(
         backend=jax.default_backend(),
         device=device,
@@ -362,7 +379,7 @@ def probe_jax(trials: int) -> JaxCheck:
         aligned_zero_copy=aligned_hits,
         keeps_alive=keeps_alive,
         race_observed=race,
-        poll_insufficient=poll_insufficient,
+        holds_source=holds_source,
     )
 
 
@@ -565,17 +582,24 @@ def main() -> None:
         jc = probe_jax(args.iters)
         if jc.race_observed is None:
             transfer = "no GPU backend present -- device transfer untested"
+            holds = "untested"
             reuse_verdict = "untested"
-        elif jc.race_observed:
-            transfer = "ASYNC RACE -- device_put keeps reading our buffer after returning"
-            reuse_verdict = (
-                "UNSAFE -- weakref died mid-DMA; JAX must opt out of reuse"
-                if jc.poll_insufficient
-                else "ok -- JAX holds the source alive for its own transfer (pinning still out)"
-            )
         else:
-            transfer = f"no race in {jc.trials} trials (absence of evidence, not safety)"
-            reuse_verdict = "ok -- no async read observed"
+            transfer = (
+                "ASYNC -- device_put keeps reading our buffer after returning"
+                if jc.race_observed
+                else f"no race in {jc.trials} trials (absence of evidence, not safety)"
+            )
+            holds = (
+                "yes -- JAX references the source across its transfer"
+                if jc.holds_source
+                else "NO -- source is unreferenced the moment we drop it"
+            )
+            reuse_verdict = (
+                "UNSAFE -- async transfer JAX does not hold; JAX must opt out of reuse"
+                if jc.poll_insufficient
+                else "ok -- the poll covers it"
+            )
         _report(
             "jax -- does the pool's liveness poll hold for the JAX adapter?",
             "",
@@ -587,6 +611,7 @@ def main() -> None:
                 "   <- what an aligned pool would give",
                 f"  keeps source alive      {jc.keeps_alive}   <- what the poll needs",
                 f"  device transfer         {transfer}",
+                f"  JAX holds the source    {holds}   <- deterministic, unlike the race",
                 f"  reuse under the poll    {reuse_verdict}",
             ],
         )

--- a/bench/probe_batch_buffers.py
+++ b/bench/probe_batch_buffers.py
@@ -257,7 +257,8 @@ class JaxCheck(NamedTuple):
     default_zero_copy: int  # of `trials` np.empty buffers, how many JAX aliased
     aligned_zero_copy: int  # ...and of `trials` 128-byte-aligned ones
     keeps_alive: bool  # when it DOES alias, JAX holds the source alive (what the poll needs)
-    race_observed: bool | None  # None = no GPU backend present to test
+    race_observed: bool | None  # device_put still reading our buffer after it returned
+    poll_insufficient: bool | None  # ...*and* the weakref already dead -> reuse unsafe
 
 
 def probe_jax(trials: int) -> JaxCheck:
@@ -278,10 +279,18 @@ def probe_jax(trials: int) -> JaxCheck:
 
     The last check probes the unguardable gap: ``device_put`` to the GPU, immediately scribble
     the host buffer, then read the device array back. Seeing the scribble means the transfer
-    was still reading our memory after ``device_put`` returned -- an async copy we cannot
-    guard, which would rule out pinning on the JAX path. It is a **race** detector, so a clean
-    run is "not observed in N trials", never proof of safety.
+    was still reading our memory after ``device_put`` returned -- an async copy we have no
+    event to wait on. It is a **race** detector, so a clean run is "not observed in N trials",
+    never proof of safety.
+
+    An async copy alone only rules out *pinning*. What decides whether **reuse** is safe is
+    whether JAX holds the source alive for the duration of its own transfer: the trial drops
+    every reference the consumer would have dropped and checks the weakref *before* forcing
+    the copy to finish. Racing while the weakref is already dead (``poll_insufficient``) means
+    the pool's liveness poll can hand a buffer back mid-DMA, and the JAX path must opt out of
+    reuse entirely rather than merely skip pinning.
     """
+    import gc
     import weakref
 
     try:
@@ -317,19 +326,33 @@ def probe_jax(trials: int) -> JaxCheck:
 
     gpus = [d for d in jax.devices() if d.platform == "gpu"]
     race: bool | None = None
+    poll_insufficient: bool | None = None
     if gpus:
         # Big buffer: the wider the copy, the wider the window a race can be seen in.
         big = Case("jax-race", 8, (2, 32, 512, 512), np.dtype("f4"))
-        race = False
+        race = poll_insufficient = False
         for _ in range(trials):
             host = aligned_empty(big.shape, big.dtype)
             host.fill(0.0)
-            on_device = jax.device_put(jnp.from_dlpack(host[: big.batch]), gpus[0])
-            host.fill(7.0)  # scribble the source the instant device_put returns
+            src = host[: big.batch]
+            ref = weakref.ref(src)
+            on_device = jax.device_put(jnp.from_dlpack(src), gpus[0])
+
+            # Drop every reference *we* hold, exactly as the consumer loop does when it
+            # moves on. If JAX keeps the source alive for the duration of its own transfer,
+            # the weakref survives here and the pool's poll is sound; if it dies while the
+            # copy is still reading, the poll would hand the buffer back mid-DMA.
+            del src
+            gc.collect()
+            released_early = ref() is None
+
+            host.fill(7.0)  # scribble the source the instant device_put returned
             # ravel: the case is (batch, *inner) and so rank 5 -- read element 0 without
             # having to spell every axis. The read is what forces the transfer to finish.
-            if float(on_device.ravel()[0]) == 7.0:
-                race = True
+            raced = float(on_device.ravel()[0]) == 7.0
+            race |= raced
+            poll_insufficient |= raced and released_early
+            if poll_insufficient:
                 break
     return JaxCheck(
         backend=jax.default_backend(),
@@ -339,6 +362,7 @@ def probe_jax(trials: int) -> JaxCheck:
         aligned_zero_copy=aligned_hits,
         keeps_alive=keeps_alive,
         race_observed=race,
+        poll_insufficient=poll_insufficient,
     )
 
 
@@ -541,10 +565,17 @@ def main() -> None:
         jc = probe_jax(args.iters)
         if jc.race_observed is None:
             transfer = "no GPU backend present -- device transfer untested"
+            reuse_verdict = "untested"
         elif jc.race_observed:
-            transfer = "ASYNC RACE OBSERVED -- device_put keeps reading our buffer"
+            transfer = "ASYNC RACE -- device_put keeps reading our buffer after returning"
+            reuse_verdict = (
+                "UNSAFE -- weakref died mid-DMA; JAX must opt out of reuse"
+                if jc.poll_insufficient
+                else "ok -- JAX holds the source alive for its own transfer (pinning still out)"
+            )
         else:
             transfer = f"no race in {jc.trials} trials (absence of evidence, not safety)"
+            reuse_verdict = "ok -- no async read observed"
         _report(
             "jax -- does the pool's liveness poll hold for the JAX adapter?",
             "",
@@ -556,6 +587,7 @@ def main() -> None:
                 "   <- what an aligned pool would give",
                 f"  keeps source alive      {jc.keeps_alive}   <- what the poll needs",
                 f"  device transfer         {transfer}",
+                f"  reuse under the poll    {reuse_verdict}",
             ],
         )
 

--- a/bench/probe_batch_buffers.py
+++ b/bench/probe_batch_buffers.py
@@ -32,8 +32,10 @@ Five arms, each isolating one claim:
 * **jax** (needs JAX) -- the same soundness question for the other zero-copy adapter.
   ``to_jax`` aliases pool memory just as torch does, so reuse is safe only if JAX holds the
   source alive; and JAX exposes no event to poll, so an async device transfer would be
-  unguardable. (TF needs no arm: ``to_tf`` copies into TF-owned memory -- its experimental
-  DLPack mishandles buffer ownership -- so it never touches the pool.)
+  unguardable. **Run this one as ``--arms all``**: the async read only reproduces with the
+  GPU under load from the other arms, and on an idle device the transfer lands before the
+  probe can observe it. (TF needs no arm: ``to_tf`` copies into TF-owned memory -- its
+  experimental DLPack mishandles buffer ownership -- so it never touches the pool.)
 
 Read the result as: *alloc* says whether buffer reuse alone pays, *h2d* bounds the pinning
 prize, *overlap* says whether that prize is real or already collected, *roundtrip* says

--- a/bench/probe_batch_buffers.py
+++ b/bench/probe_batch_buffers.py
@@ -1,0 +1,306 @@
+"""Probe: what a pool of reused (and pinned) batch buffers could actually buy.
+
+``pool.gather`` allocates a fresh ``np.empty`` per variable per batch, and that heap
+memory is never page-locked, so H2D copies are pageable. Replacing it with a pool of
+pre-pinned buffers fixes both at once -- but only if either half is on the critical
+path. This probe measures the **ceiling** for both, before any engine change, so the
+decision is a number and not an instinct.
+
+Three arms, each isolating one claim:
+
+* **alloc** (no GPU needed) -- fresh ``np.empty`` vs a reused buffer, running
+  ``gather``'s exact inner loop (one coalesced fancy-index per chunk). ``np.empty``
+  itself is nearly free (it reserves address space, it does not touch pages), so what
+  this really measures is **first-touch page faults** on the scatter-write. glibc's
+  *dynamic* mmap threshold (128 KiB, growing to at most 32 MiB as blocks are freed)
+  means a batch under ~32 MiB gets recycled on the heap and re-faults nothing, while a
+  larger one is ``mmap``/``munmap``'d every batch and faults its whole page set again.
+  Expect a cliff, not a curve -- and expect ~0 for a WB2-sized batch.
+* **h2d** (needs CUDA) -- pinned vs pageable ``.to('cuda', non_blocking=True)``,
+  ``torch.cuda.Event``-timed. Gives the raw bandwidth ratio: the *upper bound* on what
+  pinning can save per batch.
+* **overlap** (needs CUDA) -- the question that actually decides it. Issue the copy on a
+  side stream against a busy compute stream and compare wall time to the serialized
+  sum. Only a pinned source can overlap; a pageable one is staged through a driver
+  bounce buffer and serializes. If the copy is already hidden by prefetch, both arms
+  land at the same wall time and pinning buys nothing end to end.
+
+Read the result as: *alloc* says whether buffer reuse alone pays, *h2d* bounds the
+pinning prize, *overlap* says whether that prize is real or already collected.
+
+    uv run python -m bench.probe_batch_buffers                 # host arm only
+    uv run python -m bench.probe_batch_buffers --arms all      # on a GPU box
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+from collections.abc import Callable
+from typing import TYPE_CHECKING, NamedTuple
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import torch
+
+# Coalesced groups per batch: gather does one fancy-index per distinct source chunk
+# (``np.unique(read_cid)``), so the write is a handful of strided scatters, not one
+# contiguous memcpy. Page-fault cost is the same either way; keep the shape honest.
+CHUNKS = 4
+
+ARMS = ("alloc", "h2d", "overlap")
+
+
+class Case(NamedTuple):
+    """One batch payload to sweep: ``(batch, *inner)`` of ``dtype``."""
+
+    name: str
+    batch: int
+    inner: tuple[int, ...]
+    dtype: np.dtype
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return (self.batch, *self.inner)
+
+    @property
+    def mib(self) -> float:
+        return self.batch * int(np.prod(self.inner)) * self.dtype.itemsize / 2**20
+
+
+# Chosen to bracket glibc's 32 MiB dynamic mmap ceiling: the first two land under it
+# (heap-recycled), the last two above it (mmap churn + a full re-fault every batch).
+CASES = (
+    Case("wb2 16x3x128x64", 16, (3, 128, 64), np.dtype("f4")),
+    Case("vit 32x3x224x224", 32, (3, 224, 224), np.dtype("f4")),
+    Case("vit-big 64x3x224x224", 64, (3, 224, 224), np.dtype("f4")),
+    Case("microscopy 8x2x32x512x512", 8, (2, 32, 512, 512), np.dtype("f4")),
+)
+
+
+def _median_ms(fn: Callable[[], None], iters: int) -> float:
+    """Median wall time of *iters* calls, in ms.
+
+    Median, not mean: page-fault and allocator noise is one-sided, and a single unlucky
+    ``munmap`` should not set the number.
+    """
+    samples = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        fn()
+        samples.append(time.perf_counter() - t0)
+    return statistics.median(samples) * 1e3
+
+
+def probe_alloc(case: Case, iters: int) -> tuple[float, float]:
+    """``(fresh_ms, reuse_ms)`` for one batch assembly.
+
+    The arms differ only in where ``out`` comes from -- identical scatter-write from
+    identical sources -- so the delta is allocation plus first touch, nothing else.
+    """
+    src = [np.ones(case.shape, dtype=case.dtype) for _ in range(CHUNKS)]
+    row_chunk = np.arange(case.batch) % CHUNKS
+    masks = [row_chunk == k for k in range(CHUNKS)]
+    pooled = np.empty(case.shape, dtype=case.dtype)
+
+    def assemble(out: np.ndarray) -> None:
+        for k in range(CHUNKS):
+            out[masks[k]] = src[k][masks[k]]
+
+    def fresh() -> None:
+        assemble(np.empty(case.shape, dtype=case.dtype))
+
+    def reuse() -> None:
+        assemble(pooled)
+
+    # Warm both arms: the pooled buffer's own first touch must not be timed.
+    fresh()
+    reuse()
+    return _median_ms(fresh, iters), _median_ms(reuse, iters)
+
+
+def probe_h2d(case: Case, iters: int) -> tuple[float, float]:
+    """``(pageable_ms, pinned_ms)`` for one H2D copy of a batch, CUDA-event timed.
+
+    Events, not the wall clock: ``non_blocking=True`` returns before the copy lands, so
+    a host-side timer would measure the launch and not the transfer.
+    """
+    import torch
+
+    dtype = getattr(torch, str(case.dtype))
+    pageable = torch.empty(case.shape, dtype=dtype)
+    pinned = torch.empty(case.shape, dtype=dtype, pin_memory=True)
+
+    def timed(src: torch.Tensor) -> float:
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        samples = []
+        for _ in range(iters):
+            start.record()
+            src.to("cuda", non_blocking=True)
+            end.record()
+            torch.cuda.synchronize()
+            samples.append(start.elapsed_time(end))
+        return statistics.median(samples)
+
+    timed(pageable)  # warm the context and the caching allocator
+    timed(pinned)
+    return timed(pageable), timed(pinned)
+
+
+def probe_overlap(case: Case, iters: int, compute_ms: float) -> tuple[float, float]:
+    """``(pageable_ms, pinned_ms)`` wall time for a copy *issued alongside compute*.
+
+    The copy goes on a side stream while a matmul occupies the default stream, sized to
+    roughly ``compute_ms`` -- a stand-in for the training step the loader is meant to
+    hide behind. A pinned source DMAs straight off the page-locked pages and overlaps; a
+    pageable one is staged through a driver bounce buffer and serializes. If both arms
+    land at the compute time alone, the transfer is already hidden and pinning is moot.
+    """
+    import torch
+
+    dtype = getattr(torch, str(case.dtype))
+    pageable = torch.empty(case.shape, dtype=dtype)
+    pinned = torch.empty(case.shape, dtype=dtype, pin_memory=True)
+    stream = torch.cuda.Stream()
+
+    # Size the synthetic load once so both arms contend with the same compute.
+    a = torch.randn(2048, 2048, device="cuda")
+    b = torch.randn(2048, 2048, device="cuda")
+    reps = max(1, round(compute_ms / _gpu_ms(lambda: a @ b)))
+
+    def run(src: torch.Tensor) -> float:
+        def once() -> None:
+            with torch.cuda.stream(stream):
+                src.to("cuda", non_blocking=True)
+            for _ in range(reps):
+                a @ b
+            torch.cuda.synchronize()
+
+        torch.cuda.synchronize()
+        return _median_ms(once, iters)
+
+    run(pageable)
+    run(pinned)
+    return run(pageable), run(pinned)
+
+
+def _gpu_ms(fn: Callable[[], object]) -> float:
+    """Median GPU time of one op, in ms -- used to size the synthetic compute load."""
+    import torch
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    fn()
+    torch.cuda.synchronize()
+    samples = []
+    for _ in range(5):
+        start.record()
+        fn()
+        end.record()
+        torch.cuda.synchronize()
+        samples.append(start.elapsed_time(end))
+    return max(statistics.median(samples), 1e-3)
+
+
+def _device_name() -> str:
+    """Assert a usable CUDA device and name it, or exit with the reason.
+
+    A silent CPU fallback would report a meaningless "pinning does nothing", so the GPU
+    arms fail fast rather than degrade.
+    """
+    try:
+        import torch
+    except ImportError as exc:  # pragma: no cover - torch-less installs
+        raise SystemExit("the h2d/overlap arms need PyTorch: uv sync --extra torch") from exc
+    if not torch.cuda.is_available():
+        raise SystemExit("no CUDA device visible -- run the h2d/overlap arms on a GPU box")
+    name: str = torch.cuda.get_device_name(0)
+    return name
+
+
+def _report(header: str, columns: str, rows: list[str]) -> None:
+    print(header)
+    print(columns)
+    for row in rows:
+        print(row)
+    print()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "--arms",
+        default="alloc",
+        help="comma-separated: alloc,h2d,overlap (or 'all'). Default: alloc (no GPU needed).",
+    )
+    ap.add_argument("--iters", type=int, default=50, help="timed repetitions per measurement")
+    ap.add_argument(
+        "--compute-ms",
+        type=float,
+        default=20.0,
+        help="synthetic per-step GPU compute the overlap arm hides the copy behind",
+    )
+    args = ap.parse_args()
+    arms = set(ARMS) if args.arms == "all" else set(args.arms.split(","))
+    unknown = arms - set(ARMS)
+    if unknown:
+        raise SystemExit(f"unknown arm(s): {sorted(unknown)}; choose from {list(ARMS)}")
+
+    if arms & {"h2d", "overlap"}:
+        print(f"device: {_device_name()}\n")
+
+    if "alloc" in arms:
+        rows = []
+        for case in CASES:
+            iters = args.iters if case.mib < 50 else max(10, args.iters // 5)
+            fresh, reuse = probe_alloc(case, iters)
+            pct = 100 * (fresh - reuse) / fresh if fresh else 0.0
+            rows.append(
+                f"{case.name:<28}{case.mib:>9.1f}{fresh:>10.3f}{reuse:>10.3f}"
+                f"{fresh - reuse:>10.3f}{pct:>7.1f}%"
+            )
+        _report(
+            "alloc -- batch assembly, fresh np.empty vs reused buffer",
+            f"{'case':<28}{'MiB':>9}{'fresh ms':>10}{'reuse ms':>10}{'saved':>10}{'saved':>8}",
+            rows,
+        )
+
+    if "h2d" in arms:
+        rows = []
+        for case in CASES:
+            page_ms, pin_ms = probe_h2d(case, args.iters)
+            gib = case.mib / 1024
+            rows.append(
+                f"{case.name:<28}{case.mib:>9.1f}{page_ms:>10.3f}{pin_ms:>10.3f}"
+                f"{gib / (page_ms / 1e3):>11.1f}{gib / (pin_ms / 1e3):>10.1f}"
+            )
+        _report(
+            "h2d -- one batch copied to device, CUDA-event timed",
+            f"{'case':<28}{'MiB':>9}{'page ms':>10}{'pin ms':>10}{'GB/s page':>11}{'GB/s pin':>10}",
+            rows,
+        )
+
+    if "overlap" in arms:
+        rows = []
+        for case in CASES:
+            page_ms, pin_ms = probe_overlap(case, max(10, args.iters // 5), args.compute_ms)
+            pct = 100 * (page_ms - pin_ms) / page_ms if page_ms else 0.0
+            rows.append(
+                f"{case.name:<28}{case.mib:>9.1f}{page_ms:>10.3f}{pin_ms:>10.3f}"
+                f"{page_ms - pin_ms:>10.3f}{pct:>7.1f}%"
+            )
+        _report(
+            f"overlap -- copy issued against ~{args.compute_ms:.0f}ms of compute (wall time)",
+            f"{'case':<28}{'MiB':>9}{'page ms':>10}{'pin ms':>10}{'saved':>10}{'saved':>8}",
+            rows,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/probe_batch_buffers.py
+++ b/bench/probe_batch_buffers.py
@@ -297,10 +297,10 @@ def probe_jax(trials: int) -> JaxCheck:
         hits = 0
         for _ in range(trials):
             base = alloc()
-            base[0, 0] = 0.0
+            base.flat[0] = 0.0
             arr = jnp.from_dlpack(base[: shape[0]])
-            base[0, 0] = 99.0  # a host write shows through only if JAX aliased
-            hits += float(arr[0, 0]) == 99.0
+            base.flat[0] = 99.0  # a host write shows through only if JAX aliased
+            hits += float(arr.ravel()[0]) == 99.0
         return hits
 
     default_hits = zero_copy_hits(lambda: np.empty(shape, dtype))
@@ -326,7 +326,9 @@ def probe_jax(trials: int) -> JaxCheck:
             host.fill(0.0)
             on_device = jax.device_put(jnp.from_dlpack(host[: big.batch]), gpus[0])
             host.fill(7.0)  # scribble the source the instant device_put returns
-            if float(on_device[0, 0, 0, 0]) == 7.0:
+            # ravel: the case is (batch, *inner) and so rank 5 -- read element 0 without
+            # having to spell every axis. The read is what forces the transfer to finish.
+            if float(on_device.ravel()[0]) == 7.0:
                 race = True
                 break
     return JaxCheck(

--- a/bench/probe_batch_buffers.py
+++ b/bench/probe_batch_buffers.py
@@ -6,7 +6,7 @@ pre-pinned buffers fixes both at once -- but only if either half is on the criti
 path. This probe measures the **ceiling** for both, before any engine change, so the
 decision is a number and not an instinct.
 
-Four arms, each isolating one claim:
+Five arms, each isolating one claim:
 
 * **alloc** (no GPU needed) -- fresh ``np.empty`` vs a reused buffer, running
   ``gather``'s exact inner loop (one coalesced fancy-index per chunk). ``np.empty``
@@ -29,10 +29,16 @@ Four arms, each isolating one claim:
   adapter, and every batch would travel ``pinned tensor -> .numpy() -> base[:k] view ->
   DLPack -> .to(cuda)``. This asks whether pinning actually survives that path. It is the
   gate on the whole design: if it fails, pinning needs a torch-owned buffer instead.
+* **jax** (needs JAX) -- the same soundness question for the other zero-copy adapter.
+  ``to_jax`` aliases pool memory just as torch does, so reuse is safe only if JAX holds the
+  source alive; and JAX exposes no event to poll, so an async device transfer would be
+  unguardable. (TF needs no arm: ``to_tf`` copies into TF-owned memory -- its experimental
+  DLPack mishandles buffer ownership -- so it never touches the pool.)
 
 Read the result as: *alloc* says whether buffer reuse alone pays, *h2d* bounds the pinning
-prize, *overlap* says whether that prize is real or already collected, and *roundtrip* says
-whether we can collect it without putting torch in the core.
+prize, *overlap* says whether that prize is real or already collected, *roundtrip* says
+whether we can collect it without putting torch in the core, and *jax* says how far the
+answer generalises past torch.
 
     uv run python -m bench.probe_batch_buffers                 # host arm only
     uv run python -m bench.probe_batch_buffers --arms all      # on a GPU box
@@ -56,7 +62,7 @@ if TYPE_CHECKING:
 # contiguous memcpy. Page-fault cost is the same either way; keep the shape honest.
 CHUNKS = 4
 
-ARMS = ("alloc", "h2d", "overlap", "roundtrip")
+ARMS = ("alloc", "h2d", "overlap", "roundtrip", "jax")
 
 
 class Case(NamedTuple):
@@ -227,6 +233,113 @@ def probe_roundtrip(case: Case, iters: int) -> Roundtrip:
     )
 
 
+XLA_ALIGN = 128  # XLA:CPU's zero-copy alignment requirement, in bytes
+
+
+def aligned_empty(shape: tuple[int, ...], dtype: np.dtype, align: int = XLA_ALIGN) -> np.ndarray:
+    """``np.empty(shape, dtype)`` whose data pointer is a multiple of ``align``.
+
+    Over-allocate a byte buffer, skip to the next boundary, then view/reshape. numpy makes
+    no alignment promise beyond its own 16-byte floor, which is why this is needed at all.
+    """
+    n = int(np.prod(shape)) * dtype.itemsize
+    raw = np.empty(n + align, dtype=np.uint8)
+    off = (-raw.__array_interface__["data"][0]) % align
+    return raw[off : off + n].view(dtype).reshape(shape)
+
+
+class JaxCheck(NamedTuple):
+    """Whether the pool's liveness poll is sound for the JAX adapter too."""
+
+    backend: str
+    device: str  # where `from_dlpack` actually placed the array
+    trials: int
+    default_zero_copy: int  # of `trials` np.empty buffers, how many JAX aliased
+    aligned_zero_copy: int  # ...and of `trials` 128-byte-aligned ones
+    keeps_alive: bool  # when it DOES alias, JAX holds the source alive (what the poll needs)
+    race_observed: bool | None  # None = no GPU backend present to test
+
+
+def probe_jax(trials: int) -> JaxCheck:
+    """Does JAX behave like torch under the pool -- alias, and hold the source alive?
+
+    ``to_jax`` uses ``jnp.from_dlpack``, so a JAX consumer aliases pool memory exactly as a
+    torch one does, and reuse is only safe if JAX keeps the source array alive. Two things
+    make this worth checking rather than assuming torch's answer carries over: JAX arrays are
+    advertised as **immutable**, so an aliased buffer we later recycle would mutate one
+    silently; and JAX exposes no event we can poll, so unlike ``to_torch(device=...)`` there
+    is no way to guard an in-flight device transfer.
+
+    JAX's zero-copy is **conditional on alignment** -- XLA:CPU needs the buffer on a 128-byte
+    boundary and silently copies otherwise -- and numpy only guarantees 16, so whether any
+    given batch is zero-copy is down to the allocator's luck. Both arms are measured because
+    the difference is a lever: a pool that allocates aligned makes JAX zero-copy *reliably*,
+    which plain per-batch ``np.empty`` cannot.
+
+    The last check probes the unguardable gap: ``device_put`` to the GPU, immediately scribble
+    the host buffer, then read the device array back. Seeing the scribble means the transfer
+    was still reading our memory after ``device_put`` returned -- an async copy we cannot
+    guard, which would rule out pinning on the JAX path. It is a **race** detector, so a clean
+    run is "not observed in N trials", never proof of safety.
+    """
+    import weakref
+
+    try:
+        import jax
+        import jax.numpy as jnp
+    except ImportError as exc:  # pragma: no cover - jax-less installs
+        raise SystemExit("the jax arm needs JAX: uv sync --extra jax") from exc
+
+    shape, dtype = (8, 4), np.dtype("f4")
+
+    def zero_copy_hits(alloc: Callable[[], np.ndarray]) -> int:
+        """How many of ``trials`` fresh buffers JAX aliased rather than copied."""
+        hits = 0
+        for _ in range(trials):
+            base = alloc()
+            base[0, 0] = 0.0
+            arr = jnp.from_dlpack(base[: shape[0]])
+            base[0, 0] = 99.0  # a host write shows through only if JAX aliased
+            hits += float(arr[0, 0]) == 99.0
+        return hits
+
+    default_hits = zero_copy_hits(lambda: np.empty(shape, dtype))
+    aligned_hits = zero_copy_hits(lambda: aligned_empty(shape, dtype))
+
+    # Soundness is only meaningful on a buffer JAX actually aliased, so force alignment.
+    base = aligned_empty(shape, dtype)
+    view = base[: shape[0]]
+    ref = weakref.ref(view)
+    arr = jnp.from_dlpack(view)
+    del view
+    keeps_alive = ref() is not None
+    device = str(next(iter(arr.devices())))
+
+    gpus = [d for d in jax.devices() if d.platform == "gpu"]
+    race: bool | None = None
+    if gpus:
+        # Big buffer: the wider the copy, the wider the window a race can be seen in.
+        big = Case("jax-race", 8, (2, 32, 512, 512), np.dtype("f4"))
+        race = False
+        for _ in range(trials):
+            host = aligned_empty(big.shape, big.dtype)
+            host.fill(0.0)
+            on_device = jax.device_put(jnp.from_dlpack(host[: big.batch]), gpus[0])
+            host.fill(7.0)  # scribble the source the instant device_put returns
+            if float(on_device[0, 0, 0, 0]) == 7.0:
+                race = True
+                break
+    return JaxCheck(
+        backend=jax.default_backend(),
+        device=device,
+        trials=trials,
+        default_zero_copy=default_hits,
+        aligned_zero_copy=aligned_hits,
+        keeps_alive=keeps_alive,
+        race_observed=race,
+    )
+
+
 class Load(NamedTuple):
     """A fixed synthetic training step: ``reps`` matmuls of ``a @ b`` on the GPU.
 
@@ -323,7 +436,8 @@ def _device_name() -> str:
 
 def _report(header: str, columns: str, rows: list[str]) -> None:
     print(header)
-    print(columns)
+    if columns:  # the jax arm reports labelled lines, not a table
+        print(columns)
     for row in rows:
         print(row)
     print()
@@ -337,7 +451,7 @@ def main() -> None:
     ap.add_argument(
         "--arms",
         default="alloc",
-        help="comma-separated: alloc,h2d,overlap,roundtrip (or 'all'). Default: alloc.",
+        help="comma-separated: alloc,h2d,overlap,roundtrip,jax (or 'all'). Default: alloc.",
     )
     ap.add_argument("--iters", type=int, default=50, help="timed repetitions per measurement")
     ap.add_argument(
@@ -352,7 +466,7 @@ def main() -> None:
     if unknown:
         raise SystemExit(f"unknown arm(s): {sorted(unknown)}; choose from {list(ARMS)}")
 
-    if arms - {"alloc"}:
+    if arms & {"h2d", "overlap", "roundtrip"}:  # the jax arm brings its own backend
         print(f"device: {_device_name()}\n")
 
     if "alloc" in arms:
@@ -419,6 +533,28 @@ def main() -> None:
             f"{'case':<28}{'MiB':>9}{'alias':>7}{'pinned':>8}{'ragged':>8}"
             f"{'via ms':>10}{'pin ms':>10}{'page ms':>10}  verdict",
             rows,
+        )
+
+    if "jax" in arms:
+        jc = probe_jax(args.iters)
+        if jc.race_observed is None:
+            transfer = "no GPU backend present -- device transfer untested"
+        elif jc.race_observed:
+            transfer = "ASYNC RACE OBSERVED -- device_put keeps reading our buffer"
+        else:
+            transfer = f"no race in {jc.trials} trials (absence of evidence, not safety)"
+        _report(
+            "jax -- does the pool's liveness poll hold for the JAX adapter?",
+            "",
+            [
+                f"  backend                 {jc.backend}  (from_dlpack placed on {jc.device})",
+                f"  zero-copy, np.empty     {jc.default_zero_copy}/{jc.trials}"
+                "   <- alignment luck, not a guarantee",
+                f"  zero-copy, {XLA_ALIGN}-aligned  {jc.aligned_zero_copy}/{jc.trials}"
+                "   <- what an aligned pool would give",
+                f"  keeps source alive      {jc.keeps_alive}   <- what the poll needs",
+                f"  device transfer         {transfer}",
+            ],
         )
 
 

--- a/bench/probe_batch_buffers.py
+++ b/bench/probe_batch_buffers.py
@@ -30,8 +30,8 @@ Five arms, each isolating one claim:
   DLPack -> .to(cuda)``. This asks whether pinning actually survives that path. It is the
   gate on the whole design: if it fails, pinning needs a torch-owned buffer instead.
 * **jax** (needs JAX) -- the same soundness question for the other zero-copy adapter.
-  ``to_jax`` aliases pool memory just as torch does, so reuse is safe only if JAX holds the
-  source alive; and JAX exposes no event to poll, so an async device transfer would be
+  ``to_jax`` aliases pool memory just as torch does, so reuse is safe only if JAX keeps a
+  reference to that memory; and JAX exposes no event to poll, so an async device transfer would be
   unguardable. **Run this one as ``--arms all``**: the async read only reproduces with the
   GPU under load from the other arms, and on an idle device the transfer lands before the
   probe can observe it. (TF needs no arm: ``to_tf`` copies into TF-owned memory -- its
@@ -258,7 +258,7 @@ class JaxCheck(NamedTuple):
     trials: int
     default_zero_copy: int  # of `trials` np.empty buffers, how many JAX aliased
     aligned_zero_copy: int  # ...and of `trials` 128-byte-aligned ones
-    keeps_alive: bool  # when it DOES alias, JAX holds the source alive (what the poll needs)
+    keeps_alive: bool  # when it DOES alias, JAX holds the lent array itself (see probe_jax)
     race_observed: bool | None  # device_put still reading our buffer after it returned
     holds_source: bool | None  # JAX itself keeps the source referenced across the transfer
 
@@ -275,8 +275,15 @@ def probe_jax(trials: int) -> JaxCheck:
     """Does JAX behave like torch under the pool -- alias, and hold the source alive?
 
     ``to_jax`` uses ``jnp.from_dlpack``, so a JAX consumer aliases pool memory exactly as a
-    torch one does, and reuse is only safe if JAX keeps the source array alive. Two things
-    make this worth checking rather than assuming torch's answer carries over: JAX arrays are
+    torch one does, and reuse is only safe if JAX keeps *something* referencing that memory.
+    This asserts the stronger property -- that JAX holds the lent array itself -- which is
+    sufficient but not what the pool requires: :class:`insitubatch.buffers._Buffer` counts
+    references to the data *owner*, so a framework holding either the lent array or the owner
+    is equally safe. A ``False`` here would therefore be worth investigating rather than
+    trusting: it could mean the memory is genuinely unheld, or merely held one level down.
+
+    Two things make this worth checking rather than assuming torch's answer carries over: JAX
+    arrays are
     advertised as **immutable**, so an aliased buffer we later recycle would mutate one
     silently; and JAX exposes no event we can poll, so unlike ``to_torch(device=...)`` there
     is no way to guard an in-flight device transfer.
@@ -611,7 +618,7 @@ def main() -> None:
                 "   <- alignment luck, not a guarantee",
                 f"  zero-copy, {XLA_ALIGN}-aligned  {jc.aligned_zero_copy}/{jc.trials}"
                 "   <- what an aligned pool would give",
-                f"  keeps source alive      {jc.keeps_alive}   <- what the poll needs",
+                f"  keeps source alive      {jc.keeps_alive}   <- holds the lent array itself",
                 f"  device transfer         {transfer}",
                 f"  JAX holds the source    {holds}   <- deterministic, unlike the race",
                 f"  reuse under the poll    {reuse_verdict}",

--- a/bench/probe_batch_buffers.py
+++ b/bench/probe_batch_buffers.py
@@ -6,7 +6,7 @@ pre-pinned buffers fixes both at once -- but only if either half is on the criti
 path. This probe measures the **ceiling** for both, before any engine change, so the
 decision is a number and not an instinct.
 
-Three arms, each isolating one claim:
+Four arms, each isolating one claim:
 
 * **alloc** (no GPU needed) -- fresh ``np.empty`` vs a reused buffer, running
   ``gather``'s exact inner loop (one coalesced fancy-index per chunk). ``np.empty``
@@ -24,9 +24,15 @@ Three arms, each isolating one claim:
   sum. Only a pinned source can overlap; a pageable one is staged through a driver
   bounce buffer and serializes. If the copy is already hidden by prefetch, both arms
   land at the same wall time and pinning buys nothing end to end.
+* **roundtrip** (needs CUDA) -- a feasibility check, not a measurement. The core is numpy
+  and imports no framework, so pinning would arrive via an allocator injected by the torch
+  adapter, and every batch would travel ``pinned tensor -> .numpy() -> base[:k] view ->
+  DLPack -> .to(cuda)``. This asks whether pinning actually survives that path. It is the
+  gate on the whole design: if it fails, pinning needs a torch-owned buffer instead.
 
-Read the result as: *alloc* says whether buffer reuse alone pays, *h2d* bounds the
-pinning prize, *overlap* says whether that prize is real or already collected.
+Read the result as: *alloc* says whether buffer reuse alone pays, *h2d* bounds the pinning
+prize, *overlap* says whether that prize is real or already collected, and *roundtrip* says
+whether we can collect it without putting torch in the core.
 
     uv run python -m bench.probe_batch_buffers                 # host arm only
     uv run python -m bench.probe_batch_buffers --arms all      # on a GPU box
@@ -50,7 +56,7 @@ if TYPE_CHECKING:
 # contiguous memcpy. Page-fault cost is the same either way; keep the shape honest.
 CHUNKS = 4
 
-ARMS = ("alloc", "h2d", "overlap")
+ARMS = ("alloc", "h2d", "overlap", "roundtrip")
 
 
 class Case(NamedTuple):
@@ -121,33 +127,104 @@ def probe_alloc(case: Case, iters: int) -> tuple[float, float]:
     return _median_ms(fresh, iters), _median_ms(reuse, iters)
 
 
-def probe_h2d(case: Case, iters: int) -> tuple[float, float]:
-    """``(pageable_ms, pinned_ms)`` for one H2D copy of a batch, CUDA-event timed.
+def _time_h2d(src: torch.Tensor, iters: int) -> float:
+    """Median ms for one ``src -> cuda`` copy, CUDA-event timed.
 
     Events, not the wall clock: ``non_blocking=True`` returns before the copy lands, so
     a host-side timer would measure the launch and not the transfer.
     """
     import torch
 
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    samples = []
+    for _ in range(iters):
+        start.record()
+        src.to("cuda", non_blocking=True)
+        end.record()
+        torch.cuda.synchronize()
+        samples.append(start.elapsed_time(end))
+    return statistics.median(samples)
+
+
+def probe_h2d(case: Case, iters: int) -> tuple[float, float]:
+    """``(pageable_ms, pinned_ms)`` for one H2D copy of a batch."""
+    import torch
+
     dtype = getattr(torch, str(case.dtype))
     pageable = torch.empty(case.shape, dtype=dtype)
     pinned = torch.empty(case.shape, dtype=dtype, pin_memory=True)
 
-    def timed(src: torch.Tensor) -> float:
-        start = torch.cuda.Event(enable_timing=True)
-        end = torch.cuda.Event(enable_timing=True)
-        samples = []
-        for _ in range(iters):
-            start.record()
-            src.to("cuda", non_blocking=True)
-            end.record()
-            torch.cuda.synchronize()
-            samples.append(start.elapsed_time(end))
-        return statistics.median(samples)
+    _time_h2d(pageable, iters)  # warm the context and the caching allocator
+    _time_h2d(pinned, iters)
+    return _time_h2d(pageable, iters), _time_h2d(pinned, iters)
 
-    timed(pageable)  # warm the context and the caching allocator
-    timed(pinned)
-    return timed(pageable), timed(pinned)
+
+class Roundtrip(NamedTuple):
+    """Whether pinned-ness survives the pool's hand-out path, and what it costs."""
+
+    shares: bool  # the numpy base aliases the pinned tensor (no silent copy)
+    full_pinned: bool  # torch sees a full-batch view as pinned
+    prefix_pinned: bool  # ...and a ragged `base[:k]` prefix too
+    ms: float  # H2D through the full path
+    pageable_ms: float
+    pinned_ms: float
+
+    @property
+    def verdict(self) -> str:
+        """Which reference the round-trip timing actually matches.
+
+        ``is_pinned()`` alone is not enough to trust: the failure that matters is a
+        ``non_blocking`` copy silently degrading to a synchronous pageable one, and that
+        shows up in the clock, not the flag. Require both to agree.
+        """
+        if not self.shares:
+            return "BROKEN: .numpy() copied"
+        midpoint = (self.pinned_ms + self.pageable_ms) / 2
+        fast = self.ms <= midpoint
+        if self.full_pinned and self.prefix_pinned and fast:
+            return "ok"
+        if fast:
+            return "fast but flag says pageable"
+        return "DEAD: degrades to pageable"
+
+
+def probe_roundtrip(case: Case, iters: int) -> Roundtrip:
+    """Does host memory stay pinned along the pool's actual hand-out path?
+
+    The pool cannot call ``torch.empty(pin_memory=True)`` itself -- the core is numpy and
+    imports no framework -- so pinning would arrive via an allocator injected by the torch
+    adapter, and every batch would travel::
+
+        torch pinned tensor -> .numpy() -> pool base -> base[:k] view -> DLPack -> .to(cuda)
+
+    Three ways that silently fails, all checked here: ``.numpy()` could copy instead of
+    alias (the pool would then pin memory nobody reads from); CUDA could fail to recognise
+    the pages through the round-trip, so ``non_blocking=True`` degrades to a synchronous
+    pageable copy with no error; or the ragged-tail ``base[:k]`` prefix could behave
+    differently from the full-batch view. If this arm does not come back ``ok``, the
+    injected-allocator design is dead and pinning needs a torch-owned buffer instead.
+    """
+    import torch
+
+    dtype = getattr(torch, str(case.dtype))
+    owner = torch.empty(case.shape, dtype=dtype, pin_memory=True)
+    base = owner.numpy()  # must alias, not copy
+    shares = base.__array_interface__["data"][0] == owner.data_ptr()
+
+    full = torch.from_dlpack(base[: case.batch])
+    prefix = torch.from_dlpack(base[: max(1, case.batch // 2)])  # the ragged tail
+    pageable = torch.empty(case.shape, dtype=dtype)
+
+    _time_h2d(full, iters)  # warm
+    return Roundtrip(
+        shares=shares,
+        full_pinned=full.is_pinned(),
+        prefix_pinned=prefix.is_pinned(),
+        ms=_time_h2d(full, iters),
+        pageable_ms=_time_h2d(pageable, iters),
+        pinned_ms=_time_h2d(owner, iters),
+    )
 
 
 class Load(NamedTuple):
@@ -237,9 +314,9 @@ def _device_name() -> str:
     try:
         import torch
     except ImportError as exc:  # pragma: no cover - torch-less installs
-        raise SystemExit("the h2d/overlap arms need PyTorch: uv sync --extra torch") from exc
+        raise SystemExit("the GPU arms need PyTorch: uv sync --extra torch") from exc
     if not torch.cuda.is_available():
-        raise SystemExit("no CUDA device visible -- run the h2d/overlap arms on a GPU box")
+        raise SystemExit("no CUDA device visible -- run the GPU arms on a GPU box")
     name: str = torch.cuda.get_device_name(0)
     return name
 
@@ -260,7 +337,7 @@ def main() -> None:
     ap.add_argument(
         "--arms",
         default="alloc",
-        help="comma-separated: alloc,h2d,overlap (or 'all'). Default: alloc (no GPU needed).",
+        help="comma-separated: alloc,h2d,overlap,roundtrip (or 'all'). Default: alloc.",
     )
     ap.add_argument("--iters", type=int, default=50, help="timed repetitions per measurement")
     ap.add_argument(
@@ -275,7 +352,7 @@ def main() -> None:
     if unknown:
         raise SystemExit(f"unknown arm(s): {sorted(unknown)}; choose from {list(ARMS)}")
 
-    if arms & {"h2d", "overlap"}:
+    if arms - {"alloc"}:
         print(f"device: {_device_name()}\n")
 
     if "alloc" in arms:
@@ -324,6 +401,23 @@ def main() -> None:
             " an arm at 'compute' has its copy fully hidden",
             f"{'case':<28}{'MiB':>9}{'compute':>10}{'page ms':>10}{'pin ms':>10}"
             f"{'saved':>10}{'saved':>8}",
+            rows,
+        )
+
+    if "roundtrip" in arms:
+        rows = []
+        for case in CASES:
+            rt = probe_roundtrip(case, args.iters)
+            flags = f"{str(rt.shares):>7}{str(rt.full_pinned):>8}{str(rt.prefix_pinned):>8}"
+            rows.append(
+                f"{case.name:<28}{case.mib:>9.1f}{flags}{rt.ms:>10.3f}"
+                f"{rt.pinned_ms:>10.3f}{rt.pageable_ms:>10.3f}  {rt.verdict}"
+            )
+        _report(
+            "roundtrip -- pinned tensor -> .numpy() -> base[:k] view -> DLPack -> .to(cuda);"
+            " does pinning survive the pool's hand-out path?",
+            f"{'case':<28}{'MiB':>9}{'alias':>7}{'pinned':>8}{'ragged':>8}"
+            f"{'via ms':>10}{'pin ms':>10}{'page ms':>10}  verdict",
             rows,
         )
 

--- a/bench/probe_batch_buffers.py
+++ b/bench/probe_batch_buffers.py
@@ -56,6 +56,13 @@ from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 
+# The probe measures what the pool does, so it must not carry its own copy of how the pool
+# does it. These were duplicated here when the probe predated the implementation; importing
+# them is what keeps a change to alignment or to the numpy->torch mapping show up in the
+# numbers instead of quietly diverging from them (tests/test_bench.py pins the coupling).
+from insitubatch.buffers import XLA_ALIGN, aligned_empty
+from insitubatch.frameworks import _torch_dtype
+
 if TYPE_CHECKING:
     import torch
 
@@ -159,7 +166,7 @@ def probe_h2d(case: Case, iters: int) -> tuple[float, float]:
     """``(pageable_ms, pinned_ms)`` for one H2D copy of a batch."""
     import torch
 
-    dtype = getattr(torch, str(case.dtype))
+    dtype = _torch_dtype(case.dtype)
     pageable = torch.empty(case.shape, dtype=dtype)
     pinned = torch.empty(case.shape, dtype=dtype, pin_memory=True)
 
@@ -215,7 +222,7 @@ def probe_roundtrip(case: Case, iters: int) -> Roundtrip:
     """
     import torch
 
-    dtype = getattr(torch, str(case.dtype))
+    dtype = _torch_dtype(case.dtype)
     owner = torch.empty(case.shape, dtype=dtype, pin_memory=True)
     base = owner.numpy()  # must alias, not copy
     shares = base.__array_interface__["data"][0] == owner.data_ptr()
@@ -233,21 +240,6 @@ def probe_roundtrip(case: Case, iters: int) -> Roundtrip:
         pageable_ms=_time_h2d(pageable, iters),
         pinned_ms=_time_h2d(owner, iters),
     )
-
-
-XLA_ALIGN = 128  # XLA:CPU's zero-copy alignment requirement, in bytes
-
-
-def aligned_empty(shape: tuple[int, ...], dtype: np.dtype, align: int = XLA_ALIGN) -> np.ndarray:
-    """``np.empty(shape, dtype)`` whose data pointer is a multiple of ``align``.
-
-    Over-allocate a byte buffer, skip to the next boundary, then view/reshape. numpy makes
-    no alignment promise beyond its own 16-byte floor, which is why this is needed at all.
-    """
-    n = int(np.prod(shape)) * dtype.itemsize
-    raw = np.empty(n + align, dtype=np.uint8)
-    off = (-raw.__array_interface__["data"][0]) % align
-    return raw[off : off + n].view(dtype).reshape(shape)
 
 
 class JaxCheck(NamedTuple):
@@ -430,7 +422,7 @@ def probe_overlap(case: Case, iters: int, load: Load) -> tuple[float, float, flo
     """
     import torch
 
-    dtype = getattr(torch, str(case.dtype))
+    dtype = _torch_dtype(case.dtype)
     pageable = torch.empty(case.shape, dtype=dtype)
     pinned = torch.empty(case.shape, dtype=dtype, pin_memory=True)
     stream = torch.cuda.Stream()

--- a/bench/result.py
+++ b/bench/result.py
@@ -48,6 +48,23 @@ def rss_breakdown_mb() -> tuple[float, float]:
     return anon, file
 
 
+def minor_faults() -> int:
+    """Minor page faults this process has taken (``ru_minflt``).
+
+    The direct measure of batch-buffer allocation churn, and a far more sensitive one than
+    wall time: a freshly allocated batch faults in its whole page set on the scatter-write,
+    while a reused buffer faults once ever. Above glibc's 32 MiB dynamic mmap threshold --
+    where every batch is ``mmap``/``munmap``'d rather than recycled on the heap -- the
+    difference is large and shows even when IO is hiding the time saved.
+
+    Process-wide and **cumulative**, so it is only meaningful per fresh process. That is why
+    the batch-buffer sweep runs one child per config: glibc's threshold is itself stateful
+    (it rises once a large block is freed), so configs measured in one process would
+    contaminate each other.
+    """
+    return int(resource.getrusage(resource.RUSAGE_SELF).ru_minflt)
+
+
 @dataclass
 class Result:
     engine: str  # insitu | naive | memory | workers | xbatcher
@@ -69,6 +86,7 @@ class Result:
     peak_rss_mb: float  # ru_maxrss high-water (monotonic, process-wide)
     rss_anon_mb: float = 0.0  # heap/stack at row time (Linux); the real memory bound
     rss_file_mb: float = 0.0  # file-backed mmap at row time (mmap cache .npy; reclaimable)
+    minor_faults: int = 0  # ru_minflt: page faults served without IO -- see minor_faults()
     host: str = field(default_factory=socket.gethostname)
     platform: str = field(default_factory=platform.platform)
     ts: float = field(default_factory=time.time)

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -374,8 +374,77 @@ again in the cold fill: TTFB rises as chunks shrink (0.41 → 0.73 s) or fan int
 <iframe src="../figures/advection_chunk.html" width="100%" height="420" frameborder="0"></iframe>
 <iframe src="../figures/advection_inner.html" width="100%" height="420" frameborder="0"></iframe>
 
+## Batch buffers — reuse removes a cliff, pinning buys 2–4%
+
+The loader reuses its batch output buffers rather than allocating one per batch, and
+`as_torch(..., device=...)` / `pin_host_buffers` put those buffers in page-locked memory and
+own the H2D copy. The two are separate changes with separate payoffs, and each is only
+visible on the axis it acts on.
+
+### Reuse: a payload-size cliff, not a speedup
+
+Above glibc's 32 MiB `mmap` threshold a fresh batch is `mmap`ed and `munmap`ed **every
+batch** — a syscall trace shows 12 full-buffer pairs per 12-batch epoch without reuse and 2
+with it — so the kernel re-zeroes the whole buffer each time. Below that threshold the freed
+block is recycled on the heap and reuse is a small cost instead.
+
+Synthetic sweep (`bench/batch_buffer_sweep.py`, L4, `--inner 256,256`, arms alternated):
+
+| MiB/batch | 8 | 16 | 32 | 64 | 128 |
+|---|--:|--:|--:|--:|--:|
+| no reuse (samples/s) | 5404 | 5186 | 4435 | 4585 | 4765 |
+| reuse | 5240 | 5060 | 5148 | 5173 | 5266 |
+| delta | −3.0% | −2.4% | **+16.1%** | **+12.8%** | **+10.5%** |
+
+**Read the shape, not a headline number.** Reuse holds throughput flat across a 16× payload
+range while fresh allocation falls off a cliff; the small-batch end pays 2–3%. Weather-shaped
+batches sit in the losing region — a fraction of a percent of a step, but a cost, not a wash.
+
+That cost does **not** surface in the GPU training loop above: across four alternating runs
+(with and without reuse, 5 epochs × 7 repeats), the 128² geometry held 99.2 / 99.3 / 99.4 /
+99.3 % of ceiling — 0.2 points of spread, with no arm signal. Producer-side work is what
+prefetch is for, and a compute-bound loop absorbs it.
+
+### Pinning: +2–4% end to end, and it shows in the ceiling too
+
+Same checkout, same box, back-to-back, `--pin` the only difference:
+
+| geometry | payload | without | with | delta |
+|---|--:|--:|--:|--:|
+| 64² | 0.5 MiB | 4448.7 | 4672.2 | **+5.0%** |
+| 128² | 2 MiB | 583.1 | 605.8 | **+3.9%** |
+| 256² | 8 MiB | 145.2 | 148.5 | **+2.3%** |
+
+Pinned is the maximum at every geometry and outside the range of the four unpinned runs in
+all three. The compute ceiling rises by almost exactly the same amount (+6.1 / +3.6 / +2.1%)
+because the ceiling loop preloads batches into RAM but still issues the same per-step H2D
+copy — loader and ceiling moving in lockstep is the evidence that what changed is *the
+transfer*. The larger field gains least: its compute per sample is 4× heavier, so the copy is
+a smaller share of the step.
+
+This matches the isolated prediction. `bench/probe_batch_buffers.py --arms overlap` put a
+1.5 MiB pinned copy at 0.785 ms saved against a 25 ms step (3.0%); the real loop returns 3.9%
+at 2 MiB.
+
+!!! warning "Use the right metric for each"
+    **`% of ceiling` is the wrong metric for pinning** — it measures loader efficiency against
+    compute, and pinning speeds up a copy both sides perform, so it barely moves (it fell 0.9
+    points at 64² while absolute throughput rose 5%). Read absolute throughput for pinning,
+    and only between back-to-back runs: the compute ceiling drifted up to **9.7%** between
+    sessions on an unchanged checkout. Conversely `% of ceiling` *is* the right metric for the
+    reuse regression check, since it normalizes that drift away.
+
+    The ceiling is sampled **once per geometry per run** (`do_ceiling = ceiling and r == 0`)
+    while insitu gets every repeat, so `% of ceiling` inherits a single measurement's noise and
+    resolves only ~1 point however many repeats you add. The 64² row is the least reliable:
+    fastest, shortest, and it drifted monotonically (95.2 → 94.4 → 94.2 → 93.0) across
+    alternating arms. Prefer 128².
+
 ## Deferred
 
+- **Pinning at large payloads** — measured only at 0.5–8 MiB here, where the probe says the
+  win is smallest. Microscopy-scale batches (≥32 MiB) are where both halves should be worth
+  the most, and neither has been run end to end at that size.
 - **GPU baseline head-to-head** — the section above establishes insitu stays GPU-fed
   (94–98% of the compute ceiling); the matching `compute_ms` sweep of the **worker stacks**
   stalling once IO-bound is still to run.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -374,12 +374,33 @@ again in the cold fill: TTFB rises as chunks shrink (0.41 → 0.73 s) or fan int
 <iframe src="../figures/advection_chunk.html" width="100%" height="420" frameborder="0"></iframe>
 <iframe src="../figures/advection_inner.html" width="100%" height="420" frameborder="0"></iframe>
 
-## Batch buffers — reuse removes a cliff, pinning buys 1–2%
+## Batch buffers — what they're worth is a range, and your loop picks the point
 
 The loader reuses its batch output buffers rather than allocating one per batch, and
 `as_torch(..., device=...)` / `pin_host_buffers` put those buffers in page-locked memory and
 own the H2D copy. The two are separate changes with separate payoffs, and each is only
 visible on the axis it acts on.
+
+**Read every number below as a point in a range, not a headline.** Both optimizations remove
+*loader-side* cost, so their end-to-end value is bounded above by what an isolated probe
+measures with that cost fully exposed, and below by **zero** — because a loop whose compute
+step already hides the loader gets nothing, which is prefetch doing its job. Where a given
+workload falls is decided by one thing: how much compute it spends per byte delivered.
+
+| | upper bound (loader cost exposed) | our GPU training loop | lower bound |
+|---|---|---|---|
+| **reuse** | +10 … +16% above 32 MiB | **≈ 0** (±0.3 pt) | 0 |
+| **pinning** | copy hidden entirely below ~37 MiB | **+1 … +2%** | 0 |
+
+The advection loop runs at 98.7–100% of its compute ceiling, so for reuse it *is* the lower
+bound rather than an interior point — a well-fed GPU is the hardest case for a loader
+optimization to show up in, by construction. These land differently because they act on
+different sides: reuse saves producer-thread time, which prefetch is built to hide, while
+pinning shortens a copy on the consumer's critical path, which prefetch cannot.
+
+So the workloads that collect the top of these ranges are the ones spending less compute per
+byte — **inference rather than training**, shallow models, cold caches, IO-bound epochs. A
+saturated training GPU is where you should expect the least.
 
 ### Reuse: a payload-size cliff, not a speedup
 
@@ -388,7 +409,8 @@ batch** — a syscall trace shows 12 full-buffer pairs per 12-batch epoch withou
 with it — so the kernel re-zeroes the whole buffer each time. Below that threshold the freed
 block is recycled on the heap and reuse is a small cost instead.
 
-Synthetic sweep (`bench/batch_buffer_sweep.py`, L4, `--inner 256,256`, arms alternated):
+**The upper bound**, with allocation cost fully exposed (`bench/batch_buffer_sweep.py`, L4,
+`--inner 256,256`, arms alternated):
 
 | MiB/batch | 8 | 16 | 32 | 64 | 128 |
 |---|--:|--:|--:|--:|--:|
@@ -400,8 +422,8 @@ Synthetic sweep (`bench/batch_buffer_sweep.py`, L4, `--inner 256,256`, arms alte
 range while fresh allocation falls off a cliff; the small-batch end pays 2–3%. Weather-shaped
 batches sit in the losing region — a fraction of a percent of a step, but a cost, not a wash.
 
-That cliff does **not** surface in the GPU training loop. Sweeping batch size over one 256²
-store (`--sweeps payload`, 5 epochs × 5 repeats), with the no-reuse arm run from a checkout
+**The lower bound** is a GPU training loop, where the cliff does not surface at all. Sweeping
+batch size over one 256² store (`--sweeps payload`, 5 epochs × 5 repeats), with the no-reuse arm run from a checkout
 identical but for the `gather` call site, and each arm scored against **its own** in-session
 ceiling:
 
@@ -419,11 +441,12 @@ agrees to **0.04%** (138.52 vs 138.57 samples/s) — there the 0.29-point gap is
 sessions' *ceilings* differing, not the loader. Every arm returned a persistence RMSE of
 `0.588030696`, bit-identical, so the paths provably deliver the same bytes.
 
-So reuse removes a cliff that a compute-bound loop was already hiding. It earns its place on
-the loops that *aren't* — where allocation is not absorbed by a GPU step — and the synthetic
-sweep above is what measures those.
+So a saturated GPU sits at the bottom of reuse's range, and that is the expected place for it:
+prefetch exists to hide exactly this cost. The value is real at the other end — the +10–16%
+above — and it is collected by loops that do less compute per byte, plus the guarantee that
+growing your batch past 32 MiB cannot walk you off a cliff.
 
-### Pinning: +1 to +2%, and drift is half the signal
+### Pinning: +1 to +2% end to end, and drift is half the signal
 
 | geometry | payload/step | estimate | method |
 |---|--:|--:|---|
@@ -441,6 +464,14 @@ Round it to **+1 to +2%** and do not quote a third digit. The honest reading is 
 is a real but small win whose size is not resolved by ~0.7%-per-block drift, and that closing
 that gap needs `--pin` alternated *per repeat* inside one sweep rather than more hand-run
 blocks.
+
+Unlike reuse, this is an *interior* point in its range rather than the floor. In isolation
+(`bench/probe_batch_buffers.py --arms overlap`) a pinned copy below ~37 MiB is hidden
+completely — the pinned arm sits on the compute floor, while a pageable one costs more than
+its own transfer time, because it stages through a driver bounce buffer and cannot overlap at
+all. Pinning survives a compute-bound loop where reuse does not because it shortens work on
+the **consumer's** critical path; prefetch can hide producer-thread cost, but it cannot hide
+the step's own copy.
 
 !!! warning "Use the right metric for each — they differ"
     **`% of ceiling` is right for reuse and wrong for pinning.** Reuse changes only the loader,

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -405,17 +405,19 @@ store (`--sweeps payload`, 5 epochs × 5 repeats), with the no-reuse arm run fro
 identical but for the `gather` call site, and each arm scored against **its own** in-session
 ceiling:
 
-| MiB per variable buffer | 8 | 16 | 32 |
-|---|--:|--:|--:|
-| reuse (% of ceiling) | 99.69 | 99.92 | 99.74 |
-| no reuse | 99.49 | 99.72 | 99.92 |
-| delta (points) | +0.21 | +0.20 | −0.18 |
+| MiB per variable buffer | 8 | 16 | 32 | 64 |
+|---|--:|--:|--:|--:|
+| reuse (% of ceiling) | 99.69 | 99.92 | 99.74 | 98.74 |
+| no reuse | 99.49 | 99.72 | 99.92 | 99.03 |
+| delta (points) | +0.21 | +0.20 | −0.18 | −0.29 |
 
-Inside ±0.2 points with the sign flipping — a null. The loop runs at 99.5–100% of its compute
-ceiling with 0.1–0.3% stall, so producer-side allocation has nowhere to surface, **including
-at 32 MiB where the `mmap` path demonstrably engages** (0 faults per allocation at 8 and 16
-MiB, 100% of pages at 32 and 64). Both arms returned a persistence RMSE of `0.588030696`,
-bit-identical, so the two paths provably deliver the same bytes.
+Inside ±0.3 points with the sign flipping twice — a null across an 8× payload range. The loop
+runs at 98.7–100% of its compute ceiling, so producer-side allocation has nowhere to surface,
+**including above 32 MiB where the `mmap` path demonstrably engages** (0 faults per allocation
+at 8 and 16 MiB, 100% of pages at 32 and 64). At 64 MiB the two arms' absolute throughput
+agrees to **0.04%** (138.52 vs 138.57 samples/s) — there the 0.29-point gap is the two
+sessions' *ceilings* differing, not the loader. Every arm returned a persistence RMSE of
+`0.588030696`, bit-identical, so the paths provably deliver the same bytes.
 
 So reuse removes a cliff that a compute-bound loop was already hiding. It earns its place on
 the loops that *aren't* — where allocation is not absorbed by a GPU step — and the synthetic

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -487,7 +487,11 @@ the step's own copy.
     an unchanged checkout — the same size as these effects.
 
     Reproduce the no-reuse arm with `INSITUBATCH_NO_BUFFER_REUSE=1` rather than a second
-    checkout; the epoch log stamps `REUSE OFF` so those rows stay identifiable.
+    checkout; the epoch log stamps `REUSE OFF` so those rows stay identifiable. Do not combine
+    it with `--pin` for a *timing* row: the pin budget is a monotone counter sized for a pool
+    that converges, so without reuse it is spent within a few batches and the rest of the run
+    silently runs pageable. The pool warns when you do it. It is still the right way to ask
+    whether reuse is corrupting a pinned run — a correctness question, not a throughput one.
 
     The ceiling is sampled **once per geometry per run** (`do_ceiling = ceiling and r == 0`)
     while insitu gets every repeat, so `% of ceiling` inherits a single measurement's noise and

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -374,7 +374,7 @@ again in the cold fill: TTFB rises as chunks shrink (0.41 → 0.73 s) or fan int
 <iframe src="../figures/advection_chunk.html" width="100%" height="420" frameborder="0"></iframe>
 <iframe src="../figures/advection_inner.html" width="100%" height="420" frameborder="0"></iframe>
 
-## Batch buffers — reuse removes a cliff, pinning buys 2–4%
+## Batch buffers — reuse removes a cliff, pinning buys 1–2%
 
 The loader reuses its batch output buffers rather than allocating one per batch, and
 `as_torch(..., device=...)` / `pin_host_buffers` put those buffers in page-locked memory and
@@ -400,39 +400,61 @@ Synthetic sweep (`bench/batch_buffer_sweep.py`, L4, `--inner 256,256`, arms alte
 range while fresh allocation falls off a cliff; the small-batch end pays 2–3%. Weather-shaped
 batches sit in the losing region — a fraction of a percent of a step, but a cost, not a wash.
 
-That cost does **not** surface in the GPU training loop above: across four alternating runs
-(with and without reuse, 5 epochs × 7 repeats), the 128² geometry held 99.2 / 99.3 / 99.4 /
-99.3 % of ceiling — 0.2 points of spread, with no arm signal. Producer-side work is what
-prefetch is for, and a compute-bound loop absorbs it.
+That cliff does **not** surface in the GPU training loop. Sweeping batch size over one 256²
+store (`--sweeps payload`, 5 epochs × 5 repeats), with the no-reuse arm run from a checkout
+identical but for the `gather` call site, and each arm scored against **its own** in-session
+ceiling:
 
-### Pinning: +2–4% end to end, and it shows in the ceiling too
+| MiB per variable buffer | 8 | 16 | 32 |
+|---|--:|--:|--:|
+| reuse (% of ceiling) | 99.69 | 99.92 | 99.74 |
+| no reuse | 99.49 | 99.72 | 99.92 |
+| delta (points) | +0.21 | +0.20 | −0.18 |
 
-Same checkout, same box, back-to-back, `--pin` the only difference:
+Inside ±0.2 points with the sign flipping — a null. The loop runs at 99.5–100% of its compute
+ceiling with 0.1–0.3% stall, so producer-side allocation has nowhere to surface, **including
+at 32 MiB where the `mmap` path demonstrably engages** (0 faults per allocation at 8 and 16
+MiB, 100% of pages at 32 and 64). Both arms returned a persistence RMSE of `0.588030696`,
+bit-identical, so the two paths provably deliver the same bytes.
 
-| geometry | payload | without | with | delta |
-|---|--:|--:|--:|--:|
-| 64² | 0.5 MiB | 4448.7 | 4672.2 | **+5.0%** |
-| 128² | 2 MiB | 583.1 | 605.8 | **+3.9%** |
-| 256² | 8 MiB | 145.2 | 148.5 | **+2.3%** |
+So reuse removes a cliff that a compute-bound loop was already hiding. It earns its place on
+the loops that *aren't* — where allocation is not absorbed by a GPU step — and the synthetic
+sweep above is what measures those.
 
-Pinned is the maximum at every geometry and outside the range of the four unpinned runs in
-all three. The compute ceiling rises by almost exactly the same amount (+6.1 / +3.6 / +2.1%)
-because the ceiling loop preloads batches into RAM but still issues the same per-step H2D
-copy — loader and ceiling moving in lockstep is the evidence that what changed is *the
-transfer*. The larger field gains least: its compute per sample is 4× heavier, so the copy is
-a smaller share of the step.
+### Pinning: +1 to +2%, and drift is half the signal
 
-This matches the isolated prediction. `bench/probe_batch_buffers.py --arms overlap` put a
-1.5 MiB pinned copy at 0.785 ms saved against a 25 ms step (3.0%); the real loop returns 3.9%
-at 2 MiB.
+| geometry | payload/step | estimate | method |
+|---|--:|--:|---|
+| 256² batch 128 | 128 MiB | **+1.5%** (bounds +0.8 … +2.2%) | A/B/A bracket |
+| 256² batch 32–128 | 32–128 MiB | **+2.0 … +2.3%** | cross-session ceilings |
 
-!!! warning "Use the right metric for each"
-    **`% of ceiling` is the wrong metric for pinning** — it measures loader efficiency against
-    compute, and pinning speeds up a copy both sides perform, so it barely moves (it fell 0.9
-    points at 64² while absolute throughput rose 5%). Read absolute throughput for pinning,
-    and only between back-to-back runs: the compute ceiling drifted up to **9.7%** between
-    sessions on an unchanged checkout. Conversely `% of ceiling` *is* the right metric for the
-    reuse regression check, since it normalizes that drift away.
+Both agree on the sign; they disagree on magnitude by about 1.5×, and the gap *is* the
+measurement error. An A/B/A at batch 128 — unpinned, pinned, unpinned, back to back — read
+145.4 / 146.6 / 143.4 samples/s. The two **identical** unpinned blocks differ by 1.4% some 20
+minutes apart, systematically (each block's own repeats agreed to ±0.3). Fitting that as a 1.0
+samples/s per-block decline puts the unpinned baseline at 144.4 in the pinned slot against an
+actual 146.6, hence +1.5%; taking `b−a` or `b−c` instead gives +0.8% or +2.2%.
+
+Round it to **+1 to +2%** and do not quote a third digit. The honest reading is that pinning
+is a real but small win whose size is not resolved by ~0.7%-per-block drift, and that closing
+that gap needs `--pin` alternated *per repeat* inside one sweep rather than more hand-run
+blocks.
+
+!!! warning "Use the right metric for each — they differ"
+    **`% of ceiling` is right for reuse and wrong for pinning.** Reuse changes only the loader,
+    so scoring against the in-session ceiling isolates it and divides drift out. Pinning
+    changes a copy **both** sides perform: `--pin` reaches the ceiling too, because
+    `pin_host_buffers` runs before `preload_epoch`, which is `list(ds.train)`. The ceiling then
+    moves with the loader (+2.0–2.3% in lockstep) and `% of ceiling` cancels the effect —
+    it sat at ~99.8% across a pinned A/B while absolute throughput moved 2.2%. For pinning,
+    read bracketed absolute throughput and nothing else.
+
+    Run the control arm **twice, before and after** the treatment, and read the treatment
+    against their interpolation. A single back-to-back pair carries roughly ±0.7% of drift on
+    an unchanged checkout — the same size as these effects.
+
+    Reproduce the no-reuse arm with `INSITUBATCH_NO_BUFFER_REUSE=1` rather than a second
+    checkout; the epoch log stamps `REUSE OFF` so those rows stay identifiable.
 
     The ceiling is sampled **once per geometry per run** (`do_ceiling = ceiling and r == 0`)
     while insitu gets every repeat, so `% of ceiling` inherits a single measurement's noise and

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -2,7 +2,12 @@
 
 This page is practical guidance for setting up `InSituDataset` on your own store. For *why*
 the engine behaves this way — the read plan, the pool, the prefetch pipeline — see
-[Architecture](architecture.md).
+[Architecture](architecture.md); for the measurements behind the numbers here, see
+[Benchmarks](benchmarks.md).
+
+Read [Two operating points](#two-operating-points) first if you are serving inference rather
+than training — several defaults below are chosen for training and are the wrong call for a
+latency-sensitive single pass.
 
 ## The mental model
 
@@ -17,6 +22,37 @@ Hold these two sentences and the rest follows:
 So the loader reads each chunk once, holds a rolling window of them, and serves shuffled
 batches out of that window — concurrency fills the window, the window bounds memory.
 
+## Two operating points
+
+The same knobs point in different directions depending on what you are optimizing, and the
+difference is large enough that guidance for one is actively wrong for the other.
+
+- **Training** optimizes **steady-state throughput per GB of RAM**. It runs for hours, so the
+  first batch costs nothing, and it re-reads the data every epoch, so caching and shuffle
+  quality matter.
+- **Inference / scoring** optimizes **time to first batch**. It is single-pass (no shuffle to
+  protect, nothing to cache across epochs) and often short-lived, so a cold start you could
+  ignore in training is the whole latency budget.
+
+`max_inflight` is where they diverge, and not in the way its name suggests. Sweeping it over
+real WeatherBench2 ERA5 on a GPU loop:
+
+| `max_inflight` | samples/s | stall | peak RSS | **cold TTFB** | warm TTFB |
+|---|--:|--:|--:|--:|--:|
+| 1 | 1332.1 | 3.7% | 1095 MB | **3462 ms** | 87 ms |
+| 4 | 1330.3 | 3.6% | 1121 MB | 656 ms | 85 ms |
+| 16 | 1326.9 | 3.7% | 1198 MB | 347 ms | 88 ms |
+| 32 (default) | 1332.1 | 3.4% | 1246 MB | **317 ms** | 80 ms |
+
+**Steady-state throughput does not move at all** — 1332.1 at either end, stall flat — while
+cold TTFB moves **11×**. On a loop with enough compute per byte, read-ahead is a *cold-start*
+dial, not a throughput dial. Dropping it to 1 buys ~150 MB (12%) for free in training, and
+costs an inference service more than three seconds on its first request.
+
+The corollary for the other two axes: **`block_chunks` is a training knob** (it buys shuffle
+quality, and only `.train` shuffles — eval views are deterministic), and the **cross-epoch
+cache is a training knob** (single-pass scoring never reads a chunk twice).
+
 ## The knobs you set
 
 All of these are `InSituDataset(...)` arguments except the last, which is fixed when the
@@ -26,15 +62,17 @@ store is written.
 |---|---|---|---|
 | batch size | `batch_size` | samples per batch | 32 |
 | shuffle window | `block_chunks` | outer chunks held resident + shuffled across at once | 16 |
-| reads in flight | `max_inflight` | concurrent stored-chunk GETs (the network dial) | 32 |
+| reads in flight | `max_inflight` | concurrent stored-chunk GETs — sets **cold start**; sets throughput only while IO-bound | 32 |
 | batch queue | `prefetch_depth` | assembled batches queued ahead of your training step | 2 |
 | cache | `cache_budget_bytes`, `cache_dir` | decoded data retained across epochs (decode-once) | off |
 | stored-chunk size | `inner_chunks` (write time) | the fetch unit — how each chunk is split for IO | — |
 
 `batch_size` is the ordinary ML knob and barely touches IO. `block_chunks` trades shuffle
-quality against RAM. `max_inflight` is what you turn to saturate the network. The cache is
-how repeated epochs (or repeated scoring passes) skip re-reading. `inner_chunks` is the one
-decision made when the data is written, and it sets how cheap concurrency can be.
+quality against RAM. `max_inflight` saturates the network *while you are IO-bound* — once
+compute is the constraint it stops buying throughput and buys cold start instead, which is
+why the table above matters more than its name suggests. The cache is how repeated epochs (or
+repeated scoring passes) skip re-reading. `inner_chunks` is the one decision made when the
+data is written, and it sets how cheap concurrency can be.
 
 ## The memory model
 
@@ -94,25 +132,53 @@ converges toward a full-dataset shuffle over many epochs — the regime training
 in. [`shuffle_quality`](api.md) scores an emitted order 0–1 (1 ≈ global) if you want to
 measure it; [Architecture](architecture.md) explains why the block-local shuffle converges.
 
+This section is training-only: only `.train` shuffles — `.val`, `.test` and `.all` are
+deterministic — so a scoring pass has no shuffle quality to protect.
+
 ## The recipe
 
 1. **At write time, pick `inner_chunks`** so a stored chunk is ~10–50 MB: small enough that
    many reads in flight stay cheap, large enough that per-request overhead doesn't dominate.
 2. **Start with the defaults** (`max_inflight=32`, `block_chunks=16`). 32 reads in flight
    saturates in-region S3 in most cases.
-3. **Raise `block_chunks`** for better shuffle quality, as far as your RAM allows
-   (`block_chunks × outer_chunk_bytes` ≤ your budget).
-4. **Tune `max_inflight`** if the network isn't saturated — raise it until decoded MB/s
-   stops climbing. From the repo you can measure the knee directly:
+3. **Size `block_chunks` to your RAM budget** (`block_chunks × outer_chunk_bytes` ≤ what you
+   have). Which direction to push it from there is the branch below.
+4. **Tune `max_inflight`** by the metric your operating point cares about — raise it until
+   decoded MB/s stops climbing, *and* check TTFB, because past the IO-bound region only TTFB
+   keeps responding. From the repo you can measure the knee directly:
 
    ```bash
    python -m bench.probe_decode --url <store> --concurrency 1,4,8,16,32
    ```
 
+   If throughput is flat across that range you are compute-bound, and the knob is now buying
+   cold start alone — see the table above before turning it down to reclaim memory.
+
 5. **Sanity-check concurrency cost** (`max_inflight × stored_chunk_bytes`). If it's large,
    your stored chunks are too big — chunk the inner dims (step 1).
-6. **For multi-epoch training**, set `cache_budget_bytes` to hold the split (and `cache_dir`
-   on NVMe to spill); epoch 0 warms it and later epochs read decode-once.
+
+Then branch on what you are running:
+
+**For multi-epoch training**
+
+- Set `cache_budget_bytes` to hold the split (and `cache_dir` on NVMe to spill); epoch 0 warms
+  it and later epochs read decode-once.
+- Raise `block_chunks` as far as RAM allows — it is your shuffle quality.
+- If RAM is tight, **`max_inflight` is the cheapest thing to give up**: measured, dropping it
+  to 1 cost nothing in steady-state throughput and returned ~12% of peak RSS. You pay the cold
+  start once, at the start of a run that lasts hours.
+
+**For inference / single-pass scoring**
+
+- **Leave `max_inflight` high.** It is the cold-start knob, worth ~11× on time to first batch,
+  and the ~150 MB it costs is the cheapest latency you will ever buy. This is the one place
+  not to economize.
+- Keep `block_chunks` small — there is no shuffle to protect (eval views are deterministic),
+  so the window only needs to hold the read plan.
+- Skip the cross-epoch cache unless you score the same data more than once; a single pass
+  never reads a chunk twice, so the budget is pure overhead.
+- If the first batch still dominates, the remaining lever is at write time: smaller
+  `inner_chunks` make the first window's reads finish sooner (step 1).
 
 ## Regimes
 

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -57,6 +57,33 @@ If you set `cache_budget_bytes` above the working set, residency rises to that b
 purpose — that extra memory *is* the cross-epoch cache. Point `cache_dir` at local NVMe to
 spill it to disk instead of RAM.
 
+### The batch queue is a high-water mark
+
+Batch buffers are pooled and held for the dataset's lifetime, so that third bound is the
+largest number of batches ever simultaneously live — not the steady state. A transient burst
+that holds many at once (`list(ds.val)` to materialize a split, gradient accumulation over N
+steps, an exported tensor kept past its batch) permanently raises the resident floor to that
+burst's size.
+
+It cannot raise **peak** memory. The floor is exactly what was simultaneously live at the
+peak, which fresh-allocation-per-batch also held at that instant; pooling only declines to
+give it back afterwards. If the burst fit, the floor fits.
+
+`close()` is the only release, and it drops the cross-epoch chunk cache and store session with
+it — so size the budget for your burst rather than planning to reclaim between phases. The
+per-epoch log line reports the pool directly, and `allocated` staying nonzero after the first
+epoch is the signal that batches are not coming back:
+
+```
+epoch 3 (train): chunks 151/151 hit (100%), peak resident 51;
+                 batch buffers 17 x pinned = 544.0 MiB, 100 lent, 0 allocated
+```
+
+Under `pin_host_buffers` / `as_torch(..., device=...)` the floor is page-locked, which the
+kernel cannot reclaim — so it is bounded separately at RAM/8 by default. Past that the loader
+hands out ordinary pageable memory and warns once, rather than raising or stalling; raise
+`pin_budget_bytes` if you meant to exceed it.
+
 ## Shuffle quality
 
 `block_chunks` is also the shuffle-quality knob. Each batch is drawn from the samples in the

--- a/examples/_logging.py
+++ b/examples/_logging.py
@@ -1,0 +1,39 @@
+"""Logging setup for the examples.
+
+insitubatch emits one INFO line per epoch summarising both pools -- chunk-cache hit rate and
+peak residency, batch-buffer count/kind/reuse -- but it never configures logging, because a
+library that calls ``basicConfig`` hijacks its caller's setup. Applications do that, and the
+examples are applications, so the wiring lives here and every example CLI gets the same flag.
+
+Only the ``insitubatch`` logger is turned up. Setting the *root* level to INFO instead would
+also unmute zarr, obstore, gcsfs and aiohttp, which bury the one line worth reading.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+LEVELS = ("debug", "info", "warning", "error")
+DEFAULT_LEVEL = "info"
+"""Examples show the per-epoch summary by default -- seeing what the loader did is the point."""
+
+
+def add_log_level(parser: argparse.ArgumentParser) -> None:
+    """Add ``--log-level`` to an example's CLI."""
+    parser.add_argument(
+        "--log-level",
+        choices=LEVELS,
+        default=DEFAULT_LEVEL,
+        help="insitubatch log level (default: info -- one summary line per epoch)",
+    )
+
+
+def configure_logging(level: str = DEFAULT_LEVEL) -> None:
+    """Install a stderr handler and set the ``insitubatch`` logger's level.
+
+    ``basicConfig`` supplies the handler and leaves everything else at WARNING; only the
+    insitubatch logger is raised, so third-party INFO chatter stays out of the way.
+    """
+    logging.basicConfig(format="%(levelname)s %(name)s: %(message)s", level=logging.WARNING)
+    logging.getLogger("insitubatch").setLevel(getattr(logging, level.upper()))

--- a/examples/advection/data.py
+++ b/examples/advection/data.py
@@ -291,6 +291,50 @@ def evaluate(view: Iterable[Batch], predict: Callable[[Batch], np.ndarray]) -> t
     return rmse(pred, target), rmse(persistence, target)
 
 
+def format_skill(model_rmse: float, persistence_rmse: float) -> str:
+    """The end-of-run verdict line: forecast skill against persistence, with a verdict word.
+
+    Reported as a **signed skill score** (``1 - model/persistence``) rather than a ratio,
+    because the sign is what matters and a ratio hides it. A corrupt-batch run once printed
+    "0.5x better" for a model that was *84% worse* than predicting no change; a reader skims
+    past that, and it went unnoticed for a night. ``-84.2% skill  [FAIL]`` does not.
+
+    **The verdict is the sign of the skill, and nothing else** -- deliberately no "too low"
+    band. Healthy skill is a property of the *data*, not of correctness: measured, this
+    example earns +33% on the 64-cell synthetic grid, +22% at 128, +10% at 256, and +11% on
+    real WeatherBench2 ERA5. A corrupt run scored +13.6% -- above honest ERA5. So no fixed
+    threshold separates working from broken, and any band tight enough to catch corruption
+    would fire on real data. ``skill < 0`` is the one comparison that means the same thing on
+    every dataset: worse than predicting no change.
+
+    The second line is the stronger check, and it catches what the sign test cannot.
+    Persistence RMSE is ``rmse(t2m(t), t2m(t+24h))`` -- **no model is involved**, so it is a
+    fixed property of the validation data and must be identical across runs, repeats, and
+    code paths reading the same store. The +13.6% run above was corrupt precisely because
+    *its* persistence had drifted 0.682 -> 0.934 and varied +-0.307 between repeats of one
+    config, while a healthy arm reproduced 0.682 to the last digit every time. The skill
+    number passed; the invariant did not. So the invariant is printed as an invariant rather
+    than buried as a denominator, and :func:`bench.advection_sweep` asserts it across repeats.
+    """
+    skill = 1.0 - model_rmse / persistence_rmse
+    verdict = "PASS" if skill > 0 else "FAIL"
+    lines = [
+        f"\n24 h forecast skill on held-out data: model RMSE {model_rmse:.3f} vs "
+        f"persistence {persistence_rmse:.3f}  ->  {skill:+.1%} skill  [{verdict}]"
+    ]
+    if verdict == "FAIL":
+        lines.append(
+            "  FAIL: worse than predicting no change at all -- on any dataset that is a broken "
+            "run,\n  and the data path is the first suspect, not the training."
+        )
+    lines.append(
+        f"  persistence RMSE ({persistence_rmse:.3f}) is model-independent -- a fixed property "
+        "of the val data.\n  If it moves between runs over the same store, the loader is "
+        "returning different bytes."
+    )
+    return "\n".join(lines)
+
+
 def _range(s: str) -> tuple[int, int]:
     start, stop = (int(x) for x in s.split(","))
     return (start, stop)

--- a/examples/advection/data.py
+++ b/examples/advection/data.py
@@ -38,6 +38,8 @@ from insitubatch import (
     split_by_chunk,
 )
 
+from .._logging import add_log_level, configure_logging
+
 # The public WeatherBench2 ERA5 (6-hourly) ARCO store the wb2_* examples use.
 WB2_URL = (
     "gs://weatherbench2/datasets/era5/1959-2022-6h-128x64_equiangular_with_poles_conservative.zarr"
@@ -346,6 +348,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="spill the decoded-chunk cache here (e.g. NVMe) for cross-epoch reuse",
     )
+    add_log_level(p)
     p.add_argument(
         "--max-inflight",
         type=int,
@@ -356,8 +359,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def cli() -> argparse.Namespace:
-    """Parse the shared CLI for the three canonical training files."""
-    return build_parser().parse_args()
+    """Parse the shared CLI for the three canonical training files, and set logging up."""
+    args = build_parser().parse_args()
+    configure_logging(args.log_level)
+    return args
 
 
 def build_datasets(args: argparse.Namespace) -> InSituDataset:

--- a/examples/advection/train_jax.py
+++ b/examples/advection/train_jax.py
@@ -18,7 +18,7 @@ import optax
 
 from insitubatch import Batch, InSituDataset, to_jax
 
-from .data import build_datasets, cli, evaluate
+from .data import build_datasets, cli, evaluate, format_skill
 
 
 class AdvectionCNN(fnn.Module):
@@ -89,10 +89,7 @@ def main() -> None:
     args = cli()
     ds = build_datasets(args)
     model_rmse, persistence_rmse = train(ds, epochs=args.epochs, device=args.device)
-    print(
-        f"\n24 h forecast RMSE on held-out data: model {model_rmse:.3f}  vs  "
-        f"persistence {persistence_rmse:.3f}  ({persistence_rmse / model_rmse:.1f}x better)"
-    )
+    print(format_skill(model_rmse, persistence_rmse))
 
 
 if __name__ == "__main__":

--- a/examples/advection/train_tf.py
+++ b/examples/advection/train_tf.py
@@ -14,7 +14,7 @@ from tensorflow import keras
 
 from insitubatch import Batch, InSituDataset, to_tf
 
-from .data import build_datasets, cli, evaluate
+from .data import build_datasets, cli, evaluate, format_skill
 
 
 class CircularConv(keras.layers.Layer):
@@ -92,10 +92,7 @@ def main() -> None:
     args = cli()
     ds = build_datasets(args)
     model_rmse, persistence_rmse = train(ds, epochs=args.epochs, device=args.device)
-    print(
-        f"\n24 h forecast RMSE on held-out data: model {model_rmse:.3f}  vs  "
-        f"persistence {persistence_rmse:.3f}  ({persistence_rmse / model_rmse:.1f}x better)"
-    )
+    print(format_skill(model_rmse, persistence_rmse))
 
 
 if __name__ == "__main__":

--- a/examples/advection/train_torch.py
+++ b/examples/advection/train_torch.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import torch
 from torch import nn
 
-from insitubatch import Batch, InSituDataset, to_torch
+from insitubatch import InSituDataset, to_torch
 
 from .data import build_datasets, cli, evaluate
 
@@ -48,16 +48,29 @@ class AdvectionCNN(nn.Module):
         return self.net(xn)
 
 
-def _forecast(model: AdvectionCNN, batch: Batch, device: torch.device) -> torch.Tensor:
-    """t2m(t+24h) forecast for one batch: persistence + the model's predicted tendency.
+def _forecast(model: AdvectionCNN, d: dict[str, torch.Tensor]) -> torch.Tensor:
+    """t2m(t+24h) forecast for one already-transferred batch: persistence + predicted tendency.
 
-    ``to_torch(..., device=...)`` hands the batch over by DLPack and issues the H2D copy in
-    one step. Stacking happens **after** the transfer, on the device: stacking first would
-    build a fresh (B, 3, H, W) CPU tensor -- a copy of the whole batch into memory the loader
-    does not own, which is both wasted work and unpinnable, so it would defeat page-locked
-    buffers for the one tensor that matters most.
+    Takes **device tensors, not a** ``Batch``: the H2D copy belongs to the caller, once per
+    step. Passing the batch in and converting here would move every variable a second time,
+    since the loop also needs ``target`` -- twice the traffic the step actually requires, which
+    is exactly the kind of overhead a pinning measurement would then misattribute to pinning.
+
+    Stacking happens **after** the transfer, on the device: stacking first would build a fresh
+    (B, 3, H, W) CPU tensor -- a copy of the whole batch into memory the loader does not own,
+    which is both wasted work and unpinnable, so it would defeat page-locked buffers for the
+    one tensor that matters most.
+
+    That trade is not free, and the cost is device memory. Counting a (B, H, W) variable as one
+    unit: stacking on the host holds 5 units on the GPU (the stack, plus t2m and target moved
+    separately) and copies 5 across PCIe; stacking here holds **7** (four transferred variables
+    plus the stack) and copies 4. So it is +2 units of GPU memory for one fewer variable-copy
+    per step -- 224 MiB vs 160 MiB at a 32 MiB payload, against conv activations that are
+    larger still. A loop tight on device memory would instead transfer straight into the slices
+    of a preallocated ``x``, which needs an ``out=``-style device target this adapter does not
+    have yet (it would also have to hold the source until the copy lands, which is exactly what
+    ``to_torch(..., device=...)`` does for us here).
     """
-    d = to_torch(batch, device=device)  # {label: (B, H, W)}, already on device
     x = torch.stack([d["t2m"], d["u10"], d["v10"]], dim=1)  # (B, 3, H, W), on device
     return d["t2m"][:, None] + model(x)  # (B, 1, H, W)
 
@@ -72,8 +85,8 @@ def train(ds: InSituDataset, *, epochs: int, device: str = "cpu") -> tuple[float
         model.train()
         last = 0.0
         for batch in ds.train:
-            target = to_torch(batch, device=dev)["target"][:, None]
-            loss = nn.functional.mse_loss(_forecast(model, batch, dev), target)
+            d = to_torch(batch, device=dev)  # the step's one H2D transfer, all variables
+            loss = nn.functional.mse_loss(_forecast(model, d), d["target"][:, None])
             opt.zero_grad()
             loss.backward()
             opt.step()
@@ -81,7 +94,9 @@ def train(ds: InSituDataset, *, epochs: int, device: str = "cpu") -> tuple[float
         print(f"epoch {epoch}  train mse {last:.4f}")
     model.eval()
     with torch.no_grad():
-        return evaluate(ds.val, lambda b: _forecast(model, b, dev).detach().cpu().numpy())
+        return evaluate(
+            ds.val, lambda b: _forecast(model, to_torch(b, device=dev)).detach().cpu().numpy()
+        )
 
 
 def main() -> None:

--- a/examples/advection/train_torch.py
+++ b/examples/advection/train_torch.py
@@ -51,11 +51,15 @@ class AdvectionCNN(nn.Module):
 def _forecast(model: AdvectionCNN, batch: Batch, device: torch.device) -> torch.Tensor:
     """t2m(t+24h) forecast for one batch: persistence + the model's predicted tendency.
 
-    ``to_torch`` is a zero-copy DLPack hand-off on CPU; moving to ``device`` is the H2D
-    copy -- placement is the training loop's job, not the dataset's (it speaks numpy)."""
-    d = to_torch(batch)  # {label: (B, H, W) tensor}, CPU via DLPack
-    x = torch.stack([d["t2m"], d["u10"], d["v10"]], dim=1).to(device)  # (B, 3, H, W)
-    return d["t2m"][:, None].to(device) + model(x)  # (B, 1, H, W)
+    ``to_torch(..., device=...)`` hands the batch over by DLPack and issues the H2D copy in
+    one step. Stacking happens **after** the transfer, on the device: stacking first would
+    build a fresh (B, 3, H, W) CPU tensor -- a copy of the whole batch into memory the loader
+    does not own, which is both wasted work and unpinnable, so it would defeat page-locked
+    buffers for the one tensor that matters most.
+    """
+    d = to_torch(batch, device=device)  # {label: (B, H, W)}, already on device
+    x = torch.stack([d["t2m"], d["u10"], d["v10"]], dim=1)  # (B, 3, H, W), on device
+    return d["t2m"][:, None] + model(x)  # (B, 1, H, W)
 
 
 def train(ds: InSituDataset, *, epochs: int, device: str = "cpu") -> tuple[float, float]:
@@ -68,7 +72,7 @@ def train(ds: InSituDataset, *, epochs: int, device: str = "cpu") -> tuple[float
         model.train()
         last = 0.0
         for batch in ds.train:
-            target = to_torch(batch)["target"][:, None].to(dev)
+            target = to_torch(batch, device=dev)["target"][:, None]
             loss = nn.functional.mse_loss(_forecast(model, batch, dev), target)
             opt.zero_grad()
             loss.backward()

--- a/examples/advection/train_torch.py
+++ b/examples/advection/train_torch.py
@@ -19,7 +19,7 @@ from torch import nn
 
 from insitubatch import InSituDataset, to_torch
 
-from .data import build_datasets, cli, evaluate
+from .data import build_datasets, cli, evaluate, format_skill
 
 
 class AdvectionCNN(nn.Module):
@@ -103,10 +103,7 @@ def main() -> None:
     args = cli()
     ds = build_datasets(args)
     model_rmse, persistence_rmse = train(ds, epochs=args.epochs, device=args.device)
-    print(
-        f"\n24 h forecast RMSE on held-out data: model {model_rmse:.3f}  vs  "
-        f"persistence {persistence_rmse:.3f}  ({persistence_rmse / model_rmse:.1f}x better)"
-    )
+    print(format_skill(model_rmse, persistence_rmse))
 
 
 if __name__ == "__main__":

--- a/examples/advection/train_torch_metrics.py
+++ b/examples/advection/train_torch_metrics.py
@@ -101,7 +101,9 @@ def train(
     """
     dev = torch.device(device)
     log = log or MetricsLog(None)
-    if pin:
+    if pin and dev.type == "cuda":
+        # Pinning is a CUDA allocation; on a CPU run it would raise from the producer thread.
+        # The sweep passes --pin unconditionally, and the examples default to --device cpu.
         pin_host_buffers(ds.train)
 
     def loader_epoch(epoch: int) -> Iterable[Batch]:

--- a/examples/advection/train_torch_metrics.py
+++ b/examples/advection/train_torch_metrics.py
@@ -26,7 +26,7 @@ from insitubatch.frameworks import pin_host_buffers
 
 from .._forecast_metrics import MetricsLog, StallTimer, preload_epoch
 from .._logging import configure_logging
-from .data import build_datasets, build_parser, evaluate
+from .data import build_datasets, build_parser, evaluate, format_skill
 from .train_torch import AdvectionCNN, _forecast
 
 
@@ -182,10 +182,7 @@ def main() -> None:
     )
     log.summary()
     log.flush()
-    print(
-        f"\n24 h forecast RMSE on held-out data: model {model_rmse:.3f}  vs  "
-        f"persistence {persistence_rmse:.3f}  ({persistence_rmse / model_rmse:.1f}x better)"
-    )
+    print(format_skill(model_rmse, persistence_rmse))
 
 
 if __name__ == "__main__":

--- a/examples/advection/train_torch_metrics.py
+++ b/examples/advection/train_torch_metrics.py
@@ -22,6 +22,7 @@ import torch
 from torch import nn
 
 from insitubatch import Batch, InSituDataset, to_torch
+from insitubatch.frameworks import pin_host_buffers
 
 from .._forecast_metrics import MetricsLog, StallTimer, preload_epoch
 from .data import build_datasets, build_parser, evaluate
@@ -52,7 +53,7 @@ def _fit(
             torch.cuda.reset_peak_memory_stats(dev)
         timer = StallTimer()
         for batch in timer.wrap(epochs_source(epoch)):
-            target = to_torch(batch)["target"][:, None].to(dev)
+            target = to_torch(batch, device=dev)["target"][:, None]
             loss = nn.functional.mse_loss(_forecast(model, batch, dev), target)
             opt.zero_grad()
             loss.backward()
@@ -87,14 +88,21 @@ def train(
     source: str = "synthetic",
     batch_size: int = 32,
     ceiling: bool = False,
+    pin: bool = False,
     log: MetricsLog | None = None,
 ) -> tuple[float, float]:
     """Train the CNN and record stall/throughput metrics to ``log``; return the val skill.
 
     With ``ceiling=True`` it then trains a second, identical model on a RAM-preloaded epoch
-    (no IO) -- the compute-only ceiling the ``insitu`` run is scored against."""
+    (no IO) -- the compute-only ceiling the ``insitu`` run is scored against. ``pin`` puts the
+    batch buffers in page-locked memory so the H2D copies this loop already issues through
+    ``to_torch(..., device=...)`` can overlap compute instead of serialising on a driver
+    bounce buffer; it is A/B-able because everything else about the loop is unchanged.
+    """
     dev = torch.device(device)
     log = log or MetricsLog(None)
+    if pin:
+        pin_host_buffers(ds.train)
 
     def loader_epoch(epoch: int) -> Iterable[Batch]:
         ds.set_epoch(epoch)
@@ -127,7 +135,7 @@ def train(
 
 
 def cli() -> argparse.Namespace:
-    """The shared example CLI plus the two benchmark-only flags."""
+    """The shared example CLI plus the benchmark-only flags."""
     p = build_parser()
     p.add_argument(
         "--ceiling",
@@ -139,6 +147,11 @@ def cli() -> argparse.Namespace:
         default=None,
         metavar="PATH",
         help="append per-(run,epoch) JSONL metrics here (default: print only, no file)",
+    )
+    p.add_argument(
+        "--pin",
+        action="store_true",
+        help="page-lock the batch buffers so this loop's H2D copies can overlap compute",
     )
     return p.parse_args()
 
@@ -154,6 +167,7 @@ def main() -> None:
         source=args.source,
         batch_size=args.batch_size,
         ceiling=args.ceiling,
+        pin=args.pin,
         log=log,
     )
     log.summary()

--- a/examples/advection/train_torch_metrics.py
+++ b/examples/advection/train_torch_metrics.py
@@ -25,6 +25,7 @@ from insitubatch import Batch, InSituDataset, to_torch
 from insitubatch.frameworks import pin_host_buffers
 
 from .._forecast_metrics import MetricsLog, StallTimer, preload_epoch
+from .._logging import configure_logging
 from .data import build_datasets, build_parser, evaluate
 from .train_torch import AdvectionCNN, _forecast
 
@@ -160,7 +161,9 @@ def cli() -> argparse.Namespace:
         action="store_true",
         help="page-lock the batch buffers so this loop's H2D copies can overlap compute",
     )
-    return p.parse_args()
+    args = p.parse_args()
+    configure_logging(args.log_level)  # `build_parser` added --log-level
+    return args
 
 
 def main() -> None:

--- a/examples/advection/train_torch_metrics.py
+++ b/examples/advection/train_torch_metrics.py
@@ -53,8 +53,11 @@ def _fit(
             torch.cuda.reset_peak_memory_stats(dev)
         timer = StallTimer()
         for batch in timer.wrap(epochs_source(epoch)):
-            target = to_torch(batch, device=dev)["target"][:, None]
-            loss = nn.functional.mse_loss(_forecast(model, batch, dev), target)
+            # One transfer per step, all four variables. Converting again inside `_forecast`
+            # would double this loop's H2D traffic -- and a pinning A/B measured on a loop that
+            # moves twice what it needs overstates what pinning is worth to an efficient one.
+            d = to_torch(batch, device=dev)
+            loss = nn.functional.mse_loss(_forecast(model, d), d["target"][:, None])
             opt.zero_grad()
             loss.backward()
             opt.step()
@@ -77,7 +80,9 @@ def _fit(
 def _val_rmse(model: AdvectionCNN, ds: InSituDataset, dev: torch.device) -> tuple[float, float]:
     model.eval()
     with torch.no_grad():
-        return evaluate(ds.val, lambda b: _forecast(model, b, dev).detach().cpu().numpy())
+        return evaluate(
+            ds.val, lambda b: _forecast(model, to_torch(b, device=dev)).detach().cpu().numpy()
+        )
 
 
 def train(

--- a/examples/fit_scaler.py
+++ b/examples/fit_scaler.py
@@ -41,6 +41,8 @@ from insitubatch import (
 )
 from insitubatch.source import InSituDataset
 
+from ._logging import add_log_level, configure_logging
+
 try:
     from sklearn.preprocessing import StandardScaler
 except ImportError as exc:  # pragma: no cover - example-only dep
@@ -191,7 +193,9 @@ def main() -> None:
         help="comma list; must share the sample axis + chunking. --wb2 default: two "
         "surface fields. Synthetic/other URLs default to every variable in the store.",
     )
+    add_log_level(p)
     a = p.parse_args()
+    configure_logging(a.log_level)
     url = WB2 if a.wb2 else a.url
     if a.variables:
         variables = a.variables.split(",")

--- a/examples/hubble/data.py
+++ b/examples/hubble/data.py
@@ -44,6 +44,8 @@ from insitubatch import (
     split_by_chunk,
 )
 
+from .._logging import add_log_level, configure_logging
+
 SCI_VAR = "SCI"
 BUCKET = "stpubdata"
 S3_PREFIX = "s3://stpubdata"
@@ -307,4 +309,7 @@ def cli(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument("--sigma", type=float, default=NOISE_SIGMA)
     p.add_argument("--n-frames", type=int, default=12, help="synthetic frame count")
     p.add_argument("--size", type=int, default=128, help="synthetic frame size (Y=X)")
-    return p.parse_args(argv)
+    add_log_level(p)
+    args = p.parse_args(argv)
+    configure_logging(args.log_level)
+    return args

--- a/examples/microscopy/data.py
+++ b/examples/microscopy/data.py
@@ -39,6 +39,8 @@ from insitubatch import (
     split_by_chunk,
 )
 
+from .._logging import add_log_level, configure_logging
+
 # A public OME-NGFF (zarr v0.1) image in the EMBL-EBI Image Data Repository: a 3D two-channel
 # confocal stack with an expert instance-segmentation label. Read anonymously off the IDR S3.
 IDR_URL = "s3://idr/zarr/v0.1/6001240.zarr"
@@ -338,12 +340,15 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="throttle read-ahead depth (lower = lower cold TTFB over a high-latency network)",
     )
+    add_log_level(p)
     return p
 
 
 def cli() -> argparse.Namespace:
     """Parse the shared CLI."""
-    return build_parser().parse_args()
+    args = build_parser().parse_args()
+    configure_logging(args.log_level)
+    return args
 
 
 def build_datasets(args: argparse.Namespace) -> InSituDataset:

--- a/examples/wb2_arraylake.py
+++ b/examples/wb2_arraylake.py
@@ -48,6 +48,8 @@ from insitubatch import SplitName, arraylake_store, open_geometries, split_by_ch
 from insitubatch.source import InSituDataset
 from insitubatch.types import Batch
 
+from ._logging import add_log_level, configure_logging
+
 # The public WeatherBench2 ERA5, as an Arraylake/Icechunk repo. ERA5 is grouped by
 # resolution; 240x121 is a sensible default real workload.
 ARRAYLAKE_REPO = "earthmover-public/weatherbench2"
@@ -229,7 +231,9 @@ def main() -> None:
         help="hold the (subset) train split resident -> epoch 2+ is decode-once (no re-fetch)",
     )
     p.add_argument("--cache-dir", default=None, help="spill cached slots to this NVMe dir (mmap)")
+    add_log_level(p)
     a = p.parse_args()
+    configure_logging(a.log_level)
 
     store = arraylake_store(a.repo, branch=a.branch)
     run(

--- a/examples/wb2_dataloader.py
+++ b/examples/wb2_dataloader.py
@@ -55,6 +55,8 @@ from insitubatch import (
 from insitubatch.source import InSituDataset
 from insitubatch.types import Batch
 
+from ._logging import add_log_level, configure_logging
+
 # The public WeatherBench2 ERA5 used by the Earthmover demo (zarr v2, consolidated).
 WB2_URL = (
     "gs://weatherbench2/datasets/era5/1959-2022-6h-128x64_equiangular_with_poles_conservative.zarr"
@@ -238,7 +240,9 @@ def main() -> None:
         default="obstore",
         help="store backend: obstore (default, Rust) or fsspec/gcsfs (GCS Rapid/requester-pays)",
     )
+    add_log_level(p)
     a = p.parse_args()
+    configure_logging(a.log_level)
     url, var = (WB2_URL, WB2_VAR) if a.wb2 else (a.url, a.var)
     run_demo(
         url=url,

--- a/examples/wb2_xbatcher.py
+++ b/examples/wb2_xbatcher.py
@@ -53,6 +53,8 @@ from typing import Any, cast
 
 import numpy as np
 
+from ._logging import add_log_level, configure_logging
+
 # The public WeatherBench2 ERA5 used by the Earthmover demo (zarr v2, consolidated).
 WB2_URL = (
     "gs://weatherbench2/datasets/era5/1959-2022-6h-128x64_equiangular_with_poles_conservative.zarr"
@@ -246,7 +248,9 @@ def main() -> None:
     p.add_argument("--max-batches", type=int, default=0, help="cap batches per epoch (0 = all)")
     p.add_argument("--no-shuffle", action="store_true")
     p.add_argument("--request-payer", action="store_true")
+    add_log_level(p)
     a = p.parse_args()
+    configure_logging(a.log_level)
 
     url, var = (WB2_URL, WB2_VAR) if a.wb2 else (a.url, a.var)
     common = dict(

--- a/src/insitubatch/buffers.py
+++ b/src/insitubatch/buffers.py
@@ -39,7 +39,7 @@ pinned path, since page-locked memory is page-aligned.
 
 from __future__ import annotations
 
-import weakref
+import sys
 from collections.abc import Callable
 
 import numpy as np
@@ -66,24 +66,40 @@ def aligned_empty(shape: tuple[int, ...], dtype: np.dtype, align: int = XLA_ALIG
 
 
 class _Buffer:
-    """One owned base array plus a weak handle on the view most recently lent from it."""
+    """One allocation, tracked by how many arrays still reference its data owner."""
 
-    __slots__ = ("base", "lent")
+    __slots__ = ("base", "owner", "_idle_refs")
 
     def __init__(self, base: np.ndarray) -> None:
         self.base = base
-        self.lent: weakref.ref[np.ndarray] | None = None
+        # Every array viewing this memory -- the batch we lend, a transform's crop of it, a
+        # torch/JAX tensor's hold on either -- keeps a strong reference to the object that
+        # *owns* the data. numpy collapses base chains to that owner rather than chaining, so
+        # a lent view is NOT referenced by a slice taken from it; the owner is. Probing with a
+        # throwaway slice is what identifies it, since it differs by allocator (heap arrays
+        # own their own data; a page-locked one is a view of a torch tensor's buffer).
+        probe = base[:1]
+        self.owner = base if probe.base is None else probe.base
+        del probe  # the probe is itself a reference; the idle baseline must not include it
+        self._idle_refs = 0
+        self._idle_refs = self._refs()
+
+    def _refs(self) -> int:
+        """References to the data owner. Must be reached through exactly one call frame so
+        the idle baseline and the live count are measured identically."""
+        return sys.getrefcount(self.owner)
 
     @property
     def free(self) -> bool:
-        """True when nobody holds the last view we lent -- so the memory is ours to rewrite.
+        """True when nothing outside this pool references the memory, so it is ours to rewrite.
 
-        ``lent() is None`` is the whole safety argument: CPython drops a view on its last
-        decref, and every zero-copy export we support (``torch.from_dlpack``,
-        ``jnp.from_dlpack``) takes a strong reference to that view, so a live tensor keeps
-        this False.
+        Counting references to the *owner* rather than weak-referencing the lent array is what
+        makes this survive a derived view: CPython drops each array on its last decref, and
+        every zero-copy export we support (``torch.from_dlpack``, ``jnp.from_dlpack``) holds
+        the array it was given, which in turn holds the owner. A crop the consumer kept after
+        discarding the batch therefore still counts.
         """
-        return self.lent is None or self.lent() is None
+        return self._refs() <= self._idle_refs
 
 
 class BatchBuffers:
@@ -114,15 +130,13 @@ class BatchBuffers:
 
     @staticmethod
     def _lend(buf: _Buffer, n: int) -> np.ndarray:
-        """Hand out a fresh view of ``buf`` and record a weak handle on it.
+        """Hand out a view of ``buf``'s first ``n`` rows.
 
-        The view must be a new object each time -- that is what the weakref tracks. Slicing
-        always builds one, and slicing the full length is what lets a ragged batch and a full
-        batch share the same base.
+        Slicing is what lets a ragged final batch and a full one share an allocation; the
+        returned array references the buffer's owner, which is how :attr:`_Buffer.free`
+        sees it.
         """
-        view = buf.base[:n]
-        buf.lent = weakref.ref(view)
-        return view
+        return buf.base[:n]
 
     @property
     def nbytes(self) -> int:

--- a/src/insitubatch/buffers.py
+++ b/src/insitubatch/buffers.py
@@ -9,10 +9,17 @@ count tracks batches rather than dataset size. Paid per batch, that is a fresh p
 fault in plus ``munmap``'s TLB work.
 
 Below the threshold the freed block is recycled on the heap instead and reuse buys nothing --
-it costs about 2-3%. End to end (``bench/batch_buffer_sweep.py``) the pool is *flat* across a
-16x payload range while fresh allocation falls off a cliff at 32 MiB: 8 MiB -2.4%, 32 MiB
-+16%, 64 MiB +13%, 128 MiB +10%. So this removes a cliff rather than adding speed. Weather
-batches sit well below it; ViT and microscopy batches sit above.
+it costs about 2-3%. Allocation-bound (``bench/batch_buffer_sweep.py``) the pool is *flat*
+across a 16x payload range while fresh allocation falls off a cliff at 32 MiB: 8 MiB -2.4%,
+32 MiB +16%, 64 MiB +13%, 128 MiB +10%.
+
+**In a compute-bound loop it is worth nothing, and that is the expected result.** The GPU
+advection sweep A/B'd reuse against no-reuse at 8/16/32 MiB per buffer and came back inside
++-0.2 points of ceiling with the sign flipping -- because that loop runs at 99.5-100% of its
+compute ceiling, so producer-side allocation has nowhere to surface even at 32 MiB where the
+``mmap`` path demonstrably engages. So this removes a cliff for the loops that are *not*
+already compute-bound; it does not make a fed GPU faster. Weather batches sit below the
+threshold anyway; ViT and microscopy batches sit above it.
 
 **Hand-out is by view, reclaim is by liveness.** A buffer is lent as a view of a base array the
 pool owns forever, and comes back only once that view is unreferenced. The check happens
@@ -39,6 +46,7 @@ pinned path, since page-locked memory is page-aligned.
 
 from __future__ import annotations
 
+import os
 import sys
 import threading
 from collections.abc import Callable
@@ -47,6 +55,35 @@ import numpy as np
 
 XLA_ALIGN = 128
 """Alignment XLA:CPU requires to import a DLPack buffer without copying."""
+
+NO_REUSE_ENV = "INSITUBATCH_NO_BUFFER_REUSE"
+"""Set truthy to allocate a fresh buffer per batch, bypassing reuse and its liveness tracking.
+
+An escape hatch, deliberately not a tuning parameter. Reuse is safe by construction against
+everything the transform API can do -- a transform that returns a derived array frees its
+buffer early, one that returns a view keeps it tracked, one that retains simply makes the pool
+allocate elsewhere -- so there is no knob here worth asking a user to reason about. What this
+covers is the residue: memory escaping Python object semantics (``arr.ctypes.data`` handed to
+a C extension that stores the pointer), a platform where ``sys.getrefcount`` does not mean
+what we assume, and the possibility that we are wrong. One sentence of documentation:
+*if batches contain data from a previous batch, set this and open an issue.*
+
+It is also the A/B control. Reuse was first measured against a second checkout with the
+``gather`` call site hand-reverted -- a worktree, a branch and a divergence risk, to answer a
+one-line question. This flag is the better instrument: identical code on both sides, only the
+reuse decision differs.
+
+Costs, when set: above glibc's 32 MiB ``mmap`` threshold every batch is ``mmap``ed and
+``munmap``ed again (which is the cliff reuse exists to remove), and under a *pinned* allocator
+every batch becomes its own ``cudaHostAlloc`` -- far more expensive than the pooled case. This
+is a diagnostic, not a supported production configuration.
+"""
+
+
+def _reuse_enabled() -> bool:
+    """Read :data:`NO_REUSE_ENV` once, at pool construction -- never on the hot path."""
+    return os.environ.get(NO_REUSE_ENV, "").strip().lower() in ("", "0", "false", "no")
+
 
 HostAllocator = Callable[[tuple[int, ...], np.dtype], np.ndarray]
 """How the pool gets host memory. The default is aligned heap; the torch adapter swaps in a
@@ -149,6 +186,7 @@ class BatchBuffers:
         self._alloc: HostAllocator = allocator or aligned_empty
         self._pools: dict[tuple[tuple[int, ...], np.dtype], list[_Buffer]] = {}
         self._lock = threading.Lock()
+        self._reuse = _reuse_enabled()
         # Per-epoch observability, reset at the epoch boundary like the chunk cache's
         # hits/misses. `allocations` is the one that matters: it should fall to zero once the
         # pool has converged on the in-flight count, so a nonzero count in a later epoch means
@@ -160,6 +198,14 @@ class BatchBuffers:
         """Lend an ``(n, *inner_shape)`` array of ``dtype``, reusing a free buffer if there is
         one. The returned view's contents are undefined -- the caller overwrites every row.
         """
+        if not self._reuse:
+            # The escape hatch: pre-pool behaviour exactly -- one fresh allocation per call,
+            # no _Buffer, no liveness poll, nothing to reclaim. Allocated outside the lock,
+            # which is only guarding the counters here.
+            with self._lock:
+                self.lends += 1
+                self.allocations += 1
+            return self._alloc((n, *inner_shape), dtype)
         key = (tuple(inner_shape), dtype)
         with self._lock:
             self.lends += 1
@@ -209,8 +255,13 @@ class BatchBuffers:
         Read off a label the allocator carries rather than inspected from the memory, because
         the core cannot ask CUDA anything. It reports *intent*: a pinned allocator that has
         exhausted its budget hands out pageable buffers and says so through its own warning.
+
+        Says so when reuse is switched off, because the epoch line is where someone reads back
+        what a run actually did, and a benchmark taken with the escape hatch set must not be
+        mistakable for a normal one afterwards.
         """
-        return str(getattr(self._alloc, "label", "heap"))
+        label = str(getattr(self._alloc, "label", "heap"))
+        return label if self._reuse else f"{label}, REUSE OFF ({NO_REUSE_ENV})"
 
     def reset_counters(self) -> None:
         """Zero the per-epoch counters (called at the epoch boundary, with the cache's)."""

--- a/src/insitubatch/buffers.py
+++ b/src/insitubatch/buffers.py
@@ -40,6 +40,7 @@ pinned path, since page-locked memory is page-aligned.
 from __future__ import annotations
 
 import sys
+import threading
 from collections.abc import Callable
 
 import numpy as np
@@ -81,8 +82,35 @@ class _Buffer:
         probe = base[:1]
         self.owner = base if probe.base is None else probe.base
         del probe  # the probe is itself a reference; the idle baseline must not include it
-        self._idle_refs = 0
+        self._idle_refs = 0  # provisional -- calibrate() sets the real one
+
+    def calibrate(self) -> None:
+        """Record the refcount that means *nothing is lent*, and check the buffer is trackable.
+
+        Split from ``__init__`` because the baseline is only meaningful once the allocation's
+        transient references are gone. Where the owner is the array itself -- which is what
+        ``torch.empty(pin_memory=True).numpy()`` gives us, so this is the *pinned* path, not a
+        corner case -- the allocator's return value is still on the caller's stack during
+        ``__init__``. Counting it makes the baseline permanently too high, every buffer then
+        looks free forever, and the pool hands one allocation to every batch at once, each
+        overwriting the last. So the caller drops its reference first, then calls this.
+
+        The probe below is the guard that keeps that class of bug loud: a buffer whose lent
+        view does not raise the owner's refcount cannot be tracked at all, and reusing it would
+        corrupt batches silently. Once per allocation, never per batch.
+        """
         self._idle_refs = self._refs()
+        lent = self.base[:1]
+        trackable = not self.free
+        del lent
+        if not trackable:
+            raise RuntimeError(
+                "batch buffer liveness is untrackable: a view of this allocation does not "
+                "reference the data owner, so the pool cannot tell when a batch is still in "
+                "use. The host allocator must return an array that either owns its data or "
+                "directly views the object that does (one level, as numpy collapses base "
+                f"chains) -- got {type(self.base).__name__} over {type(self.owner).__name__}."
+            )
 
     def _refs(self) -> int:
         """References to the data owner. Must be reached through exactly one call frame so
@@ -105,28 +133,44 @@ class _Buffer:
 class BatchBuffers:
     """Pool of reusable batch-output arrays, keyed by ``(inner_shape, dtype)``.
 
-    Not thread-safe by itself: it is driven from the single producer thread that assembles
-    batches (``ChunkPool.gather``), which is also the only thread that may write a lent buffer.
+    **Hand-out is locked because there can be more than one producer.** Each active iteration
+    gets its own producer thread (``source._iterate``) over the one shared ``ChunkPool``, so
+    ``zip(ds.train, ds.val)`` or two ``DataLoader``s over one dataset run two of them into this
+    pool. Deciding a buffer is free and lending it must therefore be one atomic step: otherwise
+    both producers observe the same buffer as free and write their batches into it. The lock is
+    held only across that decision -- never across a gather -- so it costs one uncontended
+    acquire per variable per batch, against a gather that copies megabytes.
+
+    Writing a lent buffer stays lock-free and always was: a buffer is lent to exactly one
+    producer, which is the only thread that touches it.
     """
 
     def __init__(self, *, allocator: HostAllocator | None = None) -> None:
         self._alloc: HostAllocator = allocator or aligned_empty
         self._pools: dict[tuple[tuple[int, ...], np.dtype], list[_Buffer]] = {}
+        self._lock = threading.Lock()
 
     def take(self, n: int, inner_shape: tuple[int, ...], dtype: np.dtype) -> np.ndarray:
         """Lend an ``(n, *inner_shape)`` array of ``dtype``, reusing a free buffer if there is
         one. The returned view's contents are undefined -- the caller overwrites every row.
         """
         key = (tuple(inner_shape), dtype)
-        buffers = self._pools.setdefault(key, [])
-        for buf in buffers:
-            # A free buffer big enough along the batch axis serves this batch; a short final
-            # batch takes a prefix of a full-size one.
-            if buf.free and buf.base.shape[0] >= n:
-                return self._lend(buf, n)
-        buf = _Buffer(self._alloc((n, *inner_shape), dtype))
-        buffers.append(buf)
-        return self._lend(buf, n)
+        with self._lock:
+            buffers = self._pools.setdefault(key, [])
+            for buf in buffers:
+                # A free buffer big enough along the batch axis serves this batch; a short
+                # final batch takes a prefix of a full-size one. The lend must happen under the
+                # lock too: it is what makes the buffer *look* taken to the next caller (the
+                # returned view is what raises the owner's refcount), so releasing between the
+                # check and the slice would hand the same memory to two producers.
+                if buf.free and buf.base.shape[0] >= n:
+                    return self._lend(buf, n)
+            allocated = self._alloc((n, *inner_shape), dtype)
+            buf = _Buffer(allocated)
+            del allocated  # load-bearing: the idle baseline must not count this reference
+            buf.calibrate()
+            buffers.append(buf)
+            return self._lend(buf, n)
 
     @staticmethod
     def _lend(buf: _Buffer, n: int) -> np.ndarray:
@@ -141,7 +185,8 @@ class BatchBuffers:
     @property
     def nbytes(self) -> int:
         """Total host memory the pool owns. Converges once the pipeline reaches steady state."""
-        return sum(buf.base.nbytes for pool in self._pools.values() for buf in pool)
+        with self._lock:  # a concurrent take may be appending to one of these lists
+            return sum(buf.base.nbytes for pool in self._pools.values() for buf in pool)
 
     def set_allocator(self, allocator: HostAllocator) -> None:
         """Swap where buffers come from, dropping any already allocated.
@@ -153,8 +198,9 @@ class BatchBuffers:
         mid-epoch is legal (outstanding batches keep their own memory by refcount) but wastes
         whatever the pool had already warmed.
         """
-        self._alloc = allocator
-        self.clear()
+        with self._lock:
+            self._alloc = allocator
+            self._pools.clear()
 
     def clear(self) -> None:
         """Drop every owned buffer (pool teardown).
@@ -164,4 +210,5 @@ class BatchBuffers:
         lifetime *on purpose* -- that is what makes the next epoch free -- so this belongs at
         close, never at an epoch boundary.
         """
-        self._pools.clear()
+        with self._lock:
+            self._pools.clear()

--- a/src/insitubatch/buffers.py
+++ b/src/insitubatch/buffers.py
@@ -123,6 +123,19 @@ class BatchBuffers:
         """Total host memory the pool owns. Converges once the pipeline reaches steady state."""
         return sum(buf.base.nbytes for pool in self._pools.values() for buf in pool)
 
+    def set_allocator(self, allocator: HostAllocator) -> None:
+        """Swap where buffers come from, dropping any already allocated.
+
+        The one injection point for page-locked memory: the core cannot call
+        ``torch.empty(pin_memory=True)`` without importing a framework, so the torch adapter
+        supplies it. Existing buffers are dropped rather than mixed, so the pool does not end
+        up half pinned and half not for no visible reason. Call before iterating -- swapping
+        mid-epoch is legal (outstanding batches keep their own memory by refcount) but wastes
+        whatever the pool had already warmed.
+        """
+        self._alloc = allocator
+        self.clear()
+
     def clear(self) -> None:
         """Drop every owned buffer (pool teardown).
 

--- a/src/insitubatch/buffers.py
+++ b/src/insitubatch/buffers.py
@@ -56,6 +56,7 @@ pinned path, since page-locked memory is page-aligned.
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 import threading
@@ -63,6 +64,8 @@ from collections.abc import Callable
 from typing import NamedTuple
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 XLA_ALIGN = 128
 """Alignment XLA:CPU requires to import a DLPack buffer without copying."""
@@ -86,8 +89,9 @@ reuse decision differs.
 
 Costs, when set: above glibc's 32 MiB ``mmap`` threshold every batch is ``mmap``ed and
 ``munmap``ed again (which is the cliff reuse exists to remove), and under a *pinned* allocator
-every batch becomes its own ``cudaHostAlloc`` -- far more expensive than the pooled case. This
-is a diagnostic, not a supported production configuration.
+every batch becomes its own ``cudaHostAlloc`` -- far more expensive than the pooled case, and
+loud about it (:meth:`BatchBuffers.set_allocator` warns). This is a diagnostic, not a supported
+production configuration.
 """
 
 
@@ -204,8 +208,31 @@ class _Buffer:
         every zero-copy export we support (``torch.from_dlpack``, ``jnp.from_dlpack``) holds
         the array it was given, which in turn holds the owner. A crop the consumer kept after
         discarding the batch therefore still counts.
+
+        Dropping *below* the baseline is a different thing entirely, and it raises. Every
+        reference counted at calibration is structural -- ``self.owner``, and the base chain
+        ``self.base`` holds -- so all of them outlive the buffer and the count can only go up.
+        A lower reading means the baseline itself over-counted a transient, which is not a
+        near-miss: it makes ``free`` permanently true, so the pool lends one allocation to
+        every batch at once and each silently overwrites the last. That is exactly the defect
+        :meth:`calibrate` exists to prevent, and it cost a night to find by its symptoms. The
+        comparison is one integer against another on a path that already copies megabytes, so
+        checking forever is free; the only reachable way to hit it is a bug in this file or a
+        platform where ``sys.getrefcount`` does not mean what we assume, and both are better
+        as a loud stop than as corrupted training data. :data:`NO_REUSE_ENV` is the way past
+        it if it ever fires.
         """
-        return self._refs() <= self._idle_refs
+        refs = self._refs()
+        if refs < self._idle_refs:
+            raise RuntimeError(
+                f"batch buffer liveness baseline is wrong: the data owner now has {refs} "
+                f"references, below the {self._idle_refs} recorded when nothing was lent. "
+                "The baseline must count only references that outlive the buffer, so it can "
+                "never be exceeded from below; a higher one makes every buffer look free and "
+                "lends one allocation to every batch at once. Set "
+                f"{NO_REUSE_ENV}=1 to bypass reuse, and please open an issue."
+            )
+        return refs <= self._idle_refs
 
 
 class BatchBuffers:
@@ -336,7 +363,26 @@ class BatchBuffers:
         up half pinned and half not for no visible reason. Call before iterating -- swapping
         mid-epoch is legal (outstanding batches keep their own memory by refcount) but wastes
         whatever the pool had already warmed.
+
+        Pinning with reuse switched off warns rather than raises. The combination is bad
+        enough to be worth saying out loud -- every batch becomes its own ``cudaHostAlloc``,
+        and the pinned allocator's budget is a monotone counter sized for a pool that
+        converges, so once it is spent the run quietly finishes on pageable memory while
+        :attr:`kind` still reports ``pinned`` intent. But it must stay *reachable*: the
+        double-lend that motivated :data:`NO_REUSE_ENV` lived on the pinned path and nowhere
+        else, so refusing this pairing would remove the one control that isolates reuse from
+        pinning, and leave a user suspecting corruption no way to test it without changing
+        two things at once.
         """
+        if not self._reuse and str(getattr(allocator, "label", "heap")) != "heap":
+            logger.warning(
+                "buffer reuse is off (%s) under a %s allocator: every batch takes its own "
+                "page-locked allocation, and the pin budget does not recycle, so it will be "
+                "spent after a few batches and the rest of the run will be pageable. Fine as "
+                "an A/B control against reuse; not a configuration to benchmark or train on.",
+                NO_REUSE_ENV,
+                str(getattr(allocator, "label", "heap")),
+            )
         with self._lock:
             self._alloc = allocator
             self._pools.clear()

--- a/src/insitubatch/buffers.py
+++ b/src/insitubatch/buffers.py
@@ -1,0 +1,134 @@
+"""Reusable batch-output buffers.
+
+``pool.gather`` used to allocate a fresh array per variable per batch. ``np.empty`` itself is
+nearly free -- it reserves address space without touching pages -- so the cost was never the
+allocation but the **first-touch page faults** on the scatter-write that follows, plus the
+``mmap``/``munmap`` churn glibc falls back to above its 32 MiB dynamic threshold. Below that
+threshold the freed block is recycled on the heap and reuse buys nothing; above it, reuse saves
+22-33% of assembly time (``bench/probe_batch_buffers.py --arms alloc``). Weather-sized batches
+are far below; ViT and microscopy batches are far above.
+
+**Hand-out is by view, reclaim is by liveness.** A buffer is lent as a view of a base array the
+pool owns forever, and comes back only once that view is unreferenced. The check happens
+lazily, inside :meth:`take` -- the latest moment it can, and exactly the moment the answer
+matters -- so there is no separate reclaim pass and nothing for a caller to remember to call.
+
+Three consequences worth stating, because they are what make this safe rather than clever:
+
+* **Retaining a batch is retaining its buffer**, automatically. A consumer that keeps a batch
+  (gradient accumulation, ``[b for b in ds]``, an exported tensor) keeps its view alive, so the
+  pool simply allocates elsewhere. There is deliberately no ``retain()`` API: holding a
+  reference already does it, and a ``retain()`` someone forgets is a silent-corruption bug
+  where a held reference is safe by construction.
+* **There is no depth parameter.** Allocate-on-miss converges on however many buffers are
+  genuinely in flight, so nobody has to derive ``prefetch_depth`` + n correctly.
+* **A short final batch is a prefix view** (``base[:k]``) of a full-size buffer -- the ragged
+  tail costs neither an allocation nor a copy.
+
+Buffers are 128-byte aligned because XLA:CPU zero-copies a DLPack import only from that
+boundary and silently copies otherwise; numpy guarantees 16, which made ``to_jax`` zero-copy
+by allocator luck (measured 25/50) rather than by construction. Alignment is also free for the
+pinned path, since page-locked memory is page-aligned.
+"""
+
+from __future__ import annotations
+
+import weakref
+from collections.abc import Callable
+
+import numpy as np
+
+XLA_ALIGN = 128
+"""Alignment XLA:CPU requires to import a DLPack buffer without copying."""
+
+HostAllocator = Callable[[tuple[int, ...], np.dtype], np.ndarray]
+"""How the pool gets host memory. The default is aligned heap; the torch adapter swaps in a
+page-locked one, which is how pinning arrives without the core importing a framework."""
+
+
+def aligned_empty(shape: tuple[int, ...], dtype: np.dtype, align: int = XLA_ALIGN) -> np.ndarray:
+    """``np.empty(shape, dtype)`` whose first byte is a multiple of ``align``.
+
+    Over-allocate a byte buffer, skip to the next boundary, then view and reshape. numpy makes
+    no alignment promise past its own 16-byte floor, so this is the only way to get the
+    guarantee rather than the coin flip.
+    """
+    nbytes = int(np.prod(shape)) * dtype.itemsize
+    raw = np.empty(nbytes + align, dtype=np.uint8)
+    offset = (-int(raw.__array_interface__["data"][0])) % align
+    return raw[offset : offset + nbytes].view(dtype).reshape(shape)
+
+
+class _Buffer:
+    """One owned base array plus a weak handle on the view most recently lent from it."""
+
+    __slots__ = ("base", "lent")
+
+    def __init__(self, base: np.ndarray) -> None:
+        self.base = base
+        self.lent: weakref.ref[np.ndarray] | None = None
+
+    @property
+    def free(self) -> bool:
+        """True when nobody holds the last view we lent -- so the memory is ours to rewrite.
+
+        ``lent() is None`` is the whole safety argument: CPython drops a view on its last
+        decref, and every zero-copy export we support (``torch.from_dlpack``,
+        ``jnp.from_dlpack``) takes a strong reference to that view, so a live tensor keeps
+        this False.
+        """
+        return self.lent is None or self.lent() is None
+
+
+class BatchBuffers:
+    """Pool of reusable batch-output arrays, keyed by ``(inner_shape, dtype)``.
+
+    Not thread-safe by itself: it is driven from the single producer thread that assembles
+    batches (``ChunkPool.gather``), which is also the only thread that may write a lent buffer.
+    """
+
+    def __init__(self, *, allocator: HostAllocator | None = None) -> None:
+        self._alloc: HostAllocator = allocator or aligned_empty
+        self._pools: dict[tuple[tuple[int, ...], np.dtype], list[_Buffer]] = {}
+
+    def take(self, n: int, inner_shape: tuple[int, ...], dtype: np.dtype) -> np.ndarray:
+        """Lend an ``(n, *inner_shape)`` array of ``dtype``, reusing a free buffer if there is
+        one. The returned view's contents are undefined -- the caller overwrites every row.
+        """
+        key = (tuple(inner_shape), dtype)
+        buffers = self._pools.setdefault(key, [])
+        for buf in buffers:
+            # A free buffer big enough along the batch axis serves this batch; a short final
+            # batch takes a prefix of a full-size one.
+            if buf.free and buf.base.shape[0] >= n:
+                return self._lend(buf, n)
+        buf = _Buffer(self._alloc((n, *inner_shape), dtype))
+        buffers.append(buf)
+        return self._lend(buf, n)
+
+    @staticmethod
+    def _lend(buf: _Buffer, n: int) -> np.ndarray:
+        """Hand out a fresh view of ``buf`` and record a weak handle on it.
+
+        The view must be a new object each time -- that is what the weakref tracks. Slicing
+        always builds one, and slicing the full length is what lets a ragged batch and a full
+        batch share the same base.
+        """
+        view = buf.base[:n]
+        buf.lent = weakref.ref(view)
+        return view
+
+    @property
+    def nbytes(self) -> int:
+        """Total host memory the pool owns. Converges once the pipeline reaches steady state."""
+        return sum(buf.base.nbytes for pool in self._pools.values() for buf in pool)
+
+    def clear(self) -> None:
+        """Drop every owned buffer (pool teardown).
+
+        Safe with batches still outstanding: a consumer's view keeps its own memory alive by
+        refcount, it just stops being reusable. Buffers are otherwise held for the pool's
+        lifetime *on purpose* -- that is what makes the next epoch free -- so this belongs at
+        close, never at an epoch boundary.
+        """
+        self._pools.clear()

--- a/src/insitubatch/buffers.py
+++ b/src/insitubatch/buffers.py
@@ -60,6 +60,7 @@ import os
 import sys
 import threading
 from collections.abc import Callable
+from typing import NamedTuple
 
 import numpy as np
 
@@ -90,14 +91,44 @@ is a diagnostic, not a supported production configuration.
 """
 
 
+_FALSY = ("", "0", "false", "no", "off")
+"""Values of :data:`NO_REUSE_ENV` that leave reuse on. ``off`` belongs here: the variable is
+named for the thing it *enables*, so ``=off`` reads as "no-reuse off" and must not disable
+reuse -- the inverted-intent bug that omitting it creates is silent apart from the log stamp."""
+
+
 def _reuse_enabled() -> bool:
     """Read :data:`NO_REUSE_ENV` once, at pool construction -- never on the hot path."""
-    return os.environ.get(NO_REUSE_ENV, "").strip().lower() in ("", "0", "false", "no")
+    return os.environ.get(NO_REUSE_ENV, "").strip().lower() in _FALSY
 
 
 HostAllocator = Callable[[tuple[int, ...], np.dtype], np.ndarray]
 """How the pool gets host memory. The default is aligned heap; the torch adapter swaps in a
 page-locked one, which is how pinning arrives without the core importing a framework."""
+
+
+class BufferStats(NamedTuple):
+    """One consistent reading of the pool, for the per-epoch log line."""
+
+    n_buffers: int
+    nbytes: int
+    kind: str  # "heap" or "pinned" -- allocator intent, see BatchBuffers.kind
+    reuse: bool
+    lends: int
+    allocations: int
+
+    def summary(self) -> str:
+        """The log fragment: ``17 x pinned = 544.0 MiB, 100 lent, 0 allocated``.
+
+        Formatted here rather than in the caller so the field names in a docstring and the
+        words in the line cannot drift, and so the reuse-off case reads as a sentence instead
+        of an interjection inside the arithmetic.
+        """
+        line = (
+            f"{self.n_buffers} x {self.kind} = {self.nbytes / 2**20:.1f} MiB, "
+            f"{self.lends} lent, {self.allocations} allocated"
+        )
+        return line if self.reuse else f"{line} (reuse OFF via {NO_REUSE_ENV})"
 
 
 def aligned_empty(shape: tuple[int, ...], dtype: np.dtype, align: int = XLA_ALIGN) -> np.ndarray:
@@ -246,6 +277,23 @@ class BatchBuffers:
         """
         return buf.base[:n]
 
+    def stats(self) -> BufferStats:
+        """A consistent snapshot of what the pool holds, under one lock acquisition.
+
+        Reading the properties individually takes the lock once each, so a producer allocating
+        between them yields a line whose count and byte total disagree. Cheap to avoid, and a
+        report that cannot be self-contradictory is worth more than three getters.
+        """
+        with self._lock:  # a concurrent take may be appending to one of these lists
+            return BufferStats(
+                n_buffers=sum(len(pool) for pool in self._pools.values()),
+                nbytes=sum(buf.base.nbytes for pool in self._pools.values() for buf in pool),
+                kind=str(getattr(self._alloc, "label", "heap")),
+                reuse=self._reuse,
+                lends=self.lends,
+                allocations=self.allocations,
+            )
+
     @property
     def nbytes(self) -> int:
         """Total host memory the pool owns. Converges once the pipeline reaches steady state."""
@@ -266,12 +314,12 @@ class BatchBuffers:
         the core cannot ask CUDA anything. It reports *intent*: a pinned allocator that has
         exhausted its budget hands out pageable buffers and says so through its own warning.
 
-        Says so when reuse is switched off, because the epoch line is where someone reads back
-        what a run actually did, and a benchmark taken with the escape hatch set must not be
-        mistakable for a normal one afterwards.
+        Reports the allocator alone; whether reuse is switched off is a separate field, which
+        :meth:`BufferStats.summary` renders alongside it -- the epoch line is where someone
+        reads back what a run actually did, and a benchmark taken with the escape hatch set
+        must not be mistakable for a normal one afterwards.
         """
-        label = str(getattr(self._alloc, "label", "heap"))
-        return label if self._reuse else f"{label}, REUSE OFF ({NO_REUSE_ENV})"
+        return str(getattr(self._alloc, "label", "heap"))
 
     def reset_counters(self) -> None:
         """Zero the per-epoch counters (called at the epoch boundary, with the cache's)."""

--- a/src/insitubatch/buffers.py
+++ b/src/insitubatch/buffers.py
@@ -149,6 +149,12 @@ class BatchBuffers:
         self._alloc: HostAllocator = allocator or aligned_empty
         self._pools: dict[tuple[tuple[int, ...], np.dtype], list[_Buffer]] = {}
         self._lock = threading.Lock()
+        # Per-epoch observability, reset at the epoch boundary like the chunk cache's
+        # hits/misses. `allocations` is the one that matters: it should fall to zero once the
+        # pool has converged on the in-flight count, so a nonzero count in a later epoch means
+        # buffers are not coming back -- retained batches, or a batch geometry that changes.
+        self.lends = 0
+        self.allocations = 0
 
     def take(self, n: int, inner_shape: tuple[int, ...], dtype: np.dtype) -> np.ndarray:
         """Lend an ``(n, *inner_shape)`` array of ``dtype``, reusing a free buffer if there is
@@ -156,6 +162,7 @@ class BatchBuffers:
         """
         key = (tuple(inner_shape), dtype)
         with self._lock:
+            self.lends += 1
             buffers = self._pools.setdefault(key, [])
             for buf in buffers:
                 # A free buffer big enough along the batch axis serves this batch; a short
@@ -170,6 +177,7 @@ class BatchBuffers:
             del allocated  # load-bearing: the idle baseline must not count this reference
             buf.calibrate()
             buffers.append(buf)
+            self.allocations += 1
             return self._lend(buf, n)
 
     @staticmethod
@@ -187,6 +195,28 @@ class BatchBuffers:
         """Total host memory the pool owns. Converges once the pipeline reaches steady state."""
         with self._lock:  # a concurrent take may be appending to one of these lists
             return sum(buf.base.nbytes for pool in self._pools.values() for buf in pool)
+
+    @property
+    def n_buffers(self) -> int:
+        """How many buffers the pool owns -- the in-flight count it converged on."""
+        with self._lock:
+            return sum(len(pool) for pool in self._pools.values())
+
+    @property
+    def kind(self) -> str:
+        """What the buffers are made of, for the epoch summary: ``"pinned"`` or ``"heap"``.
+
+        Read off a label the allocator carries rather than inspected from the memory, because
+        the core cannot ask CUDA anything. It reports *intent*: a pinned allocator that has
+        exhausted its budget hands out pageable buffers and says so through its own warning.
+        """
+        return str(getattr(self._alloc, "label", "heap"))
+
+    def reset_counters(self) -> None:
+        """Zero the per-epoch counters (called at the epoch boundary, with the cache's)."""
+        with self._lock:
+            self.lends = 0
+            self.allocations = 0
 
     def set_allocator(self, allocator: HostAllocator) -> None:
         """Swap where buffers come from, dropping any already allocated.

--- a/src/insitubatch/buffers.py
+++ b/src/insitubatch/buffers.py
@@ -1,12 +1,18 @@
 """Reusable batch-output buffers.
 
-``pool.gather`` used to allocate a fresh array per variable per batch. ``np.empty`` itself is
-nearly free -- it reserves address space without touching pages -- so the cost was never the
-allocation but the **first-touch page faults** on the scatter-write that follows, plus the
-``mmap``/``munmap`` churn glibc falls back to above its 32 MiB dynamic threshold. Below that
-threshold the freed block is recycled on the heap and reuse buys nothing; above it, reuse saves
-22-33% of assembly time (``bench/probe_batch_buffers.py --arms alloc``). Weather-sized batches
-are far below; ViT and microscopy batches are far above.
+``pool.gather`` used to allocate a fresh array per variable per batch. The cost is not the
+allocation call -- ``np.empty`` only reserves address space -- but what glibc does with a
+request above its 32 MiB dynamic ``mmap`` threshold: it ``mmap``s the batch and ``munmap``s it
+on free, **every batch**. A syscall trace confirms it directly (128 MiB batches, 12-batch
+epoch): 12 ``mmap``/``munmap`` pairs of the full buffer without the pool, 2 with it, and the
+count tracks batches rather than dataset size. Paid per batch, that is a fresh page set to
+fault in plus ``munmap``'s TLB work.
+
+Below the threshold the freed block is recycled on the heap instead and reuse buys nothing --
+it costs about 2-3%. End to end (``bench/batch_buffer_sweep.py``) the pool is *flat* across a
+16x payload range while fresh allocation falls off a cliff at 32 MiB: 8 MiB -2.4%, 32 MiB
++16%, 64 MiB +13%, 128 MiB +10%. So this removes a cliff rather than adding speed. Weather
+batches sit well below it; ViT and microscopy batches sit above.
 
 **Hand-out is by view, reclaim is by liveness.** A buffer is lent as a view of a base array the
 pool owns forever, and comes back only once that view is unreferenced. The check happens

--- a/src/insitubatch/buffers.py
+++ b/src/insitubatch/buffers.py
@@ -9,17 +9,27 @@ count tracks batches rather than dataset size. Paid per batch, that is a fresh p
 fault in plus ``munmap``'s TLB work.
 
 Below the threshold the freed block is recycled on the heap instead and reuse buys nothing --
-it costs about 2-3%. Allocation-bound (``bench/batch_buffer_sweep.py``) the pool is *flat*
-across a 16x payload range while fresh allocation falls off a cliff at 32 MiB: 8 MiB -2.4%,
-32 MiB +16%, 64 MiB +13%, 128 MiB +10%.
+it costs about 2-3%.
 
-**In a compute-bound loop it is worth nothing, and that is the expected result.** The GPU
-advection sweep A/B'd reuse against no-reuse at 8/16/32 MiB per buffer and came back inside
-+-0.2 points of ceiling with the sign flipping -- because that loop runs at 99.5-100% of its
-compute ceiling, so producer-side allocation has nowhere to surface even at 32 MiB where the
-``mmap`` path demonstrably engages. So this removes a cliff for the loops that are *not*
-already compute-bound; it does not make a fed GPU faster. Weather batches sit below the
-threshold anyway; ViT and microscopy batches sit above it.
+**What this is worth is a range, and where a workload lands in it is set by one thing: how
+much of the loader's work the compute step is already hiding.** The range is bounded at both
+ends, and both ends are measured.
+
+*Upper bound -- allocation-bound* (``bench/batch_buffer_sweep.py``, the producer's cost fully
+exposed): the pool is flat across a 16x payload range while fresh allocation falls off a
+cliff at 32 MiB. 8 MiB -2.4%, 32 MiB +16%, 64 MiB +13%, 128 MiB +10%.
+
+*Lower bound -- compute-bound: exactly zero*, and the GPU advection sweep is that case, not a
+midpoint. A/B'd against no-reuse over 8/16/32/64 MiB per buffer it came back at
++0.21/+0.20/-0.18/-0.29 points of ceiling -- sign flipping, and at 64 MiB the two arms agree
+to 0.04% absolute. That loop runs at 98.7-100% of its compute ceiling, so producer-side
+allocation has nowhere to surface *even where the* ``mmap`` *path demonstrably engages*.
+Prefetch hiding this is prefetch working.
+
+So the honest claim is not "faster training" -- it is that the cliff cannot bite you, at a
+cost of 2-3% below the threshold. It pays where the loader is not already free: shallower
+compute per byte, inference rather than training, a cold cache, an IO-bound epoch. Weather
+batches sit below the threshold anyway; ViT and microscopy batches sit above it.
 
 **Hand-out is by view, reclaim is by liveness.** A buffer is lent as a view of a base array the
 pool owns forever, and comes back only once that view is unreferenced. The check happens

--- a/src/insitubatch/frameworks.py
+++ b/src/insitubatch/frameworks.py
@@ -69,6 +69,26 @@ def _default_pin_budget() -> int:
     return total // _DEFAULT_PIN_FRACTION
 
 
+def _torch_dtype(dtype: np.dtype) -> torch.dtype:
+    """The torch dtype for a numpy one, asked of torch rather than guessed from its name.
+
+    ``getattr(torch, str(dtype))`` works for every dtype either library will actually accept
+    -- checked across the float/int/uint/bool/complex range, where it agrees with this, and
+    where the two also fail together (``float128``, ``datetime64``, structured dtypes, and
+    ``uint16`` on a torch too old to have it). So this is not a bug fix.
+
+    It is a *second mechanism* removed. The pool hands out a buffer created here, and
+    :func:`to_torch` creates the tensor that views it through ``torch.from_dlpack`` -- torch's
+    own numpy mapping. Two answers to one question is one more than there should be: were they
+    ever to diverge, the buffer's dtype and the tensor's would disagree with nothing to catch
+    it. Deriving ours from the same converter makes divergence unrepresentable, and the
+    zero-element probe costs microseconds once per *allocation*, not per batch.
+    """
+    import torch  # already imported by every caller; this is a sys.modules lookup
+
+    return torch.from_numpy(np.empty(0, dtype=dtype)).dtype
+
+
 def pinned_allocator(budget_bytes: int | None = None) -> HostAllocator:
     """A host allocator handing out page-locked buffers, up to ``budget_bytes``.
 
@@ -107,7 +127,7 @@ def pinned_allocator(budget_bytes: int | None = None) -> HostAllocator:
         # recognises the pages through the DLPack round-trip back into torch, which is what
         # keeps `non_blocking` genuinely asynchronous. Page-locked memory is page-aligned, so
         # the pool's 128-byte XLA alignment comes free.
-        pinned = torch.empty(tuple(shape), dtype=getattr(torch, str(dtype)), pin_memory=True)
+        pinned = torch.empty(tuple(shape), dtype=_torch_dtype(dtype), pin_memory=True)
         used += nbytes
         return pinned.numpy()
 
@@ -277,10 +297,22 @@ def as_torch(
     ``non_blocking`` copy and reintroduce a use-after-recycle we would then have to document
     instead of prevent.
 
-    Worth it only above ~32 MiB per batch. Measured on an L4, pinning takes a 37 MiB batch's
-    transfer from +4.0 ms to +0.3 ms against a 25 ms step, and a weather-sized batch from
-    +1.5 ms to +0.7 ms -- real but marginal. ``pin_budget_bytes`` caps the page-locked total
-    (default: an eighth of RAM); past it buffers are pageable again, with a warning.
+    What it is worth runs between two measured bounds, and how compute-bound the loop is
+    decides where you land. In isolation (``bench/probe_batch_buffers.py --arms overlap``) a
+    pinned copy below ~37 MiB is hidden *completely* -- the pinned arm sits on the compute
+    floor, while a pageable one costs more than its own transfer time because it stages
+    through a driver bounce buffer and cannot overlap at all. Against a compute step that
+    already hides the copy, it is worth nothing. **A real GPU training loop lands in between:
+    +1 to +2%**, roughly flat over a 4x payload range (32 to 128 MiB per step) rather than
+    switching on above a threshold.
+
+    Expect no more precision than that range. An A/B/A bracket on an unchanged checkout drifts
+    ~0.7% per block -- half the signal -- so the bound is +0.8% to +2.2% depending on how the
+    drift is modelled. See docs/benchmarks.md, which also explains why ``% of ceiling`` cannot
+    measure this at all.
+
+    ``pin_budget_bytes`` caps the page-locked total (default: an eighth of RAM, since the
+    kernel cannot reclaim it); past that buffers are pageable again, with one warning.
     """
     try:
         from torch.utils.data import IterableDataset

--- a/src/insitubatch/frameworks.py
+++ b/src/insitubatch/frameworks.py
@@ -25,11 +25,18 @@ nothing and a missing framework raises a clear, actionable error. ``sample_indic
 
 from __future__ import annotations
 
+import logging
+import os
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
+
+from .buffers import HostAllocator, aligned_empty
 from .source import _SplitView
 from .types import Batch
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:  # annotations only; these are optional at runtime
     import tensorflow as tf
@@ -43,13 +50,115 @@ def _missing(name: str, extra: str) -> ImportError:
     )
 
 
-def to_torch(batch: Batch) -> dict[str, torch.Tensor]:
-    """Convert a numpy ``Batch`` to a dict of torch tensors (DLPack; zero-copy on CPU)."""
+_DEFAULT_PIN_FRACTION = 8  # of physical RAM
+_FALLBACK_PIN_BUDGET = 1 << 30  # where physical RAM is not discoverable
+
+
+def _default_pin_budget() -> int:
+    """An eighth of physical RAM, or 1 GiB where that cannot be read.
+
+    Page-locked memory is a *global* resource the kernel cannot reclaim, so over-pinning
+    degrades the whole machine rather than just this process. The default is sized to never
+    fire for weather or ViT payloads and to catch a microscopy-sized pool on a small host.
+    """
+    try:
+        total: int = os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
+    except (AttributeError, ValueError, OSError):  # pragma: no cover - non-POSIX
+        return _FALLBACK_PIN_BUDGET
+    return total // _DEFAULT_PIN_FRACTION
+
+
+def pinned_allocator(budget_bytes: int | None = None) -> HostAllocator:
+    """A host allocator handing out page-locked buffers, up to ``budget_bytes``.
+
+    Past the budget it returns ordinary aligned heap memory instead. Degrading rather than
+    raising or blocking is deliberate: blocking could deadlock (a consumer legitimately holds
+    batches, so the producer could wait forever), raising would turn a performance feature
+    into a crash, and the degraded state is simply what the loader shipped before pinning
+    existed. It warns once so "pinning did nothing" is diagnosable rather than mysterious.
+    """
     try:
         import torch
     except ImportError as exc:  # pragma: no cover - torch-less installs
         raise _missing("PyTorch", "torch") from exc
-    return {k: torch.from_dlpack(v) for k, v in batch.arrays.items()}
+
+    budget = _default_pin_budget() if budget_bytes is None else int(budget_bytes)
+    used = 0
+    warned = False
+
+    def allocate(shape: tuple[int, ...], dtype: np.dtype) -> np.ndarray:
+        nonlocal used, warned
+        nbytes = int(np.prod(shape)) * dtype.itemsize
+        if used + nbytes > budget:
+            if not warned:
+                warned = True
+                logger.warning(
+                    "pinned-buffer budget exhausted (%.0f MiB used, %.0f MiB needed for the "
+                    "next buffer, budget %.0f MiB) -- further batch buffers are pageable, so "
+                    "H2D transfers stop overlapping. Raise pin_budget_bytes or lower "
+                    "batch_size/prefetch_depth.",
+                    used / 2**20,
+                    nbytes / 2**20,
+                    budget / 2**20,
+                )
+            return aligned_empty(shape, dtype)
+        # numpy view of a page-locked tensor: aliases (never copies), and CUDA still
+        # recognises the pages through the DLPack round-trip back into torch, which is what
+        # keeps `non_blocking` genuinely asynchronous. Page-locked memory is page-aligned, so
+        # the pool's 128-byte XLA alignment comes free.
+        pinned = torch.empty(tuple(shape), dtype=getattr(torch, str(dtype)), pin_memory=True)
+        used += nbytes
+        return pinned.numpy()
+
+    return allocate
+
+
+class _InFlight:
+    """Sources held until their asynchronous H2D copy has actually landed.
+
+    The reclaim hazard pinning introduces: a ``non_blocking`` copy returns before it has
+    finished reading its source, and Python refcounts cannot see an in-flight DMA, so a buffer
+    whose view the consumer has dropped could be recycled and overwritten mid-copy. Pageable
+    memory hides this (the driver stages through a bounce buffer, so the copy is effectively
+    synchronous with respect to the host) -- pinning is what makes it real.
+
+    The guard needs no new machinery in the pool: holding the *source arrays* until
+    ``event.query()`` keeps their views referenced, so the pool's existing liveness poll
+    defers reclaim on its own. Nothing crosses into the core, and ``Batch`` is untouched.
+    """
+
+    def __init__(self) -> None:
+        self._pending: list[tuple[dict[str, np.ndarray], torch.cuda.Event]] = []
+
+    def hold(self, arrays: dict[str, np.ndarray], event: torch.cuda.Event) -> None:
+        self._pending.append((arrays, event))
+        self._pending[:] = [(a, e) for a, e in self._pending if not e.query()]
+
+
+_in_flight = _InFlight()
+"""Process-wide, because CUDA streams are. Bounded: pruned on every hand-out."""
+
+
+def to_torch(batch: Batch, device: str | torch.device | None = None) -> dict[str, torch.Tensor]:
+    """Convert a numpy ``Batch`` to a dict of torch tensors (DLPack; zero-copy on CPU).
+
+    With ``device`` set, the copy is issued here rather than by the caller, and the batch's
+    source arrays are held until it lands. That is what makes pinned batch buffers safe to
+    recycle -- see :class:`_InFlight`. Without it the behaviour is unchanged: CPU tensors
+    aliasing the batch, and the caller's own ``.to(...)`` afterwards.
+    """
+    try:
+        import torch
+    except ImportError as exc:  # pragma: no cover - torch-less installs
+        raise _missing("PyTorch", "torch") from exc
+    tensors = {k: torch.from_dlpack(v) for k, v in batch.arrays.items()}
+    if device is None:
+        return tensors
+    out = {k: v.to(device, non_blocking=True) for k, v in tensors.items()}
+    event = torch.cuda.Event()
+    event.record()
+    _in_flight.hold(batch.arrays, event)
+    return out
 
 
 def to_jax(batch: Batch) -> dict[str, Any]:
@@ -86,11 +195,29 @@ def to_tf(batch: Batch) -> dict[str, Any]:
     return {k: tf.convert_to_tensor(v) for k, v in batch.arrays.items()}
 
 
-def as_torch(view: _SplitView) -> IterableDataset:
+def as_torch(
+    view: _SplitView,
+    *,
+    device: str | torch.device | None = None,
+    pin_budget_bytes: int | None = None,
+) -> IterableDataset:
     """Wrap a split view (e.g. ``ds.train``) as a torch ``IterableDataset`` for ``DataLoader``.
 
     Each yielded item is a ``dict[str, torch.Tensor]`` (via :func:`to_torch`). Use
     ``DataLoader(as_torch(ds.train), batch_size=None, num_workers=0)``.
+
+    Passing ``device`` moves batches here instead of in the training loop, and switches the
+    batch buffers to **page-locked** memory. The two are one option rather than two on
+    purpose: pinning is what makes an H2D copy genuinely asynchronous, so it is only safe
+    when whoever issues the copy also knows when it landed. A ``pin_memory=True`` flag the
+    caller could set without ``device`` would hand out pinned buffers under the caller's own
+    ``non_blocking`` copy and reintroduce a use-after-recycle we would then have to document
+    instead of prevent.
+
+    Worth it only above ~32 MiB per batch. Measured on an L4, pinning takes a 37 MiB batch's
+    transfer from +4.0 ms to +0.3 ms against a 25 ms step, and a weather-sized batch from
+    +1.5 ms to +0.7 ms -- real but marginal. ``pin_budget_bytes`` caps the page-locked total
+    (default: an eighth of RAM); past it buffers are pageable again, with a warning.
     """
     try:
         from torch.utils.data import IterableDataset
@@ -100,10 +227,12 @@ def as_torch(view: _SplitView) -> IterableDataset:
     class _TorchStream(IterableDataset):
         def __init__(self, stream: _SplitView) -> None:
             self._stream = stream
+            if device is not None:
+                stream._use_host_allocator(pinned_allocator(pin_budget_bytes))
 
         def __iter__(self) -> Iterator[dict[str, torch.Tensor]]:
             for batch in self._stream:
-                yield to_torch(batch)
+                yield to_torch(batch, device=device)
 
     return _TorchStream(view)
 

--- a/src/insitubatch/frameworks.py
+++ b/src/insitubatch/frameworks.py
@@ -176,8 +176,12 @@ def to_torch(batch: Batch, device: str | torch.device | None = None) -> dict[str
         # No async DMA to guard: a CPU target copies synchronously (or not at all), and
         # torch.cuda.Event() raises outright on a machine without a driver.
         return out
-    event = torch.cuda.Event()
-    event.record()
+    # Bind the event to the *target* device: torch.cuda.Event() and record() attach to the
+    # current device's current stream, so for `cuda:1` without a set_device the event would
+    # belong to device 0, query True immediately, and release a buffer mid-DMA.
+    with torch.cuda.device(device):
+        event = torch.cuda.Event()
+        event.record()
     _in_flight.hold(batch.arrays, event)
     return out
 
@@ -248,7 +252,10 @@ def as_torch(
     class _TorchStream(IterableDataset):
         def __init__(self, stream: _SplitView) -> None:
             self._stream = stream
-            if device is not None:
+            # Only a CUDA target: page-locking is a CUDA allocation, so pinning for a CPU
+            # device would raise "no NVIDIA driver" from inside the producer thread on the
+            # first gather -- and buys nothing even where a driver exists.
+            if device is not None and torch.device(device).type == "cuda":
                 pin_host_buffers(stream, budget_bytes=pin_budget_bytes)
 
         def __iter__(self) -> Iterator[dict[str, torch.Tensor]]:

--- a/src/insitubatch/frameworks.py
+++ b/src/insitubatch/frameworks.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
@@ -149,6 +150,17 @@ class _InFlight:
 
     def __init__(self) -> None:
         self._pending: list[tuple[dict[str, np.ndarray], torch.cuda.Event]] = []
+        # Prune-then-append is a read-modify-write, and this object is process-wide: two
+        # threads converting batches at once (two DataLoaders, `zip(ds.train, ds.val)`) both
+        # run it. Without the lock a thread can finish its comprehension, be preempted before
+        # the slice assignment lands, and then overwrite a hold another thread appended in the
+        # gap -- releasing a buffer whose DMA is still reading it. The window is only the few
+        # bytecodes between the comprehension and the store, and it does not reproduce
+        # unaided (the comprehension iterates the live list by index, so it picks up a
+        # concurrent append); widened with a sleep at exactly that point it loses a live hold
+        # 20 times out of 20. One uncontended acquire per batch against a megabyte-scale copy
+        # is not a cost worth reasoning about, and the failure it prevents is silent.
+        self._lock = threading.Lock()
 
     def hold(self, arrays: dict[str, np.ndarray], event: torch.cuda.Event) -> None:
         """Retire finished holds, then take this one -- in that order, never the reverse.
@@ -161,13 +173,25 @@ class _InFlight:
         who wins. Retiring first means a fresh hold always survives until at least the next
         transfer, so the guarantee is structural rather than probabilistic. The cost is
         deferring one buffer's reclaim by one hand-out.
+
+        Both steps happen under the lock, because together they are one atomic replacement of
+        the pending set -- see :meth:`__init__`.
         """
-        self._pending[:] = [(a, e) for a, e in self._pending if not e.query()]
-        self._pending.append((arrays, event))
+        with self._lock:
+            self._pending[:] = [(a, e) for a, e in self._pending if not e.query()]
+            self._pending.append((arrays, event))
 
 
 _in_flight = _InFlight()
-"""Process-wide, because CUDA streams are. Bounded: pruned on every hand-out."""
+"""Process-wide, because CUDA streams are.
+
+Bounded: every hand-out retires the holds whose copies have landed, so the set is whatever is
+genuinely in flight plus the one deliberately-deferred entry. The tail is that single entry --
+after the last transfer of a run, one batch's source arrays stay referenced until either the
+next transfer prunes them or the process exits. Bounded at one batch, and not reachable from
+``InSituDataset.close()``: this lives in the torch adapter, the core cannot import it, and
+draining a process-wide set on one dataset's close would be wrong anyway.
+"""
 
 
 def to_torch(batch: Batch, device: str | torch.device | None = None) -> dict[str, torch.Tensor]:

--- a/src/insitubatch/frameworks.py
+++ b/src/insitubatch/frameworks.py
@@ -53,7 +53,13 @@ def to_torch(batch: Batch) -> dict[str, torch.Tensor]:
 
 
 def to_jax(batch: Batch) -> dict[str, Any]:
-    """Convert a numpy ``Batch`` to a dict of ``jax.Array`` (DLPack)."""
+    """Convert a numpy ``Batch`` to a dict of ``jax.Array`` (DLPack).
+
+    Zero-copy only when the batch buffer sits on a 128-byte boundary: XLA:CPU requires that
+    alignment and silently falls back to a copy otherwise. numpy guarantees only 16, so with
+    today's per-batch ``np.empty`` roughly half of batches are copied (measured 20/40 —
+    ``bench/probe_batch_buffers.py --arms jax``). Correct either way, just not free.
+    """
     try:
         import jax.numpy as jnp
     except ImportError as exc:  # pragma: no cover - jax-less installs
@@ -70,7 +76,8 @@ def to_tf(batch: Batch) -> dict[str, Any]:
     of the prefetch decode threads it double-frees that buffer and aborts the process
     (SIGABRT, no message). ``convert_to_tensor`` copies into a TF-owned tensor instead, so TF
     never touches insitu-managed memory; the batch is already an owned array, so this is a
-    single CPU copy. (torch/JAX stay zero-copy; this is a TF-DLPack limitation, not ours.)
+    single CPU copy. (torch stays zero-copy, JAX when aligned -- see :func:`to_jax`; TF's is a
+    DLPack limitation, not ours.)
     """
     try:
         import tensorflow as tf

--- a/src/insitubatch/frameworks.py
+++ b/src/insitubatch/frameworks.py
@@ -113,6 +113,23 @@ def pinned_allocator(budget_bytes: int | None = None) -> HostAllocator:
     return allocate
 
 
+def pin_host_buffers(view: _SplitView, *, budget_bytes: int | None = None) -> None:
+    """Switch a split's batch buffers to page-locked memory, for the duration of the dataset.
+
+    Only safe when **we** issue the H2D copy -- that is, when every batch goes through
+    :func:`to_torch` with ``device=`` (or :func:`as_torch`, which calls this for you). Pinning
+    is what makes a ``non_blocking`` copy genuinely asynchronous, and Python refcounts cannot
+    see an in-flight DMA, so pinned buffers under a *caller's own* ``non_blocking`` copy would
+    let the pool recycle a buffer mid-transfer. With ``to_torch(..., device=...)`` the source
+    is held until its event fires and the hazard is closed.
+
+    Call before iterating. ``as_torch(view, device=...)`` is the one-liner for the
+    ``DataLoader`` path; this is the equivalent for code that iterates the dataset itself and
+    converts per batch.
+    """
+    view._use_host_allocator(pinned_allocator(budget_bytes))
+
+
 class _InFlight:
     """Sources held until their asynchronous H2D copy has actually landed.
 
@@ -155,6 +172,10 @@ def to_torch(batch: Batch, device: str | torch.device | None = None) -> dict[str
     if device is None:
         return tensors
     out = {k: v.to(device, non_blocking=True) for k, v in tensors.items()}
+    if torch.device(device).type != "cuda":
+        # No async DMA to guard: a CPU target copies synchronously (or not at all), and
+        # torch.cuda.Event() raises outright on a machine without a driver.
+        return out
     event = torch.cuda.Event()
     event.record()
     _in_flight.hold(batch.arrays, event)
@@ -228,7 +249,7 @@ def as_torch(
         def __init__(self, stream: _SplitView) -> None:
             self._stream = stream
             if device is not None:
-                stream._use_host_allocator(pinned_allocator(pin_budget_bytes))
+                pin_host_buffers(stream, budget_bytes=pin_budget_bytes)
 
         def __iter__(self) -> Iterator[dict[str, torch.Tensor]]:
             for batch in self._stream:

--- a/src/insitubatch/frameworks.py
+++ b/src/insitubatch/frameworks.py
@@ -148,8 +148,19 @@ class _InFlight:
         self._pending: list[tuple[dict[str, np.ndarray], torch.cuda.Event]] = []
 
     def hold(self, arrays: dict[str, np.ndarray], event: torch.cuda.Event) -> None:
-        self._pending.append((arrays, event))
+        """Retire finished holds, then take this one -- in that order, never the reverse.
+
+        Pruning after appending lets a hold evaporate in the microseconds between issuing the
+        copy and testing it: a small or fast DMA can already be complete, and the batch we were
+        asked to protect is released before the caller has done anything with it. Even when
+        that is *safe* (a complete event means the copy landed) it makes reuse depend on a
+        race, which is untestable by construction -- the buffer is retained or not depending on
+        who wins. Retiring first means a fresh hold always survives until at least the next
+        transfer, so the guarantee is structural rather than probabilistic. The cost is
+        deferring one buffer's reclaim by one hand-out.
+        """
         self._pending[:] = [(a, e) for a, e in self._pending if not e.query()]
+        self._pending.append((arrays, event))
 
 
 _in_flight = _InFlight()

--- a/src/insitubatch/frameworks.py
+++ b/src/insitubatch/frameworks.py
@@ -110,6 +110,9 @@ def pinned_allocator(budget_bytes: int | None = None) -> HostAllocator:
         used += nbytes
         return pinned.numpy()
 
+    # Read back by `BatchBuffers.kind` for the epoch summary: without it there is no way to
+    # confirm from a training log that `--pin` / `as_torch(device=...)` actually took effect.
+    allocate.label = "pinned"  # type: ignore[attr-defined]
     return allocate
 
 

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -498,6 +498,7 @@ class ChunkPool:
             # is load-time and persists.
             self.hits = self.misses = 0
             self.revive_mismatch = self.revive_missing = 0
+            self._buffers.reset_counters()  # batch outputs too -- same epoch boundary
             self._cv.notify_all()
 
     def _pin(self, key: tuple[str, int]) -> None:  # call under the lock

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -72,6 +72,7 @@ from typing import TextIO
 
 import numpy as np
 
+from .buffers import BatchBuffers
 from .types import ArrayGeometry, Batch, ChunkRead, DecodedChunk
 
 try:  # optional: stronger transform fingerprint (closures + globals). `--extra cache`.
@@ -292,6 +293,11 @@ class ChunkPool:
                 )
             self._load_log()
             self._open_log()
+        # Batch *output* buffers, distinct from the chunk slots below: gather lends one per
+        # variable per batch and reclaims it once the consumer's view is unreferenced. Driven
+        # only from the single producer thread that gathers (as the rest of gather already
+        # assumes), so it needs no lock of its own.
+        self._buffers = BatchBuffers()
         self._budget = budget_bytes  # None => unbounded (never self-evicts)
         self._bytes = 0
         # OrderedDict in recency order (LRU front -> MRU back). Eviction targets only
@@ -682,7 +688,7 @@ class ChunkPool:
             spc = geom.sample_chunk_size  # the variable's own grid (may differ from ref)
             read_cid = sample // spc
             within = sample % spc
-            out = np.empty((n, *out_geom.inner_shape), dtype=out_geom.dtype)
+            out = self._buffers.take(n, out_geom.inner_shape, out_geom.dtype)
             for cid in np.unique(read_cid):
                 mask = read_cid == cid  # rows that read this chunk -> one coalesced index
                 out[mask] = self._slots[(geom.path, int(cid))].data[within[mask]]
@@ -863,6 +869,7 @@ class ChunkPool:
                 self._free(slot, keep_file=self._persistent and slot.ready)
             self._bytes = 0
             self._pinned.clear()
+            self._buffers.clear()  # batch outputs too; a big-payload pool holds GBs of them
 
     def __del__(self) -> None:
         # Safety net for a pool dropped without an explicit close() -- release the open log

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -72,7 +72,7 @@ from typing import TextIO
 
 import numpy as np
 
-from .buffers import BatchBuffers
+from .buffers import BatchBuffers, BufferStats, HostAllocator
 from .types import ArrayGeometry, Batch, ChunkRead, DecodedChunk
 
 try:  # optional: stronger transform fingerprint (closures + globals). `--extra cache`.
@@ -294,9 +294,12 @@ class ChunkPool:
             self._load_log()
             self._open_log()
         # Batch *output* buffers, distinct from the chunk slots below: gather lends one per
-        # variable per batch and reclaims it once the consumer's view is unreferenced. Driven
-        # only from the single producer thread that gathers (as the rest of gather already
-        # assumes), so it needs no lock of its own.
+        # variable per batch and reclaims it once the consumer's view is unreferenced. It
+        # carries its own lock, and needs it -- one ChunkPool is shared by every active
+        # iteration, so `zip(ds.train, ds.val)` or two DataLoaders put two producer threads
+        # through `gather` at once. Do not remove that lock on the assumption that gather is
+        # single-threaded: two producers deciding the same buffer is free is a silent
+        # wrong-data bug. See BatchBuffers' own docstring.
         self._buffers = BatchBuffers()
         self._budget = budget_bytes  # None => unbounded (never self-evicts)
         self._bytes = 0
@@ -474,6 +477,20 @@ class ChunkPool:
             for key in keys:
                 self._unpin_one(key)
             self._cv.notify_all()
+
+    def buffer_stats(self) -> BufferStats:
+        """One consistent reading of the batch-output pool, for the per-epoch summary."""
+        return self._buffers.stats()
+
+    def set_host_allocator(self, allocator: HostAllocator) -> None:
+        """Point the batch-output pool at a different host allocator.
+
+        How the torch adapter installs page-locked buffers without the core importing a
+        framework. A method rather than letting callers reach ``pool._buffers`` directly, so
+        the buffer pool stays this class's private business and there is one place to look for
+        who can change it.
+        """
+        self._buffers.set_allocator(allocator)
 
     def unpin_all(self) -> None:
         """Epoch boundary reset: clear every pin and drop abandoned partials.

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -432,6 +432,7 @@ class InSituDataset:
                 self.cache_hits = pool.hits
                 self.cache_misses = pool.misses
                 self.bad_chunks = list(sched.bad_chunks)  # tiles NaN-filled this epoch
+                self._log_epoch_summary(pool)
                 # Persistence was asked for but served nothing, and the cache *was*
                 # consulted (entries existed and every revive failed) -> almost certainly
                 # a stale cache_dir or changed data/transforms. Loud once per epoch; a
@@ -446,6 +447,41 @@ class InSituDataset:
                         pool.revive_mismatch,
                         pool.revive_missing,
                     )
+
+    def _log_epoch_summary(self, pool: ChunkPool) -> None:
+        """One INFO line per epoch: what the chunk cache and the batch buffers did.
+
+        Enabled the standard way -- ``logging.getLogger("insitubatch").setLevel(logging.INFO)``
+        -- rather than through a constructor flag, so there is nothing to thread through the
+        API and nothing to leave switched on by accident. It is off by default because
+        libraries do not configure logging for their callers.
+
+        The two numbers worth watching are ``alloc`` and the hit rate. Allocations should fall
+        to zero once the pool has converged on the in-flight batch count; a nonzero count in a
+        later epoch means buffers are not coming back -- retained batches (which is legitimate,
+        but it is a memory floor) or a changing batch geometry. ``kind=pinned`` is the only
+        confirmation available from a training log that page-locked buffers are actually in
+        use, since the fallback to pageable memory is otherwise silent here.
+        """
+        if not logger.isEnabledFor(logging.INFO):
+            return  # skip the property reads (each takes the buffer pool's lock)
+        buffers = pool._buffers
+        reads = pool.hits + pool.misses
+        logger.info(
+            "epoch %d: chunks %d/%d hit (%.0f%%), peak resident %d%s; "
+            "batch buffers %d x %s = %.1f MiB, %d lent, %d allocated",
+            self._epoch,
+            pool.hits,
+            reads,
+            100 * pool.hits / reads if reads else 0.0,
+            pool.max_resident,
+            f", {len(self.bad_chunks)} bad chunks" if self.bad_chunks else "",
+            buffers.n_buffers,
+            buffers.kind,
+            buffers.nbytes / 2**20,
+            buffers.lends,
+            buffers.allocations,
+        )
 
     def close(self) -> None:
         """Release the cache pool's backing (mmap handles, cached chunks) and any async

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -460,20 +460,18 @@ class InSituDataset:
         API and nothing to leave switched on by accident. It is off by default because
         libraries do not configure logging for their callers.
 
-        The two numbers worth watching are ``alloc`` and the hit rate. Allocations should fall
-        to zero once the pool has converged on the in-flight batch count; a nonzero count in a
-        later epoch means buffers are not coming back -- retained batches (which is legitimate,
-        but it is a memory floor) or a changing batch geometry. ``kind=pinned`` is the only
-        confirmation available from a training log that page-locked buffers are actually in
-        use, since the fallback to pageable memory is otherwise silent here.
+        The two numbers worth watching are ``allocated`` and the hit rate. Allocations should
+        fall to zero once the pool has converged on the in-flight batch count; a nonzero count
+        in a later epoch means buffers are not coming back -- retained batches (which is
+        legitimate, but it is a memory floor) or a changing batch geometry. The ``x pinned``
+        term is the only confirmation available from a training log that page-locked buffers
+        are actually in use, since the fallback to pageable memory is otherwise silent here.
         """
         if not logger.isEnabledFor(logging.INFO):
-            return  # skip the property reads (each takes the buffer pool's lock)
-        buffers = pool._buffers
+            return  # skip the snapshot, which takes the buffer pool's lock
         reads = pool.hits + pool.misses
         logger.info(
-            "epoch %d (%s): chunks %d/%d hit (%.0f%%), peak resident %d%s; "
-            "batch buffers %d x %s = %.1f MiB, %d lent, %d allocated",
+            "epoch %d (%s): chunks %d/%d hit (%.0f%%), peak resident %d%s; batch buffers %s",
             self._epoch,
             split or "all",
             pool.hits,
@@ -481,11 +479,7 @@ class InSituDataset:
             100 * pool.hits / reads if reads else 0.0,
             pool.max_resident,
             f", {len(self.bad_chunks)} bad chunks" if self.bad_chunks else "",
-            buffers.n_buffers,
-            buffers.kind,
-            buffers.nbytes / 2**20,
-            buffers.lends,
-            buffers.allocations,
+            pool.buffer_stats().summary(),
         )
 
     def close(self) -> None:
@@ -539,4 +533,4 @@ class _SplitView:
         two arrive together or not at all -- pinned buffers under a caller's own
         ``non_blocking`` copy would reintroduce exactly the use-after-recycle this avoids.
         """
-        self._dataset._pool._buffers.set_allocator(allocator)
+        self._dataset._pool.set_host_allocator(allocator)

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -432,7 +432,7 @@ class InSituDataset:
                 self.cache_hits = pool.hits
                 self.cache_misses = pool.misses
                 self.bad_chunks = list(sched.bad_chunks)  # tiles NaN-filled this epoch
-                self._log_epoch_summary(pool)
+                self._log_epoch_summary(pool, split)
                 # Persistence was asked for but served nothing, and the cache *was*
                 # consulted (entries existed and every revive failed) -> almost certainly
                 # a stale cache_dir or changed data/transforms. Loud once per epoch; a
@@ -448,8 +448,12 @@ class InSituDataset:
                         pool.revive_missing,
                     )
 
-    def _log_epoch_summary(self, pool: ChunkPool) -> None:
-        """One INFO line per epoch: what the chunk cache and the batch buffers did.
+    def _log_epoch_summary(self, pool: ChunkPool, split: SplitName | None) -> None:
+        """One INFO line per epoch *per split*: what the chunk cache and the batch buffers did.
+
+        Tagged with the split because a training run iterates more than one of them per epoch
+        (train, then val) over the same pools, and two lines reading "epoch 1" with different
+        numbers is a puzzle rather than a report.
 
         Enabled the standard way -- ``logging.getLogger("insitubatch").setLevel(logging.INFO)``
         -- rather than through a constructor flag, so there is nothing to thread through the
@@ -468,9 +472,10 @@ class InSituDataset:
         buffers = pool._buffers
         reads = pool.hits + pool.misses
         logger.info(
-            "epoch %d: chunks %d/%d hit (%.0f%%), peak resident %d%s; "
+            "epoch %d (%s): chunks %d/%d hit (%.0f%%), peak resident %d%s; "
             "batch buffers %d x %s = %.1f MiB, %d lent, %d allocated",
             self._epoch,
+            split or "all",
             pool.hits,
             reads,
             100 * pool.hits / reads if reads else 0.0,

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -35,6 +35,7 @@ from collections.abc import Callable, Iterator, Sequence
 import numpy as np
 from zarr.abc.store import Store
 
+from .buffers import HostAllocator
 from .pool import ChunkPool, output_geometry
 from .scheduler import Scheduler, SchedulerConfig
 from .shuffle import block_shuffled_order, sequential_order
@@ -487,3 +488,14 @@ class _SplitView:
 
     def __iter__(self) -> Iterator[Batch]:
         return self._dataset._iterate(self._split, self._shuffle)
+
+    def _use_host_allocator(self, allocator: HostAllocator) -> None:
+        """Point the batch-buffer pool at a different host allocator (adapter-internal).
+
+        How ``frameworks.as_torch(..., device=...)`` installs page-locked buffers without the
+        core importing torch. Deliberately not public and deliberately not a constructor
+        argument: pinning is only *safe* alongside an adapter that owns the H2D copy, so the
+        two arrive together or not at all -- pinned buffers under a caller's own
+        ``non_blocking`` copy would reintroduce exactly the use-after-recycle this avoids.
+        """
+        self._dataset._pool._buffers.set_allocator(allocator)

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from bench.advection_sweep import PersistenceCheck
+from bench.advection_sweep import PersistenceCheck, store_key
 from bench.engines import Cfg, run
 from bench.make_dataset import make_dataset
 from bench.run import run_suite
@@ -186,3 +186,35 @@ def test_persistence_check_ties_every_batch_size_to_one_store() -> None:
     assert check.report()
     check.observe("synth256", 0.594, "the buggy reuse arm")
     assert not check.report()
+
+
+def test_persistence_check_separates_stores_that_differ_by_chunking() -> None:
+    # Regression: the sweep writes one store per (store, sample_chunk, inner_chunk) --
+    # `..._synth128_c256_i128.zarr` vs `..._synth128_c4_i128.zarr` -- and splits are
+    # chunk-aligned, so a different sample_chunk yields a different val set and a legitimately
+    # different persistence RMSE. Keying the invariant on `store` alone collapsed all four
+    # configs of `--sweeps chunk` onto one baseline and failed a healthy run.
+    check = PersistenceCheck()
+    for spc, value in ((256, 0.588), (64, 0.612), (16, 0.640), (4, 0.671)):
+        check.observe(
+            store_key({"store": "synth128", "size": 128, "sample_chunk": spc, "inner_chunk": None}),
+            value,
+            f"synth128 c{spc}",
+        )
+    assert check.report(), "configs reading different stores must not share a baseline"
+
+    # ...while a real drift within one store is still caught.
+    key = store_key({"store": "synth128", "size": 128, "sample_chunk": 64, "inner_chunk": None})
+    check.observe(key, 0.934, "the corrupt arm")
+    assert not check.report()
+
+
+def test_persistence_check_still_ties_inner_chunk_variants_by_their_own_store() -> None:
+    # The `inner` sweep varies spatial tiling only, which cannot move a sample-axis split --
+    # but each variant is still its own zarr, so it gets its own baseline rather than being
+    # asserted equal to the others by accident.
+    keys = {
+        store_key({"store": "synth128", "size": 128, "sample_chunk": 64, "inner_chunk": ic})
+        for ic in (128, 64, 32)
+    }
+    assert len(keys) == 3

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from bench.advection_sweep import PersistenceCheck
 from bench.engines import Cfg, run
 from bench.make_dataset import make_dataset
 from bench.run import run_suite
@@ -153,3 +154,35 @@ def test_run_forwards_store_kwargs(tmp_path) -> None:
     cfg = Cfg(engine="insitu", url=url, storage="file", sample_chunk=8, batch_size=8, epochs=1)
     rows = run(cfg, store_kwargs={"skip_signature": True})
     assert rows and rows[0].n_samples > 0
+
+
+def test_persistence_check_flags_the_drift_that_hid_the_double_lend() -> None:
+    # Replays the real 2026-07-31 numbers. The corrupt pinned arm scored +13.6% forecast
+    # skill -- better than real ERA5's honest +11.4% -- so skill could not catch it. What
+    # gave it away is that persistence RMSE, which involves no model, moved between repeats
+    # of one config while the healthy arm reproduced its value exactly.
+    check = PersistenceCheck()
+    for r, healthy in enumerate((0.682, 0.682, 0.682)):
+        check.observe("synth128", healthy, f"synth128 repeat {r}")
+    assert check.report()  # bit-identical across repeats -> silent
+
+    check = PersistenceCheck()
+    for r, corrupt in enumerate((0.682, 0.934, 0.627)):
+        check.observe("synth128", corrupt, f"synth128 repeat {r}")
+    assert not check.report()
+    assert len(check.drifted) == 2  # both departures from the first value
+
+
+def test_persistence_check_ties_every_batch_size_to_one_store() -> None:
+    # Batch size does not change the val set: measured, all of 32/64/128 returned
+    # 0.588030696 over the synth256 store. Keying on the store (not the geom) is what makes
+    # a payload sweep cross-check its own arms instead of each config trusting itself.
+    check = PersistenceCheck()
+    for bs in (32, 64, 128):
+        check.observe("synth256", 0.588030696, f"synth256b{bs}")
+    assert check.report()
+
+    check.observe("synth256", 0.588030696 * (1 + 1e-9), "fp jitter")  # under RTOL -> ignored
+    assert check.report()
+    check.observe("synth256", 0.594, "the buggy reuse arm")
+    assert not check.report()

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
+import bench.probe_batch_buffers as probe
+import insitubatch.buffers as core_buffers
 from bench.advection_sweep import PersistenceCheck, store_key
 from bench.engines import Cfg, run
 from bench.make_dataset import make_dataset
+from bench.probe_batch_buffers import ARMS, CASES, Case, JaxCheck, Roundtrip
 from bench.run import run_suite
 
 
@@ -218,3 +222,133 @@ def test_persistence_check_still_ties_inner_chunk_variants_by_their_own_store() 
         for ic in (128, 64, 32)
     }
     assert len(keys) == 3
+
+
+# --- probe_batch_buffers -----------------------------------------------------------------
+#
+# The probe is what decided the pool's design, and it is the instrument we go back to when a
+# measurement is disputed -- so it has to keep measuring the thing the core actually does. It
+# predates the implementation, and carried its own copies of `aligned_empty`, `XLA_ALIGN` and
+# the numpy->torch dtype mapping; a change to any of those in `src/` would have left the probe
+# quietly reporting the old design's numbers. These tests pin the coupling (identity, not
+# equality: an equal-looking reimplementation is exactly the drift being prevented) and run the
+# CPU-reachable arms end to end so an API rename breaks CI rather than the next GPU session.
+
+# One tiny case: the arms are exercised for wiring, not timed. The real CASES sweep to 256 MiB
+# per buffer times four source chunks, which is a benchmark, not a test.
+_TOY = (Case("toy", 4, (2, 3), np.dtype("f4")),)
+
+
+def test_probe_shares_the_cores_buffer_primitives() -> None:
+    assert probe.aligned_empty is core_buffers.aligned_empty
+    assert probe.XLA_ALIGN is core_buffers.XLA_ALIGN
+
+
+def test_probe_alloc_arm_times_both_sides() -> None:
+    fresh_ms, reuse_ms = probe.probe_alloc(_TOY[0], iters=3)
+    assert fresh_ms > 0 and reuse_ms > 0
+
+
+def test_probe_main_runs_the_host_arm(monkeypatch, capsys) -> None:  # type: ignore[no-untyped-def]
+    """The default invocation from the module docstring, on a toy payload."""
+    monkeypatch.setattr(probe, "CASES", _TOY)
+    monkeypatch.setattr("sys.argv", ["probe_batch_buffers", "--arms", "alloc", "--iters", "2"])
+    probe.main()
+    out = capsys.readouterr().out
+    assert "fresh np.empty vs reused buffer" in out and "toy" in out
+
+
+def test_probe_rejects_an_unknown_arm(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setattr("sys.argv", ["probe_batch_buffers", "--arms", "aloc"])
+    with pytest.raises(SystemExit, match="unknown arm"):
+        probe.main()
+
+
+def test_probe_cases_are_dtypes_the_core_can_allocate() -> None:
+    """Every swept case must survive the pool's own allocator and torch's own mapping.
+
+    The GPU arms build their tensors with `_torch_dtype`, the same converter `pinned_allocator`
+    uses, so a case whose dtype the core cannot serve is a probe measuring nothing -- and it
+    would only show up on a GPU box. Checked here, on CPU, for the real CASES.
+    """
+    torch = pytest.importorskip("torch")
+    from insitubatch.frameworks import _torch_dtype
+
+    for case in CASES:
+        assert probe.aligned_empty((1, *case.inner), case.dtype).dtype == case.dtype
+        assert torch.empty(0, dtype=_torch_dtype(case.dtype)).numpy().dtype == case.dtype
+
+
+def test_probe_jax_arm_runs_without_a_gpu() -> None:
+    """The soundness question `to_jax` rests on, exercised on whatever backend is present.
+
+    Without a GPU the two device-transfer checks are untestable and must report *unknown*
+    rather than *safe* -- a probe that returns "ok" on a CPU box would retire the question it
+    exists to keep open.
+    """
+    pytest.importorskip("jax")
+    check = probe.probe_jax(trials=2)
+    assert check.keeps_alive, "jnp.from_dlpack must hold the array it was given"
+    assert check.aligned_zero_copy == 2, "128-byte alignment is what makes zero-copy reliable"
+    if not [d for d in __import__("jax").devices() if d.platform == "gpu"]:
+        assert (check.race_observed, check.holds_source, check.poll_insufficient) == (
+            None,
+            None,
+            None,
+        )
+
+
+@pytest.mark.parametrize(
+    ("race", "holds", "insufficient"),
+    [(True, False, True), (True, True, False), (False, False, False), (None, None, None)],
+)
+def test_jax_verdict_needs_both_an_async_copy_and_an_unheld_source(
+    race: bool | None, holds: bool | None, insufficient: bool | None
+) -> None:
+    # Only the pairing condemns reuse: an async transfer JAX holds across is guarded by the
+    # pool's own poll, and a synchronous one has no window at all.
+    check = JaxCheck(
+        backend="cpu",
+        device="cpu",
+        trials=1,
+        default_zero_copy=1,
+        aligned_zero_copy=1,
+        keeps_alive=True,
+        race_observed=race,
+        holds_source=holds,
+    )
+    assert check.poll_insufficient is insufficient
+
+
+@pytest.mark.parametrize(
+    ("shares", "full", "prefix", "ms", "verdict"),
+    [
+        (False, True, True, 1.0, "BROKEN: .numpy() copied"),
+        (True, True, True, 1.0, "ok"),
+        (True, False, True, 1.0, "fast but flag says pageable"),
+        (True, True, True, 9.0, "DEAD: degrades to pageable"),
+        (True, True, False, 1.0, "fast but flag says pageable"),
+    ],
+)
+def test_roundtrip_verdict_requires_the_flag_and_the_clock_to_agree(
+    shares: bool, full: bool, prefix: bool, ms: float, verdict: str
+) -> None:
+    # `is_pinned()` alone is not trustworthy: the failure that matters is a non_blocking copy
+    # silently degrading to a synchronous pageable one, which shows up in the clock.
+    rt = Roundtrip(
+        shares=shares,
+        full_pinned=full,
+        prefix_pinned=prefix,
+        ms=ms,
+        pageable_ms=10.0,
+        pinned_ms=1.0,
+    )
+    assert rt.verdict == verdict
+
+
+def test_every_declared_arm_is_reachable_from_main() -> None:
+    # `--arms all` expands to ARMS, so an arm added to the tuple without a branch in main()
+    # (or renamed in one place only) is a silent no-op.
+    source = probe.main.__code__.co_consts
+    branches = {c for c in source if isinstance(c, str)}
+    assert set(ARMS) <= branches

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -16,6 +16,7 @@ corrupted batches in a training run.
 
 from __future__ import annotations
 
+import re
 import threading
 import time
 from typing import Any
@@ -340,6 +341,64 @@ def test_concurrent_take_never_lends_one_buffer_twice() -> None:
     for t in threads:
         t.join()
     assert not failures, failures[:5]
+
+
+def test_counters_separate_reuse_from_allocation() -> None:
+    """``allocations`` vs ``lends`` is the signal that the pool converged; keep them honest."""
+    pool = BatchBuffers()
+    first = pool.take(4, (3,), np.dtype("f4"))
+    second = pool.take(4, (3,), np.dtype("f4"))  # first still live -> a second allocation
+    assert (pool.lends, pool.allocations, pool.n_buffers) == (2, 2, 2)
+
+    del first, second
+    pool.take(4, (3,), np.dtype("f4"))  # both free now -> reuse, no allocation
+    assert (pool.lends, pool.allocations, pool.n_buffers) == (3, 2, 2)
+
+    pool.reset_counters()  # the epoch boundary: counters zero, buffers stay
+    assert (pool.lends, pool.allocations, pool.n_buffers) == (0, 0, 2)
+
+
+def test_epoch_summary_reports_buffer_state(write_zarr, caplog) -> None:  # type: ignore[no-untyped-def]
+    """The per-epoch INFO line is the only place buffer behaviour surfaces in a training log."""
+    import logging
+
+    from insitubatch import InSituDataset, obstore_store, open_geometries, split_by_chunk
+
+    url, _srcs = write_zarr(n=40, spc=8)
+    geom = open_geometries(obstore_store(url))["t2m"]
+    ds = InSituDataset(
+        obstore_store(url),
+        split_by_chunk(geom, fractions=(1.0, 0.0, 0.0)),
+        shuffle=False,
+        batch_size=5,
+        block_chunks=2,
+    )
+
+    with caplog.at_level(logging.INFO, logger="insitubatch.source"):
+        for epoch in range(2):
+            ds.set_epoch(epoch)
+            for _ in ds.train:
+                pass
+
+    lines = [r.getMessage() for r in caplog.records if "batch buffers" in r.getMessage()]
+    assert len(lines) == 2, lines  # one per epoch
+    assert "epoch 1:" in lines[1] and "heap" in lines[1]
+
+    def counts(line: str) -> tuple[int, int]:
+        m = re.search(r"(\d+) lent, (\d+) allocated", line)
+        assert m, line
+        return int(m[1]), int(m[2])
+
+    (lent0, alloc0), (lent1, alloc1) = counts(lines[0]), counts(lines[1])
+    # 10 batches, not 8: a batch never crosses a shuffle block, so 40 rows in blocks of
+    # 16/16/8 give ragged batches. One buffer lent per batch, every epoch.
+    assert lent0 == lent1 == 10
+    # The point of the line. Epoch 0 allocates however many are genuinely in flight -- 3 or 4
+    # here, decided by producer/consumer timing, so it is not a fixed number. What must hold is
+    # that a warm pool stops allocating: were buffers failing to come back, this would climb
+    # toward one per batch and the pool would be a growing memory floor.
+    assert alloc0 >= 1
+    assert alloc1 <= 1, f"warm epoch still allocating: {lines[1]}"
 
 
 def test_exported_torch_tensor_holds_the_buffer() -> None:

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -47,6 +47,38 @@ def test_retained_view_is_never_reused() -> None:
     assert np.all(held == 1.0)  # the retained batch is untouched
 
 
+def test_a_derived_view_keeps_its_buffer() -> None:
+    """A *slice* of a lent batch must hold the buffer, not just the lent array itself.
+
+    numpy collapses base chains: ``lent[..., i:j].base`` is the ultimate data owner, **not**
+    ``lent``. So tracking liveness by the lent object alone frees the buffer the moment a
+    consumer keeps a crop and drops the original -- which is precisely what a cropping
+    ``batch_transform`` does (``examples/wb2_arraylake.py``, and the guidance in
+    docs/architecture.md), and it corrupts training data silently.
+    """
+    pool = BatchBuffers()
+    lent = pool.take(4, (8, 8), np.dtype("f4"))
+    lent[:] = 1.0
+    crop = lent[..., 0:4, 0:4]  # a transform's output, aliasing the buffer
+    del lent  # the consumer keeps only the crop
+
+    other = pool.take(4, (8, 8), np.dtype("f4"))
+    other[:] = 9.0
+    assert np.all(crop == 1.0), "the pool recycled a buffer a live view still aliases"
+
+
+def test_a_derived_view_of_a_ragged_prefix_keeps_its_buffer() -> None:
+    """Same, for the short final batch -- a prefix view is where the tail lives."""
+    pool = BatchBuffers()
+    lent = pool.take(3, (8, 8), np.dtype("f4"))
+    lent[:] = 2.0
+    crop = lent[..., 2:6, 2:6]
+    del lent
+
+    pool.take(3, (8, 8), np.dtype("f4"))[:] = 7.0
+    assert np.all(crop == 2.0)
+
+
 def test_pool_grows_to_the_in_flight_count_then_stops() -> None:
     """No depth parameter: allocate-on-miss converges on however many are live at once."""
     pool = BatchBuffers()

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -382,7 +382,7 @@ def test_epoch_summary_reports_buffer_state(write_zarr, caplog) -> None:  # type
 
     lines = [r.getMessage() for r in caplog.records if "batch buffers" in r.getMessage()]
     assert len(lines) == 2, lines  # one per epoch
-    assert "epoch 1:" in lines[1] and "heap" in lines[1]
+    assert "epoch 1 (train):" in lines[1] and "heap" in lines[1]
 
     def counts(line: str) -> tuple[int, int]:
         m = re.search(r"(\d+) lent, (\d+) allocated", line)

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -1,0 +1,234 @@
+"""Batch-output buffer reuse: liveness-polled hand-out, and the guarantees it rests on.
+
+:class:`BatchBuffers` recycles a batch's output array instead of allocating a fresh one per
+batch, which is only safe because a buffer is handed back *as a view* and reclaimed only once
+that view is unreferenced. Two properties carry the whole design and are asserted here: a
+dropped view returns its buffer, and a **retained** one never does -- consumers hold batches
+for perfectly ordinary reasons (gradient accumulation, ``[b for b in ds]``) and recycling
+underneath them would corrupt training data silently.
+
+The framework tests at the bottom guard facts that are load-bearing but not contractual:
+``torch.from_dlpack`` and ``jax.device_put`` both keep the source alive, which is what makes
+the poll sufficient for an exported tensor. JAX documents in-place mutation of a ``from_dlpack``
+buffer as *undefined behaviour*, so if that ever regresses we want a red test here rather than
+corrupted batches in a training run.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from insitubatch.buffers import XLA_ALIGN, BatchBuffers, aligned_empty
+
+
+def _ptr(a: np.ndarray) -> int:
+    """Address of an array's first byte -- identity of the underlying allocation."""
+    return int(a.__array_interface__["data"][0])
+
+
+def test_dropped_view_is_reused() -> None:
+    """The point of the pool: back-to-back batches share one allocation."""
+    pool = BatchBuffers()
+    first = pool.take(4, (3, 2), np.dtype("f4"))
+    addr = _ptr(first)
+    del first
+    assert _ptr(pool.take(4, (3, 2), np.dtype("f4"))) == addr
+
+
+def test_retained_view_is_never_reused() -> None:
+    """A held batch must keep its memory -- this is the invariant that makes reuse safe."""
+    pool = BatchBuffers()
+    held = pool.take(4, (3, 2), np.dtype("f4"))
+    held[:] = 1.0
+    second = pool.take(4, (3, 2), np.dtype("f4"))
+    second[:] = 2.0
+    assert _ptr(second) != _ptr(held)
+    assert np.all(held == 1.0)  # the retained batch is untouched
+
+
+def test_pool_grows_to_the_in_flight_count_then_stops() -> None:
+    """No depth parameter: allocate-on-miss converges on however many are live at once."""
+    pool = BatchBuffers()
+    live = [pool.take(4, (3, 2), np.dtype("f4")) for _ in range(3)]
+    addrs = {_ptr(a) for a in live}
+    assert len(addrs) == 3  # three live at once -> three buffers
+    del live
+    # Nothing is live now, so the next three hand-outs must come from those same three.
+    again = [pool.take(4, (3, 2), np.dtype("f4")) for _ in range(3)]
+    assert {_ptr(a) for a in again} == addrs
+
+
+def test_ragged_tail_reuses_the_full_buffer_as_a_prefix() -> None:
+    """A short final batch is a prefix view of a full-size buffer, not a new allocation."""
+    pool = BatchBuffers()
+    full = pool.take(8, (3,), np.dtype("f4"))
+    addr = _ptr(full)
+    del full
+    tail = pool.take(3, (3,), np.dtype("f4"))
+    assert tail.shape == (3, 3)
+    assert _ptr(tail) == addr  # same allocation, shorter view
+
+
+def test_a_larger_request_does_not_alias_a_smaller_buffer() -> None:
+    """Growing past a buffer's capacity must allocate, never over-run it."""
+    pool = BatchBuffers()
+    small = pool.take(2, (3,), np.dtype("f4"))
+    addr = _ptr(small)
+    del small
+    big = pool.take(8, (3,), np.dtype("f4"))
+    assert big.shape == (8, 3)
+    assert _ptr(big) != addr
+
+
+@pytest.mark.parametrize(
+    ("inner", "dtype"),
+    [((3, 2), "f4"), ((3,), "f4"), ((3, 2), "f8")],
+)
+def test_shape_and_dtype_do_not_collide(inner: tuple[int, ...], dtype: str) -> None:
+    """Buffers are keyed by geometry: a batch never gets another variable's memory."""
+    pool = BatchBuffers()
+    a = pool.take(4, (3, 2), np.dtype("f4"))
+    b = pool.take(4, inner, np.dtype(dtype))
+    assert b.shape == (4, *inner) and b.dtype == np.dtype(dtype)
+    if (inner, dtype) != ((3, 2), "f4"):
+        assert _ptr(a) != _ptr(b)
+
+
+def test_buffers_are_xla_aligned() -> None:
+    """128-byte alignment is what makes ``to_jax`` reliably zero-copy rather than lucky."""
+    pool = BatchBuffers()
+    for _ in range(8):  # several allocations: default numpy alignment passes only by chance
+        assert _ptr(pool.take(4, (3, 2), np.dtype("f4"))) % XLA_ALIGN == 0
+
+
+def test_aligned_empty_is_a_real_writable_array() -> None:
+    """The alignment trick must not hand back a read-only or mis-shaped view."""
+    a = aligned_empty((4, 3), np.dtype("f4"))
+    a[:] = 7.0
+    assert a.shape == (4, 3) and a.dtype == np.dtype("f4") and np.all(a == 7.0)
+    assert _ptr(a) % XLA_ALIGN == 0
+
+
+def test_a_custom_allocator_is_used_for_every_buffer() -> None:
+    """The injection point pinning arrives through (the torch adapter supplies a pinned one)."""
+    calls: list[tuple[tuple[int, ...], np.dtype]] = []
+
+    def spy(shape: tuple[int, ...], dtype: np.dtype) -> np.ndarray:
+        calls.append((shape, dtype))
+        return aligned_empty(shape, dtype)
+
+    pool = BatchBuffers(allocator=spy)
+    pool.take(4, (3, 2), np.dtype("f4"))
+    assert calls == [((4, 3, 2), np.dtype("f4"))]
+
+
+def test_iteration_recycles_buffers_and_still_yields_correct_data(write_zarr) -> None:  # type: ignore[no-untyped-def]
+    """End to end: a real epoch reuses a bounded set of buffers *and* stays correct.
+
+    Correctness is the half that matters -- recycling is only worth anything if a reused
+    buffer is fully overwritten, so every batch is checked against the source array. The
+    address count proves the wiring actually reached ``gather``; asserting merely that the
+    data is right would pass just as well with the old fresh-allocation path.
+    """
+    from insitubatch import InSituDataset, obstore_store, open_geometries, split_by_chunk
+
+    url, srcs = write_zarr(n=40, spc=8)
+    geom = open_geometries(obstore_store(url))["t2m"]
+    ds = InSituDataset(
+        obstore_store(url),
+        split_by_chunk(geom, fractions=(1.0, 0.0, 0.0)),
+        shuffle=False,
+        batch_size=5,
+        block_chunks=2,
+    )
+    ds.set_epoch(0)
+
+    addrs = set()
+    for batch in ds.train:
+        addrs.add(_ptr(batch.arrays["t2m"]))
+        expected = srcs["t2m"][batch.sample_indices]
+        assert np.array_equal(batch.arrays["t2m"], expected)
+    # 8 batches drawn, but only the handful actually in flight at once get allocated.
+    assert 0 < len(addrs) < 8
+
+
+def test_a_retained_batch_survives_later_iteration(write_zarr) -> None:  # type: ignore[no-untyped-def]
+    """Keeping batches while iterating -- ``[b for b in ds]`` -- must not corrupt them."""
+    from insitubatch import InSituDataset, obstore_store, open_geometries, split_by_chunk
+
+    url, srcs = write_zarr(n=40, spc=8)
+    geom = open_geometries(obstore_store(url))["t2m"]
+    ds = InSituDataset(
+        obstore_store(url),
+        split_by_chunk(geom, fractions=(1.0, 0.0, 0.0)),
+        shuffle=False,
+        batch_size=5,
+        block_chunks=2,
+    )
+    ds.set_epoch(0)
+
+    kept = list(ds.train)  # every batch held at once -> no buffer may be recycled
+    for batch in kept:
+        assert np.array_equal(batch.arrays["t2m"], srcs["t2m"][batch.sample_indices])
+    assert len({_ptr(b.arrays["t2m"]) for b in kept}) == len(kept)  # all distinct
+
+
+def test_early_break_leaves_no_buffer_stranded(write_zarr) -> None:  # type: ignore[no-untyped-def]
+    """Abandoning an epoch mid-iteration must not strand buffers as permanently 'lent'.
+
+    This is the shape of bug that forced ``unpin_all()`` for *chunk* residency pins, where an
+    early ``break`` leaks the read-ahead's pins into the next epoch. Liveness-based reclaim is
+    immune by construction -- an abandoned batch is an unreferenced view, so its buffer is free
+    again with no epoch-boundary reset to remember -- and this pins that down.
+    """
+    from insitubatch import InSituDataset, obstore_store, open_geometries, split_by_chunk
+
+    url, srcs = write_zarr(n=40, spc=8)
+    geom = open_geometries(obstore_store(url))["t2m"]
+    ds = InSituDataset(
+        obstore_store(url),
+        split_by_chunk(geom, fractions=(1.0, 0.0, 0.0)),
+        shuffle=False,
+        batch_size=5,
+        block_chunks=2,
+    )
+
+    ds.set_epoch(0)
+    for _ in ds.train:  # take one batch, walk away
+        break
+
+    for epoch in range(1, 5):  # further epochs stay correct and do not accumulate
+        ds.set_epoch(epoch)
+        for batch in ds.train:
+            assert np.array_equal(batch.arrays["t2m"], srcs["t2m"][batch.sample_indices])
+
+    # 8 batches per epoch, 4 epochs since the break: a pool that stranded anything would
+    # have grown with the iteration. It is bounded by what is in flight instead.
+    assert ds._pool._buffers.nbytes < 8 * (5 * 2 * 2 * 4)
+
+
+def test_exported_torch_tensor_holds_the_buffer() -> None:
+    """A live DLPack export must block reuse -- torch keeps a strong ref to the source."""
+    torch = pytest.importorskip("torch")
+    pool = BatchBuffers()
+    view = pool.take(4, (3, 2), np.dtype("f4"))
+    addr = _ptr(view)
+    tensor = torch.from_dlpack(view)
+    tensor[:] = 5.0
+    del view  # only the tensor holds it now
+    assert _ptr(pool.take(4, (3, 2), np.dtype("f4"))) != addr
+    assert torch.all(tensor == 5.0)
+
+
+def test_exported_jax_array_holds_the_buffer() -> None:
+    """Same for JAX, where recycling under a live array is documented undefined behaviour."""
+    jnp = pytest.importorskip("jax.numpy")
+    pool = BatchBuffers()
+    view = pool.take(4, (3, 2), np.dtype("f4"))
+    view[:] = 5.0
+    addr = _ptr(view)
+    arr = jnp.from_dlpack(view)
+    del view
+    assert _ptr(pool.take(4, (3, 2), np.dtype("f4"))) != addr
+    assert bool((arr == 5.0).all())

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -16,10 +16,14 @@ corrupted batches in a training run.
 
 from __future__ import annotations
 
+import threading
+import time
+from typing import Any
+
 import numpy as np
 import pytest
 
-from insitubatch.buffers import XLA_ALIGN, BatchBuffers, aligned_empty
+from insitubatch.buffers import XLA_ALIGN, BatchBuffers, HostAllocator, aligned_empty
 
 
 def _ptr(a: np.ndarray) -> int:
@@ -142,6 +146,38 @@ def test_aligned_empty_is_a_real_writable_array() -> None:
     assert _ptr(a) % XLA_ALIGN == 0
 
 
+@pytest.mark.parametrize(
+    "allocator",
+    [
+        pytest.param(lambda shape, dtype: np.empty(shape, dtype), id="owns-its-data"),
+        pytest.param(lambda shape, dtype: aligned_empty(shape, dtype), id="view-of-a-buffer"),
+    ],
+)
+def test_liveness_holds_however_the_allocator_owns_its_memory(
+    allocator: HostAllocator,
+) -> None:
+    """Reuse safety must not depend on *how* the allocator's array holds its memory.
+
+    The liveness poll compares the data owner's refcount against a baseline recorded when the
+    buffer was built. Whether the owner is the array itself (``np.empty``) or something it
+    views (``aligned_empty``) decides which transient references are live at that moment, so a
+    baseline taken carelessly is right for one allocator and silently too high for the other --
+    and a baseline that is too high means every buffer always looks free, so the pool lends one
+    allocation to every batch at once and each overwrites the last.
+
+    This is not hypothetical for the pinned path: ``torch.empty(pin_memory=True).numpy()`` is
+    an owner-is-the-array allocation (``tests/test_pinned.py`` covers it on a CUDA box).
+    """
+    pool = BatchBuffers(allocator=allocator)
+    first = pool.take(4, (16,), np.dtype("f4"))
+    first[:] = 1.0
+    second = pool.take(4, (16,), np.dtype("f4"))
+    second[:] = 2.0
+
+    assert _ptr(first) != _ptr(second), "the pool lent one allocation to two live batches"
+    assert np.all(first == 1.0), "a live batch was overwritten by the next one"
+
+
 def test_a_custom_allocator_is_used_for_every_buffer() -> None:
     """The injection point pinning arrives through (the torch adapter supplies a pinned one)."""
     calls: list[tuple[tuple[int, ...], np.dtype]] = []
@@ -238,6 +274,72 @@ def test_early_break_leaves_no_buffer_stranded(write_zarr) -> None:  # type: ign
     # 8 batches per epoch, 4 epochs since the break: a pool that stranded anything would
     # have grown with the iteration. It is bounded by what is in flight instead.
     assert ds._pool._buffers.nbytes < 8 * (5 * 2 * 2 * 4)
+
+
+class _SlowSlice(np.ndarray):
+    """An array whose slicing pauses, to widen the check-then-lend window in ``take``.
+
+    ``take`` decides a buffer is free and *then* slices it to lend it. That gap is a handful
+    of bytecodes wide, so a plain thread stress test hits it only by luck and would be
+    flaky-red rather than red. Slowing the slice makes the existing gap observable without
+    touching the code under test -- it arrives through the public allocator hook, so the
+    production path (check, lend, hand out) is exactly the one being exercised.
+    """
+
+    delay = 0.0005
+
+    def __getitem__(self, key: Any) -> Any:
+        time.sleep(self.delay)
+        return super().__getitem__(key)
+
+
+def _slow_slice_allocator(shape: tuple[int, ...], dtype: np.dtype) -> np.ndarray:
+    # Constructed, not ``.view()``-ed, so the array owns its own data: a view would insert an
+    # extra level into the base chain and the pool would track the wrong owner (see
+    # ``test_an_allocator_whose_views_escape_liveness_tracking_is_rejected``).
+    return _SlowSlice(shape, dtype)
+
+
+def test_concurrent_take_never_lends_one_buffer_twice() -> None:
+    """Two producers must never be handed the same memory at the same time.
+
+    ``source._iterate`` starts a producer thread *per active iteration* against the one shared
+    ``ChunkPool``, and nothing stops there being two: ``zip(ds.train, ds.val)``, or two
+    ``DataLoader``s over one dataset, run two producers into the same :class:`BatchBuffers`.
+    Check-then-lend is not atomic, so both can observe one buffer as free, lend it, and write
+    their batches into the same memory -- silent cross-contamination of training data. The
+    pre-pool ``np.empty`` path was thread-safe by construction, so this has to hold.
+    """
+    pool = BatchBuffers(allocator=_slow_slice_allocator)
+    live: dict[int, int] = {}  # address -> id of the thread currently holding it
+    guard = threading.Lock()
+    failures: list[str] = []
+    start = threading.Barrier(4)
+
+    def worker(tid: int) -> None:
+        start.wait()
+        for _ in range(50):
+            view = pool.take(4, (16,), np.dtype("f4"))
+            addr = _ptr(view)
+            with guard:
+                if addr in live:
+                    failures.append(f"thread {tid} lent {addr:#x}, already held by {live[addr]}")
+                live[addr] = tid
+            view[:] = float(tid)  # what gather does: write this batch into its buffer
+            time.sleep(0.0002)  # ...while another producer assembles its own
+            if not np.all(view == float(tid)):
+                failures.append(f"thread {tid} found another producer's data in {addr:#x}")
+            with guard:
+                if live.get(addr) == tid:
+                    del live[addr]
+            del view
+
+    threads = [threading.Thread(target=worker, args=(t,)) for t in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not failures, failures[:5]
 
 
 def test_exported_torch_tensor_holds_the_buffer() -> None:

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -24,7 +24,7 @@ from typing import Any
 import numpy as np
 import pytest
 
-from insitubatch.buffers import XLA_ALIGN, BatchBuffers, HostAllocator, aligned_empty
+from insitubatch.buffers import NO_REUSE_ENV, XLA_ALIGN, BatchBuffers, HostAllocator, aligned_empty
 
 
 def _ptr(a: np.ndarray) -> int:
@@ -425,3 +425,40 @@ def test_exported_jax_array_holds_the_buffer() -> None:
     del view
     assert _ptr(pool.take(4, (3, 2), np.dtype("f4"))) != addr
     assert bool((arr == 5.0).all())
+
+
+def test_no_reuse_env_hands_out_a_fresh_buffer_every_time(monkeypatch) -> None:
+    # The escape hatch, and the A/B control that replaces a hand-reverted second checkout.
+    # Every take must be its own allocation: nothing pooled, nothing tracked, nothing reclaimed.
+    monkeypatch.setenv(NO_REUSE_ENV, "1")
+    pool = BatchBuffers()
+    first = pool.take(4, (2, 2), np.dtype("float32"))
+    first[:] = 1.0
+    del first  # under reuse this frees the buffer; here it must still not be handed out again
+    second = pool.take(4, (2, 2), np.dtype("float32"))
+    second[:] = 2.0
+    third = pool.take(4, (2, 2), np.dtype("float32"))
+
+    assert not np.shares_memory(second, third)
+    assert pool.n_buffers == 0 and pool.nbytes == 0  # nothing retained
+    assert pool.lends == 3 and pool.allocations == 3  # every lend is an allocation
+    assert "REUSE OFF" in pool.kind  # the epoch line must give the run away
+
+
+def test_reuse_is_on_unless_the_env_says_otherwise(monkeypatch) -> None:
+    for value in ("", "0", "false", "NO", "  "):
+        monkeypatch.setenv(NO_REUSE_ENV, value)
+        assert BatchBuffers().kind == "heap", f"{value!r} should leave reuse on"
+    for value in ("1", "true", "YES", "on"):
+        monkeypatch.setenv(NO_REUSE_ENV, value)
+        assert "REUSE OFF" in BatchBuffers().kind, f"{value!r} should switch reuse off"
+    monkeypatch.delenv(NO_REUSE_ENV)
+    assert BatchBuffers().kind == "heap"
+
+
+def test_no_reuse_keeps_the_alignment_guarantee(monkeypatch) -> None:
+    # It bypasses the pool, not the allocator: XLA:CPU's 128-byte DLPack requirement is a
+    # property of aligned_empty, so it must survive the escape hatch.
+    monkeypatch.setenv(NO_REUSE_ENV, "1")
+    buf = BatchBuffers().take(3, (5, 7), np.dtype("float32"))
+    assert buf.__array_interface__["data"][0] % XLA_ALIGN == 0

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -30,6 +30,7 @@ from insitubatch.buffers import (
     BatchBuffers,
     BufferStats,
     HostAllocator,
+    _Buffer,
     aligned_empty,
 )
 
@@ -493,6 +494,93 @@ def test_epoch_summary_line_matches_its_documented_shape() -> None:
     assert off.summary() == (
         f"0 x heap = 0.0 MiB, 100 lent, 100 allocated (reuse OFF via {NO_REUSE_ENV})"
     )
+
+
+def test_a_baseline_that_over_counts_raises_instead_of_lending_twice() -> None:
+    """Refcount below the idle baseline is not a near-miss -- it is the double-lend, early.
+
+    Every reference counted at calibration is structural and outlives the buffer, so the count
+    can only rise. A *lower* reading therefore means the baseline swallowed a transient, which
+    makes ``free`` permanently true: the pool lends one allocation to every batch at once and
+    each overwrites the last. That is what shipped and had to be found by its symptoms
+    (persistence RMSE), so the condition is now checked on every poll.
+
+    Reproduced the way the original bug arose: calibrate while an extra reference to the owner
+    is live -- exactly what ``torch.empty(pin_memory=True).numpy()`` did by leaving the
+    allocator's return value on the caller's stack -- then drop it.
+    """
+    buf = _Buffer(aligned_empty((4, 16), np.dtype("f4")))
+    extra = buf.owner  # the transient the baseline must not count
+    buf.calibrate()  # ...but does, here
+
+    lent = buf.base[:1]
+    assert not buf.free  # a lent view still reads as taken, so calibrate's own guard passes
+    del lent, extra
+
+    with pytest.raises(RuntimeError, match="liveness baseline is wrong"):
+        _ = buf.free
+
+
+def test_a_correctly_calibrated_buffer_never_reads_below_its_baseline() -> None:
+    """The other half: the guard must not fire in ordinary use, lent or idle."""
+    pool = BatchBuffers()
+    for _ in range(4):
+        lent = pool.take(4, (8, 8), np.dtype("f4"))
+        crop = lent[..., 0:2]  # a transform's derived view, then the batch itself dropped
+        del lent
+        pool.take(4, (8, 8), np.dtype("f4"))  # polls every buffer, including the held one
+        del crop
+    assert pool.n_buffers == 2
+
+
+def _labelled(label: str) -> HostAllocator:
+    """An allocator carrying an allocator-intent label, as ``pinned_allocator`` does."""
+
+    def allocate(shape: tuple[int, ...], dtype: np.dtype) -> np.ndarray:
+        return aligned_empty(shape, dtype)
+
+    allocate.label = label  # type: ignore[attr-defined]
+    return allocate
+
+
+def test_pinning_with_reuse_off_warns_and_still_works(monkeypatch, caplog) -> None:  # type: ignore[no-untyped-def]
+    """Loud, but not refused.
+
+    The pairing is bad: each batch takes its own ``cudaHostAlloc``, and the pin budget is a
+    monotone counter sized for a pool that converges, so it is spent within a few batches and
+    the rest of the run is pageable while ``kind`` still says ``pinned``. It stays *reachable*
+    because the double-lend lived on the pinned path and nowhere else -- refusing it would
+    leave a user who suspects reuse corruption unable to test that without also changing the
+    allocator, which is two variables and answers nothing.
+    """
+    monkeypatch.setenv(NO_REUSE_ENV, "1")  # read at construction, so before the pool exists
+    pool = BatchBuffers()
+
+    with caplog.at_level("WARNING", logger="insitubatch.buffers"):
+        pool.set_allocator(_labelled("pinned"))
+    assert NO_REUSE_ENV in caplog.text and "pageable" in caplog.text
+
+    batch = pool.take(4, (3, 2), np.dtype("f4"))  # the control still runs
+    assert batch.shape == (4, 3, 2) and pool.stats().kind == "pinned"
+
+
+@pytest.mark.parametrize(
+    ("no_reuse", "label"),
+    [(False, "pinned"), (True, "heap"), (False, "heap")],
+    ids=["pinned-with-reuse", "heap-without-reuse", "neither"],
+)
+def test_only_the_pinned_and_reuse_off_pairing_warns(
+    monkeypatch,  # type: ignore[no-untyped-def]
+    caplog,  # type: ignore[no-untyped-def]
+    no_reuse: bool,
+    label: str,
+) -> None:
+    """A warning on a supported configuration is a warning people learn to ignore."""
+    monkeypatch.setenv(NO_REUSE_ENV, "1" if no_reuse else "0")
+    pool = BatchBuffers()
+    with caplog.at_level("WARNING", logger="insitubatch.buffers"):
+        pool.set_allocator(_labelled(label))
+    assert caplog.text == ""
 
 
 def test_buffer_stats_is_one_consistent_snapshot() -> None:

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -24,7 +24,14 @@ from typing import Any
 import numpy as np
 import pytest
 
-from insitubatch.buffers import NO_REUSE_ENV, XLA_ALIGN, BatchBuffers, HostAllocator, aligned_empty
+from insitubatch.buffers import (
+    NO_REUSE_ENV,
+    XLA_ALIGN,
+    BatchBuffers,
+    BufferStats,
+    HostAllocator,
+    aligned_empty,
+)
 
 
 def _ptr(a: np.ndarray) -> int:
@@ -442,18 +449,20 @@ def test_no_reuse_env_hands_out_a_fresh_buffer_every_time(monkeypatch) -> None:
     assert not np.shares_memory(second, third)
     assert pool.n_buffers == 0 and pool.nbytes == 0  # nothing retained
     assert pool.lends == 3 and pool.allocations == 3  # every lend is an allocation
-    assert "REUSE OFF" in pool.kind  # the epoch line must give the run away
+    assert "reuse OFF" in pool.stats().summary()  # the epoch line gives the run away
 
 
 def test_reuse_is_on_unless_the_env_says_otherwise(monkeypatch) -> None:
-    for value in ("", "0", "false", "NO", "  "):
+    # "off" is load-bearing: the variable is named for what it enables, so `=off` means
+    # "no-reuse off" and must leave reuse ON. Omitting it inverts the user's intent silently.
+    for value in ("", "0", "false", "NO", "off", "OFF", "  "):
         monkeypatch.setenv(NO_REUSE_ENV, value)
-        assert BatchBuffers().kind == "heap", f"{value!r} should leave reuse on"
-    for value in ("1", "true", "YES", "on"):
+        assert BatchBuffers().stats().reuse, f"{value!r} should leave reuse on"
+    for value in ("1", "true", "YES", "on", "disabled"):
         monkeypatch.setenv(NO_REUSE_ENV, value)
-        assert "REUSE OFF" in BatchBuffers().kind, f"{value!r} should switch reuse off"
+        assert not BatchBuffers().stats().reuse, f"{value!r} should switch reuse off"
     monkeypatch.delenv(NO_REUSE_ENV)
-    assert BatchBuffers().kind == "heap"
+    assert BatchBuffers().stats().reuse
 
 
 def test_no_reuse_keeps_the_alignment_guarantee(monkeypatch) -> None:
@@ -462,3 +471,37 @@ def test_no_reuse_keeps_the_alignment_guarantee(monkeypatch) -> None:
     monkeypatch.setenv(NO_REUSE_ENV, "1")
     buf = BatchBuffers().take(3, (5, 7), np.dtype("float32"))
     assert buf.__array_interface__["data"][0] % XLA_ALIGN == 0
+
+
+def test_epoch_summary_line_matches_its_documented_shape() -> None:
+    """Pin the exact wording of the buffer fragment.
+
+    The line is the operator-facing contract -- tuning.md quotes it, and the guidance is to
+    watch `allocated` and the `x pinned` term. Its docstring and its format string drifted
+    apart once already (`alloc` / `kind=pinned` documented, `allocated` / `x pinned` emitted),
+    which nothing caught because every other test greps a substring. Formatting lives on
+    BufferStats so there is one place to change; this asserts what that place produces.
+    """
+    stats = BufferStats(
+        n_buffers=17, nbytes=544 * 2**20, kind="pinned", reuse=True, lends=100, allocations=0
+    )
+    assert stats.summary() == "17 x pinned = 544.0 MiB, 100 lent, 0 allocated"
+
+    # Reuse off reads as a trailing clause, not an interjection inside the arithmetic, and
+    # names the variable so a stray benchmark row can be traced back to its cause.
+    off = stats._replace(reuse=False, n_buffers=0, nbytes=0, kind="heap", allocations=100)
+    assert off.summary() == (
+        f"0 x heap = 0.0 MiB, 100 lent, 100 allocated (reuse OFF via {NO_REUSE_ENV})"
+    )
+
+
+def test_buffer_stats_is_one_consistent_snapshot() -> None:
+    # Reading n_buffers/nbytes/kind as separate properties takes the lock once each, so a
+    # producer allocating between them yields a line whose count and byte total disagree.
+    pool = BatchBuffers()
+    held = [pool.take(4, (8, 8), np.dtype("float32")) for _ in range(3)]
+    stats = pool.stats()
+    assert stats.n_buffers == 3
+    assert stats.nbytes == 3 * 4 * 8 * 8 * 4
+    assert (stats.lends, stats.allocations, stats.kind, stats.reuse) == (3, 3, "heap", True)
+    del held

--- a/tests/test_pinned.py
+++ b/tests/test_pinned.py
@@ -248,3 +248,24 @@ def test_finished_holds_are_retired_so_the_set_stays_bounded() -> None:
     for i in range(50):
         flight.hold({f"b{i}": np.empty(1, dtype="float32")}, Done())
     assert len(flight._pending) == 1  # the newest, deliberately retained until the next hold
+
+
+@pytest.mark.parametrize(
+    "name", ["float32", "float64", "float16", "int8", "int16", "int32", "int64", "uint8", "bool"]
+)
+def test_pinned_buffer_dtype_comes_from_torchs_own_mapping(name: str) -> None:
+    """The buffer's dtype must be the one the viewing tensor will have -- no CUDA needed.
+
+    The pool allocates through ``torch.empty(..., pin_memory=True).numpy()`` and ``to_torch``
+    views it with ``torch.from_dlpack``. If the numpy->torch mapping used at allocation ever
+    disagreed with torch's own, the buffer and the tensor would differ with nothing to catch
+    it. Asking torch both times makes that unrepresentable; this pins the round-trip.
+    """
+    from insitubatch.frameworks import _torch_dtype
+
+    dtype = np.dtype(name)
+    resolved = _torch_dtype(dtype)
+    # The whole round trip an allocation makes, minus the page-locking (which needs a device).
+    assert torch.empty((2, 3), dtype=resolved).numpy().dtype == dtype
+    # ...and it agrees with the converter to_torch will use on the way back out.
+    assert torch.from_dlpack(np.empty((2, 3), dtype=dtype)).dtype == resolved

--- a/tests/test_pinned.py
+++ b/tests/test_pinned.py
@@ -1,0 +1,153 @@
+"""Page-locked batch buffers and the owned H2D transfer that makes recycling them safe.
+
+Pinning is only worth anything because a page-locked source can DMA straight to the device
+instead of being staged through a driver bounce buffer -- which is also precisely what makes
+the copy genuinely asynchronous, and therefore what makes recycling the source dangerous. So
+the two halves are tested together: that buffers really are pinned, and that a batch whose
+copy is still in flight is still held.
+
+Most of this needs a CUDA device. What runs anywhere is the budget behaviour, which is where
+the interesting policy decision lives: exhausting the budget must *degrade to pageable*, never
+block (a consumer legitimately holding batches could deadlock the producer) and never raise
+(a performance feature must not become a crash).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from insitubatch.buffers import XLA_ALIGN, BatchBuffers, aligned_empty
+
+torch = pytest.importorskip("torch")
+needs_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+
+
+def _ptr(a: np.ndarray) -> int:
+    return int(a.__array_interface__["data"][0])
+
+
+@needs_cuda
+def test_pool_buffers_are_actually_pinned() -> None:
+    """The whole point: buffers must reach torch still page-locked.
+
+    The path is long -- ``torch.empty(pin_memory=True)`` -> ``.numpy()`` -> pool base ->
+    ``base[:k]`` view -> DLPack -> tensor -- and a failure anywhere in it is silent, degrading
+    ``non_blocking`` to a synchronous copy with no error and no signal.
+    """
+    from insitubatch.frameworks import pinned_allocator
+
+    pool = BatchBuffers(allocator=pinned_allocator())
+    view = pool.take(4, (3, 2), np.dtype("f4"))
+    assert torch.from_dlpack(view).is_pinned()
+
+
+@needs_cuda
+def test_a_ragged_prefix_is_still_pinned() -> None:
+    """The short final batch takes a prefix view, which must not lose page-locking."""
+    from insitubatch.frameworks import pinned_allocator
+
+    pool = BatchBuffers(allocator=pinned_allocator())
+    full = pool.take(8, (3,), np.dtype("f4"))
+    del full
+    assert torch.from_dlpack(pool.take(3, (3,), np.dtype("f4"))).is_pinned()
+
+
+@needs_cuda
+def test_in_flight_transfer_holds_the_source_buffer() -> None:
+    """A batch whose async copy is still draining must not be recycled underneath it.
+
+    Refcounts cannot see an in-flight DMA, so ``to_torch(device=...)`` holds the source until
+    its event fires. Dropping every *visible* reference must therefore still not free the
+    buffer for reuse.
+    """
+    from insitubatch.frameworks import pinned_allocator, to_torch
+    from insitubatch.types import Batch
+
+    pool = BatchBuffers(allocator=pinned_allocator())
+    view = pool.take(64, (256, 256), np.dtype("f4"))  # big enough to still be in flight
+    view[:] = 1.0
+    addr = _ptr(view)
+
+    to_torch(Batch(arrays={"x": view}), device="cuda")
+    del view  # the caller's references are gone; the transfer's hold is not
+
+    assert _ptr(pool.take(64, (256, 256), np.dtype("f4"))) != addr
+
+
+@needs_cuda
+def test_transferred_batch_has_the_right_values() -> None:
+    """Owning the copy must not change what lands on the device."""
+    from insitubatch.frameworks import pinned_allocator, to_torch
+    from insitubatch.types import Batch
+
+    pool = BatchBuffers(allocator=pinned_allocator())
+    view = pool.take(4, (3,), np.dtype("f4"))
+    view[:] = np.arange(12, dtype="f4").reshape(4, 3)
+
+    out = to_torch(Batch(arrays={"x": view}), device="cuda")
+    torch.cuda.synchronize()
+    assert out["x"].device.type == "cuda"
+    assert np.array_equal(out["x"].cpu().numpy(), view)
+
+
+@needs_cuda
+def test_budget_exhaustion_degrades_to_pageable(caplog: pytest.LogCaptureFixture) -> None:
+    """Past the budget: keep serving, unpinned, and say so once."""
+    from insitubatch.frameworks import pinned_allocator
+
+    inner, dtype = (1024,), np.dtype("f4")
+    one = 4 * int(np.prod(inner)) * dtype.itemsize  # exactly one buffer's worth
+    pool = BatchBuffers(allocator=pinned_allocator(budget_bytes=one))
+
+    first = pool.take(4, inner, dtype)
+    second = pool.take(4, inner, dtype)  # over budget -> pageable, not an error
+    assert torch.from_dlpack(first).is_pinned()
+    assert not torch.from_dlpack(second).is_pinned()
+    assert "budget exhausted" in caplog.text
+
+
+def test_budget_of_zero_never_pins_and_still_serves(caplog: pytest.LogCaptureFixture) -> None:
+    """The degrade path itself, testable without a GPU: allocation must still succeed."""
+    from insitubatch.frameworks import pinned_allocator
+
+    pool = BatchBuffers(allocator=pinned_allocator(budget_bytes=0))
+    view = pool.take(4, (3, 2), np.dtype("f4"))
+    view[:] = 3.0  # writable, correctly shaped, simply not pinned
+    assert view.shape == (4, 3, 2) and np.all(view == 3.0)
+    assert _ptr(view) % XLA_ALIGN == 0  # the fallback keeps XLA alignment
+    assert "budget exhausted" in caplog.text
+
+
+def test_warning_is_emitted_once_not_per_batch(caplog: pytest.LogCaptureFixture) -> None:
+    """A per-batch warning would bury a training log."""
+    from insitubatch.frameworks import pinned_allocator
+
+    pool = BatchBuffers(allocator=pinned_allocator(budget_bytes=0))
+    for _ in range(5):
+        del pool._pools  # force a fresh miss each time
+        pool._pools = {}
+        pool.take(4, (3, 2), np.dtype("f4"))
+    assert caplog.text.count("budget exhausted") == 1
+
+
+def test_set_allocator_drops_old_buffers_and_uses_the_new_one() -> None:
+    """Swapping allocators must not leave the pool half pinned and half not.
+
+    Asserted by what the pool owns and which allocator it calls -- not by comparing
+    addresses, since a freed block is very often handed straight back by ``malloc``.
+    """
+    calls: list[tuple[int, ...]] = []
+
+    def spy(shape: tuple[int, ...], dtype: np.dtype) -> np.ndarray:
+        calls.append(shape)
+        return aligned_empty(shape, dtype)
+
+    pool = BatchBuffers()
+    pool.take(4, (3, 2), np.dtype("f4"))
+    assert pool.nbytes > 0
+
+    pool.set_allocator(spy)
+    assert pool.nbytes == 0  # the un-swapped buffers are gone, not mixed in
+    pool.take(4, (3, 2), np.dtype("f4"))
+    assert calls == [(4, 3, 2)]

--- a/tests/test_pinned.py
+++ b/tests/test_pinned.py
@@ -131,6 +131,24 @@ def test_warning_is_emitted_once_not_per_batch(caplog: pytest.LogCaptureFixture)
     assert caplog.text.count("budget exhausted") == 1
 
 
+def test_to_torch_with_a_cpu_device_needs_no_cuda() -> None:
+    """``device="cpu"`` must work on a machine with no driver.
+
+    The guard only exists for an async DMA, and ``torch.cuda.Event()`` raises outright where
+    there is no NVIDIA driver -- so a CPU target has to skip it rather than construct one.
+    Examples default to ``--device cpu``, which is how this surfaced.
+    """
+    from insitubatch.frameworks import to_torch
+    from insitubatch.types import Batch
+
+    pool = BatchBuffers()
+    view = pool.take(4, (3,), np.dtype("f4"))
+    view[:] = 2.0
+    out = to_torch(Batch(arrays={"x": view}), device="cpu")
+    assert out["x"].device.type == "cpu"
+    assert np.array_equal(out["x"].numpy(), view)
+
+
 def test_set_allocator_drops_old_buffers_and_uses_the_new_one() -> None:
     """Swapping allocators must not leave the pool half pinned and half not.
 

--- a/tests/test_pinned.py
+++ b/tests/test_pinned.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 
 from insitubatch.buffers import XLA_ALIGN, BatchBuffers, aligned_empty
+from insitubatch.frameworks import _InFlight
 
 torch = pytest.importorskip("torch")
 needs_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
@@ -192,3 +193,58 @@ def test_set_allocator_drops_old_buffers_and_uses_the_new_one() -> None:
     assert pool.nbytes == 0  # the un-swapped buffers are gone, not mixed in
     pool.take(4, (3, 2), np.dtype("f4"))
     assert calls == [(4, 3, 2)]
+
+
+def test_concurrent_holds_never_drop_a_live_one() -> None:
+    """Two threads converting batches at once must not lose each other's holds.
+
+    ``_InFlight`` is process-wide -- two DataLoaders, or ``zip(ds.train, ds.val)``, run this
+    concurrently -- and prune-then-append is a read-modify-write. Dropping a hold releases a
+    buffer whose DMA is still reading it, so the pool can recycle it mid-copy: silent
+    corruption, exactly the class the pool's own lock exists to prevent.
+
+    This is a guard, not a reproducer, and the distinction is worth stating. The unguarded
+    window is only the few bytecodes between the comprehension and the slice assignment, and
+    it does not reproduce unaided at any thread count -- the comprehension iterates the live
+    list by index, so a concurrent append lands where it is still picked up. Widening that
+    exact gap with a sleep loses a live hold 20/20. So this test asserts the invariant under
+    real contention; the lock is what makes it hold by construction rather than by luck.
+    """
+    import threading
+
+    class NeverDone:
+        """An event whose copy is still in flight -- its hold must never be retired."""
+
+        def query(self) -> bool:
+            return False
+
+    flight = _InFlight()
+    n = 8
+    start = threading.Barrier(n)
+
+    def hold(name: str) -> None:
+        start.wait()
+        flight.hold({name: np.empty(1, dtype="float32")}, NeverDone())
+
+    threads = [threading.Thread(target=hold, args=(f"b{i}",)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    held = {name for arrays, _ in flight._pending for name in arrays}
+    expected = {f"b{i}" for i in range(n)}
+    assert held == expected, f"lost holds: {sorted(expected - held)}"
+
+
+def test_finished_holds_are_retired_so_the_set_stays_bounded() -> None:
+    # The other half of the invariant: completed copies must not accumulate, or a long run
+    # would pin every batch it ever transferred. One deferred entry is the intended tail.
+    class Done:
+        def query(self) -> bool:
+            return True
+
+    flight = _InFlight()
+    for i in range(50):
+        flight.hold({f"b{i}": np.empty(1, dtype="float32")}, Done())
+    assert len(flight._pending) == 1  # the newest, deliberately retained until the next hold

--- a/tests/test_pinned.py
+++ b/tests/test_pinned.py
@@ -54,6 +54,29 @@ def test_a_ragged_prefix_is_still_pinned() -> None:
 
 
 @needs_cuda
+def test_two_live_pinned_batches_never_share_a_buffer() -> None:
+    """Reuse must stay liveness-aware when the buffers are page-locked.
+
+    ``torch.empty(pin_memory=True).numpy()`` hands back an array that *is* its own data owner,
+    unlike the aligned-heap default which views one. That difference decides which references
+    are live when the pool records a buffer's idle refcount, and getting it wrong makes every
+    pinned buffer look permanently free -- so the pool lends one allocation to every batch and
+    each overwrites the last, silently, on the pinned path only. The CPU-side analogue is
+    ``tests/test_buffers.py::test_liveness_holds_however_the_allocator_owns_its_memory``.
+    """
+    from insitubatch.frameworks import pinned_allocator
+
+    pool = BatchBuffers(allocator=pinned_allocator())
+    first = pool.take(4, (16,), np.dtype("f4"))
+    first[:] = 1.0
+    second = pool.take(4, (16,), np.dtype("f4"))
+    second[:] = 2.0
+
+    assert _ptr(first) != _ptr(second), "the pinned pool lent one buffer to two live batches"
+    assert np.all(first == 1.0), "a live pinned batch was overwritten by the next one"
+
+
+@needs_cuda
 def test_in_flight_transfer_holds_the_source_buffer() -> None:
     """A batch whose async copy is still draining must not be recycled underneath it.
 


### PR DESCRIPTION
Reuse the batch output buffers instead of allocating one per batch, and add an opt-in
page-locked H2D path on top of that pool.

## What it's worth — a range, not a headline

Both changes remove **loader-side** cost, so their end-to-end value is bounded above by an
isolated probe with that cost fully exposed, and below by **zero** — a loop whose compute step
already hides the loader collects nothing. That's prefetch working, not a disappointment. The
useful output is the bounds plus a rule for locating yourself between them.

| | upper bound (loader cost exposed) | this GPU training loop | lower bound |
|---|---|---|---|
| **reuse** | +10 … +16% above 32 MiB | **≈ 0** (±0.3 pt) | 0 |
| **pinning** | copy hidden entirely below ~37 MiB | **+1 … +2%** | 0 |

The asymmetry is structural, not luck. **Reuse saves producer-thread time — exactly what
prefetch is built to hide. Pinning shortens a copy on the consumer's critical path, which
prefetch cannot touch.** So a saturated training GPU is reuse's *floor*, not an interior point,
and the top of these ranges is collected by workloads spending less compute per byte:
inference over training, shallow models, cold caches, IO-bound epochs.

Reuse's floor value isn't a speedup at all — it's the guarantee that growing a batch past
glibc's 32 MiB `mmap` threshold cannot walk you off a cliff.

### Reuse, measured across the threshold

Batch size swept over one 256² store, no-reuse arm from a checkout identical but for the
`gather` call site, each arm scored against **its own** in-session ceiling:

| MiB per variable buffer | 8 | 16 | 32 | 64 |
|---|--:|--:|--:|--:|
| reuse (% of ceiling) | 99.69 | 99.92 | 99.74 | 98.74 |
| no reuse | 99.49 | 99.72 | 99.92 | 99.03 |
| delta (points) | +0.21 | +0.20 | −0.18 | −0.29 |

Inside ±0.3 with the sign flipping twice, across an 8× range spanning the threshold. At 64 MiB
the two arms agree to **0.04%** absolute (138.52 vs 138.57 samples/s). The loop runs at
98.7–100% of compute ceiling, so allocation has nowhere to surface *even where the `mmap` path
demonstrably engages* (0 faults/alloc at 8 and 16 MiB, 100% of pages at 32 and 64).

### Pinning, bracketed against drift

**+1 to +2%.** Don't quote a third digit: an A/B/A on an unchanged checkout read
145.4 / 146.6 / 143.4 samples/s, so two *identical* unpinned blocks differed 1.4% twenty
minutes apart — drift is ~0.7% per block, half the signal. Linear fit gives +1.5%; the bounds
are +0.8% (`b−a`) to +2.2% (`b−c`); cross-session ceilings said +2.0–2.3%.

**Method, since it cost us a night:** run the control arm *twice*, bracketing the treatment,
and interpolate. And `% of ceiling` isolates reuse but **cancels** pinning — `--pin` reaches
the ceiling too, because `pin_host_buffers` precedes `preload_epoch` (= `list(ds.train)`), so
the ceiling moves in lockstep.

## Three defects found and fixed

1. **Uncalibrated liveness baseline** — the idle refcount was recorded while the allocation's
   own reference was still live, so every buffer looked permanently free and the pool lent
   **one allocation to every batch at once**, each overwriting the last. Pinned path only,
   because `torch.empty(pin_memory=True).numpy()` returns an array that *is* its own data
   owner while the aligned-heap default returns one that *views* an owner. Confirmed on an L4:
   `double-lent: True | first batch: 2.0` before, `False | 1.0` after. Its fingerprint —
   a refcount reading *below* the calibrated idle baseline — now raises, so this class cannot
   come back silently (see the review round).
2. **Non-atomic check-then-lend** — two producers (`zip(ds.train, ds.val)`, two DataLoaders)
   could both observe one buffer free and write into it. Now one locked step.
3. **`_InFlight.hold` unlocked read-modify-write** — prune-then-append on process-wide state;
   a thread could overwrite a hold another appended and free a buffer mid-DMA. Window is a few
   bytecodes and does **not** reproduce unaided (the comprehension iterates by index, so it
   picks up concurrent appends); widened at exactly that point it loses a live hold 20/20.

## The thing that actually caught bug 1

Neither throughput nor forecast skill did. **Persistence RMSE is model-independent** —
`rmse(t2m(t), t2m(t+24h))`, no training, no batch size — so it's a fingerprint of the bytes the
loader delivered, bit-identical at `0.588030696` across every batch size, arm, and repeat.

- Throughput missed it: the same bytes still moved.
- Skill missed it: the corrupt arm scored **+13.6%**, *above* real ERA5's honest +11.4%.
- The old summary line hid it: it printed `persistence/model` as "Nx better", so a model **84%
  worse** than predicting no change rendered as `(0.5x better)`.

Now: signed skill score with the verdict on **sign alone** (no threshold is sound — healthy
skill is +33/+22/+10% on synthetic grids and +11% on real ERA5, and a corrupt run beat ERA5),
persistence printed as a labeled invariant, and `PersistenceCheck` in `advection_sweep`
asserting it per store across repeats, configs and arms — loud inline, non-zero at exit.

## Also in here

- **`INSITUBATCH_NO_BUFFER_REUSE=1`** — escape hatch and A/B control. Reuse is safe against
  everything the transform API can do (a transform returning a derived array frees its buffer
  early, one returning a view stays tracked, one that retains makes the pool allocate
  elsewhere — all read correct data), so this is not a tuning knob; it covers memory escaping
  Python object semantics, and being wrong. It also retires the worktree the no-reuse arm
  needed. Epoch log stamps `REUSE OFF`.
- **Per-epoch INFO line** — chunk-cache hits, resident peak, and pool state. `allocated`
  staying nonzero after epoch 0 is the signal that batches aren't coming back.
- **`--log-level` on the examples**, raising only the `insitubatch` logger.
- **`_torch_dtype`** — numpy→torch mapping from torch's own converter rather than
  `getattr(torch, str(dtype))`. Not a bug fix; removes a second mechanism answering a question
  `to_torch` already answered, so buffer and tensor dtype cannot diverge.
- **Docs**: `DESIGN.md` described weakref liveness, which cannot work (numpy collapses base
  chains, so a crop doesn't reference the view it came from) and was never built; its reuse
  null was measured at 2 MiB, below the cliff; its pinning table came from voided runs.
  `tuning.md` now documents the batch queue as a high-water mark.

## Considered and rejected

- **A `reuse=False` parameter.** Its documentation would have to teach numpy base-chain
  collapsing and `sys.getrefcount`. The env var is a kill switch with a one-sentence doc, not
  a knob asking users to audit our invariant.
- **A public `trim()`.** The pool's floor can never exceed a peak the process already survived
  — it *is* what was simultaneously live at that peak, which fresh allocation also held. API
  surface for a problem with no demonstrated workload.
- **Refusing pinning + `INSITUBATCH_NO_BUFFER_REUSE`** (review). It warns instead — see below.

## Review round

Three comments, three changes.

- **`refs < idle_refs` is now an error.** Every reference counted at calibration is structural
  (`self.owner`, the base chain `self.base` holds), so all of them outlive the buffer and the
  count can only rise. A lower reading is not a near-miss — it means the baseline swallowed a
  transient, which makes `free` permanently true and lends one allocation to every batch at
  once. That is bug 1's exact fingerprint, and nothing raised on it; it had to be found by
  persistence RMSE. One integer compare against a path copying megabytes, so checking forever
  is free. Test reproduces it the way the original arose (calibrate with an extra owner
  reference live — what `torch.empty(pin_memory=True).numpy()` did by leaving the return value
  on the caller's stack) plus the converse, that ordinary lend/derive/reclaim never trips it.
- **Pinning with reuse off warns, and stays reachable.** It deserves to be loud for a reason
  the docstring didn't have: `pinned_allocator`'s budget is a monotone counter sized for a pool
  that converges, so without reuse it's spent within a few batches and the rest of the run
  finishes pageable while `kind` still reports pinned intent — misleading as a timing row, not
  merely slow. `benchmarks.md` now says so. But erroring would remove the one control that
  isolates reuse from pinning, and the double-lend lived on the pinned path and nowhere else:
  a user suspecting corruption would have to change the allocator too, which is two variables
  and answers nothing. The check sits in `set_allocator` (the single injection point), so it
  covers `as_torch` and a user-supplied labelled allocator alike; a parametrized test asserts
  the other three combinations stay silent.
- **`probe_batch_buffers` is pinned to the core API — it had already drifted.** The probe
  predates the implementation and carried its own `aligned_empty` and `XLA_ALIGN` plus
  `getattr(torch, str(dtype))` in three places, the very mechanism `_torch_dtype` was added to
  remove. A change in `src/` would have left it reporting the old design's numbers, visible
  only on a GPU box. Now imports all three; both swaps are behaviour-identical, so no published
  number moves. Tests assert *identity*, not equality — an equal-looking reimplementation is
  the drift being prevented — and run what CI can reach: `main()` end to end on the host arm
  over a toy case, unknown-arm rejection, every `CASES` dtype through the pool's allocator and
  torch's converter, and the jax arm asserting its two device checks report **unknown** without
  a GPU rather than *safe*. `Roundtrip.verdict` and `JaxCheck.poll_insufficient` get
  table-driven tests: pure logic, no hardware needed, previously uncovered.

## Open, not blocking

Whether `sys.getrefcount` is safe under free-threading. The 3.13t CI job runs the full suite
GIL-off, but only one staleness direction is dangerous (reading *low* → reuse a live buffer)
and that direction is unproven. The new baseline guard changes what a stale-low read *does* —
it raises where it previously corrupted silently, which is the direction we want, but it means
3.13t can now go red where it was quietly wrong.

## Verification

266 passed, 12 skipped; `ruff` and `mypy` clean on `src bench examples`.

