### PR TITLE
fix: make the chunk pool's "safe to take away" predicate true, not approximately true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+- **The chunk pool's "safe to take away" predicate is now true, not approximately true.**
+  Eviction eligibility was spread across five loosely-coupled fields, and each one could
+  lie. `fail()` had to set `ready = True` to wake a waiter — the only lever available —
+  which simultaneously declared a half-written slot a finished cache entry while sibling
+  tile tasks were still writing into it, and left the poisoned slot resident so the *next*
+  epoch re-raised the stale error forever instead of refetching (#33). `unpin_all()`
+  cleared the pin map globally, so with two producers over one pool (`zip(ds.train,
+  ds.val)`, a documented configuration) one iteration's epoch boundary stripped the
+  other's pins and its in-use chunks became eviction candidates mid-gather (#34). And
+  `claimed` was a single bool, so one iteration's claim satisfied another's `wait_ready`
+  — that iteration then gathered a chunk it never referenced and its release decremented
+  someone else's count (#35). All three produced *plausible* data, which throughput,
+  shapes and smoke tests all pass; only byte fingerprints catch them.
+  A slot now carries one explicit `SlotState` (`FILLING → ASSEMBLED → READY`, `FAILED`
+  terminal) advanced in exactly one place, plus two counters that answer one question
+  each: `writers` (tile tasks *running*, so eviction is never racing a live write) and
+  `pending` (tiles not yet delivered, so completeness is separate from quiescence).
+  References are owner-scoped, and a reference *is* that owner's claim, so `claimed` is
+  gone. `Scheduler` takes the pool's obligation off the caller: every tile write happens
+  inside `pool.tile_write`, whose scope releases on **every** exit path — including
+  cancellation at an `await`, which no explicit call site can cover.
+  `ASSEMBLED` is a real state, not a formality: the chunk transform and the persist
+  write-back run outside the lock between the last tile landing and the slot being
+  published, and a predicate derived only from a tile counter would call that window
+  evictable.
+
 - **Added: `insitubatch.print_debug_info()` — one paste instead of a dozen version questions.**
   Reports the storage stack (zarr / obstore / numpy / xarray), whichever framework adapter is
   actually installed, and the **free-threading state** — both the build flag and whether an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **Under-sizing the budget for concurrent iterations now says so.** One `InSituDataset`
+  owns one chunk pool and every active iteration shares it — `zip(ds.train, ds.val)`, or
+  two `DataLoader`s — but each holds its *own* chunk references, so residency is the sum
+  of their working sets, not the maximum. The auto-sized default covers one iteration and
+  deliberately stays that way: the engine cannot know how many you intend to run, and
+  guessing high would cost memory in the single-iteration case that is almost every case.
+  What was missing was the diagnostic. Starvation previously advised "raise
+  cache_budget_bytes, or lower batch_size / block_chunks" — correct but not actionable
+  when *every* resident chunk is legitimately referenced and the caller has no way to see
+  why. It now names how many iterations are sharing the pool, and the pattern that
+  produces that. Owners count from mint to release rather than from their first pin,
+  because the iteration that starves before it can pin anything is exactly the one that
+  needs naming. `docs/tuning.md` gains the sizing rule.
+
 - **The chunk pool's "safe to take away" predicate is now true, not approximately true.**
   Eviction eligibility was spread across five loosely-coupled fields, and each one could
   lie. `fail()` had to set `ready = True` to wake a waiter — the only lever available —

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -171,10 +171,13 @@ As built (PR #4), the engine stayed simpler than the original sketch:
   give disjoint train/val labels for any offset (injective translation), and the shared
   boundary timestep is only ever a val *input*, never scored. Task meaningfulness
   (non-degenerate offset choices) is the **user's** responsibility, not the engine's.
-- Residency is **reference-counted** (`pool._pinned: dict[key,int]`, not a boolean set)
-  because a windowed chunk can feed several blocks; a per-epoch `claimed` flag orders
-  pin→consume→release across the epoch boundary (fixes a cross-epoch gather/leak race).
-  Decode-once across views holds (slots key on `path`).
+- Residency is **reference-counted and owner-scoped** (`pool._pinned: dict[key, dict[owner,
+  int]]`, not a boolean set) because a windowed chunk can feed several blocks *and* because
+  one pool serves several concurrent iterations. A reference **is** that owner's claim, which
+  orders pin→consume→release across the epoch boundary (fixes a cross-epoch gather/leak race)
+  and, being per owner, cannot be satisfied by another iteration's claim. One iteration = one
+  owner, minted by `_iterate` and shared with its scheduler. Decode-once across views holds
+  (slots key on `path`).
 - **Splits are iterable views, not a constructor arg.** `InSituDataset` is split-agnostic;
   you iterate `ds.train` / `ds.val` / `ds.test` / `ds.all`, all sharing **one** `ChunkPool`.
   This matters *because* of windows: a windowed read near a split boundary spills into the
@@ -665,7 +668,7 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
 - **Refcount overhead on the non-windowed path (~3.5%, accepted).** Refcounted residency +
   offset-aware `gather` cost ~3.5% at the **GRIB-end local worst case** (one sample/chunk,
   ~36 KB blobs where decode is ≈ free, GIL build) — not residency (`resident` unchanged) and
-  not per-block setup; it is per-batch gather + per-chunk `dict`/`claimed` bookkeeping under
+  not per-block setup; it is per-batch gather + per-chunk reference bookkeeping under
   `pool._cv`. It shrinks toward noise at real chunk sizes and is invisible on blob stores.
   The microscope for this and any future *locking* work is a tiny local store with negligible
   decode under free-threading (`PYTHON_GIL=0`, where `pool._cv` is the only contention

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -95,6 +95,37 @@ If you set `cache_budget_bytes` above the working set, residency rises to that b
 purpose — that extra memory *is* the cross-epoch cache. Point `cache_dir` at local NVMe to
 spill it to disk instead of RAM.
 
+### Several iterations at once multiply the budget
+
+The three bounds above describe **one** iteration. One `InSituDataset` owns one chunk pool,
+and every active iteration shares it — `zip(ds.train, ds.val)`, or two `DataLoader`s over the
+same dataset. That is supported, and chunks a windowed read pulls across a split boundary are
+decoded once and reused by both. But each iteration holds its **own** references to the chunks
+it is working on, so residency is the sum, not the maximum:
+
+```
+cache_budget_bytes  >=  n_concurrent_iterations x (block_chunks x outer_chunk_bytes)
+```
+
+**The auto-sized default is deliberately computed for one iteration, and stays that way.**
+The engine cannot know how many iterations you intend to run, so any automatic multiplier
+would be a guess that silently costs memory for the single-iteration case — which is almost
+every case. Running several is the explicit choice, so sizing for it is yours too.
+
+Run two without raising the budget and the loader stops with `residency budget exhausted: ...`,
+naming how many iterations are sharing the pool. It cannot free a slot, because every resident
+chunk is legitimately referenced by one of them. Raise `cache_budget_bytes` (or lower
+`block_chunks`, which shrinks each iteration's share) — not `max_inflight`, which is a
+concurrency dial and is not what is binding here.
+
+!!! note "This got stricter once pin accounting became owner-scoped"
+
+    Before that fix, starting a second iteration silently released the first one's
+    references. That freed budget by accident and hid the requirement — and the cost was
+    that the first iteration's in-use chunks could be evicted mid-gather, delivering
+    plausible wrong data. A budget that appeared to work for `zip(ds.train, ds.val)` was
+    relying on that bug. Sizing for the sum is the honest requirement.
+
 ### The batch queue is a high-water mark
 
 Batch buffers are pooled and held for the dataset's lifetime, so that third bound is the

--- a/src/insitubatch/buffers.py
+++ b/src/insitubatch/buffers.py
@@ -246,6 +246,10 @@ class BatchBuffers:
     held only across that decision -- never across a gather -- so it costs one uncontended
     acquire per variable per batch, against a gather that copies megabytes.
 
+    Running two iterations also costs *residency*: each holds its own chunk references, so the
+    pool's budget must cover both working sets. The auto-sized default covers one -- see
+    docs/tuning.md, "Several iterations at once multiply the budget".
+
     Writing a lent buffer stays lock-free and always was: a buffer is lent to exactly one
     producer, which is the only thread that touches it.
     """

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -65,8 +65,9 @@ import os
 import re
 import threading
 from collections import OrderedDict
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, replace
+from enum import Enum
 from pathlib import Path
 from typing import TextIO
 
@@ -163,24 +164,102 @@ def _has_weak_token(transforms: Sequence[ChunkTransform]) -> bool:
     return cloudpickle is None and any(getattr(t, "cache_key", None) is None for t in transforms)
 
 
+class SlotState(Enum):
+    """Where a slot is in its one and only lifecycle.
+
+    ``FILLING -> ASSEMBLED -> READY``, with ``FAILED`` terminal. Exactly one function
+    advances it (:meth:`ChunkPool._advance`), so "is this gatherable" and "is this safe
+    to take away" are read off one field instead of inferred from agreeing flags.
+
+    ``ASSEMBLED`` is a *real* state, not a formality: the chunk transform and the
+    persist write-back run **outside** the lock between the last tile landing and the
+    slot being published, so another thread can observe the slot with every tile
+    delivered and the data not yet final. A predicate derived only from a tile counter
+    would call that window evictable; this one does not.
+    """
+
+    FILLING = "filling"
+    ASSEMBLED = "assembled"
+    READY = "ready"
+    FAILED = "failed"
+
+
 @dataclass(slots=True)
 class _Slot:
-    """One outer chunk's cache slot plus its completion bookkeeping.
+    """One outer chunk's cache slot plus its lifecycle bookkeeping.
 
     ``data`` is the cache slot, sized at the transform's *output* geometry. ``scratch`` is
     a transient *source*-shaped assembly buffer, present only when a reshaping transform
     means the slot cannot also be the assembly target; tiles scatter into it and the
     transformed result lands in ``data`` (then ``scratch`` is dropped). With no reshaping
     transform ``scratch`` is ``None`` and tiles scatter straight into ``data`` -- the slot
-    is buffer and cache in one, no extra copy (the common path)."""
+    is buffer and cache in one, no extra copy (the common path).
+
+    Two counters, because quiescence and completeness are different questions and
+    answering both with one number is what made ``fail()`` have to lie:
+
+    * ``writers`` -- tile tasks **currently running**. Incremented when a task enters
+      :meth:`ChunkPool.tile_write` and decremented exactly once on every exit path,
+      cancellation included. It counts *started* tasks, not planned ones: a pass that is
+      cancelled leaves some tiles never started, and counting those would keep the slot
+      permanently non-quiescent and its budget unreclaimable. ``writers == 0`` means
+      **no thread can still write here**, which is the only safe basis for eviction.
+    * ``pending`` -- tiles not yet *delivered*. Reaches 0 only when the chunk is
+      genuinely complete. A slot that quiesces with ``pending > 0`` is an abandoned
+      partial (its fetch was cancelled), never a cache entry.
+    """
 
     data: np.ndarray
-    remaining: int  # inner tiles not yet scattered; 0 => fully assembled
+    writers: int  # outstanding tile TASKS -> quiescence
+    pending: int  # tiles not yet delivered -> completeness
     nbytes: int  # slot size, charged to the budget (fixed at admit)
-    ready: bool = False
+    state: SlotState = SlotState.FILLING
     error: BaseException | None = None
-    claimed: bool = False  # the driver has referenced it *this epoch* (see wait_ready)
     scratch: np.ndarray | None = None  # source-shaped assembly buffer (reshaping path only)
+
+    @property
+    def quiescent(self) -> bool:
+        """No tile task can still write into this slot."""
+        return self.writers == 0
+
+
+@dataclass(slots=True)
+class _TileWrite:
+    """One tile task's write scope. See :meth:`ChunkPool.tile_write`.
+
+    Holds the release obligation so no caller has to remember it. ``released`` makes
+    the release idempotent: ``deliver`` releases as soon as the copy lands (so the slot
+    can publish without waiting for the coroutine to unwind), and the scope's
+    ``finally`` then finds nothing to do.
+    """
+
+    pool: ChunkPool
+    array: str
+    chunk_index: int
+    inner_coord: tuple[int, ...]
+    released: bool = False
+
+    def deliver(self, tile: np.ndarray) -> None:
+        """Land this tile in the slot, then release the write."""
+        self.pool._deliver(self.array, self.chunk_index, self.inner_coord, tile)
+        self.release()
+
+    def fail(self, error: BaseException) -> None:
+        """Poison the whole outer chunk, then release the write."""
+        self.pool.fail(self.array, self.chunk_index, error)
+        self.release()
+
+    def release(self) -> None:
+        """Drop this task's claim on the slot. Idempotent; never raises."""
+        if self.released:
+            return
+        self.released = True
+        slot = self.pool._slots.get((self.array, self.chunk_index))
+        if slot is None:  # already dropped (poisoned + unreferenced) -- nothing to release
+            return
+        with self.pool._cv:
+            slot.writers -= 1
+        self.pool._advance(self.array, self.chunk_index)
 
 
 class ChunkPool:
@@ -308,7 +387,12 @@ class ChunkPool:
         # refcounted slot is held by a live block (windows let one chunk be read by
         # several blocks at once, so pins are reference-counted, not a boolean).
         self._slots: OrderedDict[tuple[str, int], _Slot] = OrderedDict()
-        self._pinned: dict[tuple[str, int], int] = {}  # key -> refcount (>0 == pinned)
+        # key -> {owner: refcount}. Owner-scoped because one pool serves several
+        # concurrent iterations (`zip(ds.train, ds.val)`, buffers.py:238-247): a single
+        # flat map lets one iteration's epoch prologue release another's live pins, and a
+        # single `claimed` bool lets one iteration's claim satisfy another's wait_ready.
+        self._pinned: dict[tuple[str, int], dict[int, int]] = {}
+        self._owner_seq = 0  # monotonic; owners are opaque tokens minted by new_owner()
         self._cv = threading.Condition(threading.Lock())
         self._error: BaseException | None = None  # global poison (driver death)
         self.max_resident = 0  # peak distinct outer chunk positions held at once
@@ -316,6 +400,36 @@ class ChunkPool:
         # unpin, which is what lets the scheduler prove an admission starvation is
         # terminal rather than merely slow (see Scheduler._admit).
         self._waiting: dict[tuple[str, int], int] = {}  # key -> blocked waiter count
+
+    # -- ownership ----------------------------------------------------------
+
+    def new_owner(self) -> int:
+        """Mint an opaque token identifying one iteration's references.
+
+        One iteration = one owner: its scheduler's admission pins and its producer's
+        block pins are the same owner, so ``unpin_all(owner)`` at the next epoch's
+        prologue releases exactly that iteration's state and leaves a concurrent
+        iteration's untouched. Deliberately not user-visible -- ``_iterate`` mints one
+        and threads it through; nothing in the public API names an owner.
+        """
+        with self._cv:
+            self._owner_seq += 1
+            return self._owner_seq
+
+    def _refs(self, key: tuple[str, int]) -> int:  # call under the lock
+        """Total outstanding references to ``key`` across every owner."""
+        return sum(self._pinned.get(key, {}).values())
+
+    def _evictable(self, key: tuple[str, int], slot: _Slot) -> bool:  # call under the lock
+        """May the pool take this buffer away?
+
+        The one predicate. Three independent conditions, each with a distinct reason:
+        nobody may still be *writing* (``quiescent``), nobody is still *reading*
+        (no references), and the contents are a finished cache entry (``READY``).
+        A ``FAILED`` slot is never evicted here because it is dropped as soon as it
+        quiesces (see :meth:`_advance`); an ``ASSEMBLED`` one is mid-transform.
+        """
+        return slot.quiescent and self._refs(key) == 0 and slot.state is SlotState.READY
 
     # -- observability ------------------------------------------------------
 
@@ -352,7 +466,7 @@ class ChunkPool:
 
     # -- admission / pinning / eviction -------------------------------------
 
-    def try_admit(self, array: str, chunk_index: int) -> bool:
+    def try_admit(self, array: str, chunk_index: int, owner: int) -> bool:
         """Reserve + allocate + reference one outer-chunk slot, evicting ready-LRU for room.
 
         Admission takes one reference (incref) and *claims* the slot for this epoch (so
@@ -373,8 +487,10 @@ class ChunkPool:
         nbytes = int(np.prod(out.slot_shape(chunk_index), dtype=np.int64)) * out.dtype.itemsize
         with self._cv:
             if key in self._slots:
-                self._pin(key)  # already resident (in-flight or ready hit) -> incref, reuse
-                self._slots[key].claimed = True
+                # Already resident (in-flight, or a ready cross-epoch hit) -> incref and
+                # reuse. A FAILED slot is NOT reusable: it quiesces and is dropped, so a
+                # later epoch refetches instead of re-raising a stale error forever.
+                self._pin(key, owner)  # the pin IS this owner's claim (see wait_ready)
                 self._cv.notify_all()  # a ready hit may now satisfy a waiter
                 return True
             if not self._make_room(nbytes):
@@ -387,13 +503,13 @@ class ChunkPool:
             )
             self._slots[key] = _Slot(
                 data=self._alloc(array, chunk_index, out.slot_shape(chunk_index), out.dtype),
-                remaining=src.n_inner_chunks(chunk_index),
+                writers=0,  # no task has started yet; counted on entry to tile_write
+                pending=src.n_inner_chunks(chunk_index),
                 nbytes=nbytes,
-                claimed=True,
                 scratch=scratch,
             )
             self._bytes += nbytes
-            self._pin(key)
+            self._pin(key, owner)
             self.max_resident = max(self.max_resident, len(self._positions()))
             return True
 
@@ -401,9 +517,9 @@ class ChunkPool:
         """True if the chunk is resident, fully assembled, and not failed (a hit)."""
         with self._cv:
             slot = self._slots.get((array, chunk_index))
-            return slot is not None and slot.ready and slot.error is None
+            return slot is not None and slot.state is SlotState.READY
 
-    def pin_if_ready(self, array: str, chunk_index: int) -> bool:
+    def pin_if_ready(self, array: str, chunk_index: int, owner: int) -> bool:
         """Incref + return ``True`` iff the chunk is resident, ready, and not failed.
 
         A cross-epoch (or, with ``persist``, cross-*run*) cache hit the driver can skip
@@ -417,13 +533,10 @@ class ChunkPool:
         with self._cv:
             key = (array, chunk_index)
             slot = self._slots.get(key)
-            if not (slot is not None and slot.ready and slot.error is None):
-                if not self._revive(key):
-                    return False
-                slot = self._slots[key]
+            if not (slot is not None and slot.state is SlotState.READY) and not self._revive(key):
+                return False
             self.hits += 1  # resident (cross-epoch) or revived (cross-run) -> no fetch
-            self._pin(key)
-            slot.claimed = True  # publish the claim so a waiter may now proceed
+            self._pin(key, owner)  # the pin IS this owner's claim; publish it
             self._cv.notify_all()
             return True
 
@@ -469,12 +582,16 @@ class ChunkPool:
         if not self._make_room(nbytes):
             del data
             return False
-        self._slots[key] = _Slot(data=data, remaining=0, nbytes=nbytes, ready=True)
+        # A revived chunk enters the SAME lifecycle at a later state rather than being a
+        # second way to be gatherable: no tiles were ever outstanding, nothing is pending.
+        self._slots[key] = _Slot(
+            data=data, writers=0, pending=0, nbytes=nbytes, state=SlotState.READY
+        )
         self._bytes += nbytes
         self.max_resident = max(self.max_resident, len(self._positions()))
         return True
 
-    def pin_keys(self, keys: set[tuple[str, int]]) -> None:
+    def pin_keys(self, keys: set[tuple[str, int]], owner: int) -> None:
         """Reference (incref) a set of ``(path, chunk_index)`` slots for a live block.
 
         Windows make one chunk readable by several concurrent blocks, so pins are
@@ -485,9 +602,14 @@ class ChunkPool:
         """
         with self._cv:
             for key in keys:
-                self._pin(key)
+                self._pin(key, owner)
+            # Now that a reference IS this owner's claim, pinning can be the event that
+            # satisfies a consumer parked in `wait_ready` on an already-READY chunk.
+            # Under the old shared `claimed` flag it never could, so this notify was
+            # not needed; without it that consumer sleeps until some other wake-up.
+            self._cv.notify_all()
 
-    def unpin_keys(self, keys: set[tuple[str, int]]) -> None:
+    def unpin_keys(self, keys: set[tuple[str, int]], owner: int) -> None:
         """Release (decref) a block's ``(path, chunk_index)`` references.
 
         A slot dropping to refcount 0 becomes LRU-evictable (retained for cross-epoch
@@ -496,7 +618,7 @@ class ChunkPool:
         """
         with self._cv:
             for key in keys:
-                self._unpin_one(key)
+                self._unpin_one(key, owner)
             self._cv.notify_all()
 
     def buffer_stats(self) -> BufferStats:
@@ -513,43 +635,66 @@ class ChunkPool:
         """
         self._buffers.set_allocator(allocator)
 
-    def unpin_all(self) -> None:
-        """Epoch boundary reset: clear every pin and drop abandoned partials.
+    def release_owner(self, owner: int) -> None:
+        """Release everything one iteration holds: its pins, and its abandoned partials.
 
-        A pin is per-epoch working state, not cache membership -- ready chunks stay
-        resident (unpinned) for cross-epoch reuse. No pin may survive an epoch: an
-        aborted epoch (early ``break``) leaves its read-ahead and un-drained current
-        block referenced, which would shrink the next epoch's budget until admission
-        can free no room and the driver deadlocks. A *not-ready* slot at this boundary
-        is an abandoned partial (its fetch was cancelled mid-flight) -- it can never be
-        a valid cache entry, so drop it; that also restores the in-epoch invariant
-        "not ready => in flight" that protects fetches from eviction. Called at the
-        next epoch's start, when the prior scheduler is fully closed (no race).
+        Called by that iteration's own teardown, so the state dies with the thing that
+        created it. A pin is per-pass working state, not cache membership -- READY
+        chunks stay resident (unpinned) for cross-epoch reuse.
+
+        This must happen: an abandoned pass (early ``break``) otherwise leaves its
+        read-ahead and un-drained block referenced forever, shrinking every later
+        epoch's budget until admission can free no room and the driver deadlocks.
+
+        Scoped to ``owner``, because one pool serves several concurrent iterations.
+        Releasing globally is #34 -- it strips a live iteration's pins and its in-use
+        chunks become eviction candidates mid-gather. For the same reason a partial is
+        dropped only when it is quiescent *and* unreferenced: a slot still being written
+        by a live task, or held by another owner, is not ours to reclaim.
         """
         with self._cv:
-            self._pinned.clear()
-            for key in [k for k, slot in self._slots.items() if not slot.ready]:
-                self._drop(key)
-            for slot in self._slots.values():
-                slot.claimed = False  # a retained chunk must be re-claimed next epoch
-            # Per-epoch observability resets here (the epoch boundary); manifest_entries
-            # is load-time and persists.
+            for key in [k for k, owners in self._pinned.items() if owner in owners]:
+                self._pinned[key].pop(owner, None)
+                if not self._pinned[key]:
+                    self._pinned.pop(key, None)
+            for key in [
+                k
+                for k, slot in self._slots.items()
+                if slot.state is not SlotState.READY and slot.quiescent and self._refs(k) == 0
+            ]:
+                self._drop(key)  # an abandoned partial can never be a valid cache entry
+            self._cv.notify_all()  # freed budget may unpark an admission
+
+    def reset_epoch_counters(self) -> None:
+        """Zero the per-epoch observability counters at a pass boundary.
+
+        Split out of the old ``unpin_all``: releasing references and resetting counters
+        are unrelated jobs on different clocks (one belongs to an iteration's teardown,
+        the other to a pass's start), and bundling them is why the reset used to force a
+        global unpin. ``manifest_entries`` is load-time state and deliberately survives.
+        """
+        with self._cv:
             self.hits = self.misses = 0
             self.revive_mismatch = self.revive_missing = 0
             self._buffers.reset_counters()  # batch outputs too -- same epoch boundary
-            self._cv.notify_all()
 
-    def _pin(self, key: tuple[str, int]) -> None:  # call under the lock
-        self._pinned[key] = self._pinned.get(key, 0) + 1
+    def _pin(self, key: tuple[str, int], owner: int) -> None:  # call under the lock
+        owners = self._pinned.setdefault(key, {})
+        owners[owner] = owners.get(owner, 0) + 1
         if key in self._slots:
             self._slots.move_to_end(key)  # MRU (the slot may not be allocated yet)
 
-    def _unpin_one(self, key: tuple[str, int]) -> None:  # call under the lock
-        n = self._pinned.get(key, 0)
+    def _unpin_one(self, key: tuple[str, int], owner: int) -> None:  # call under the lock
+        owners = self._pinned.get(key)
+        if owners is None:
+            return
+        n = owners.get(owner, 0)
         if n <= 1:
-            self._pinned.pop(key, None)
+            owners.pop(owner, None)
         else:
-            self._pinned[key] = n - 1
+            owners[owner] = n - 1
+        if not owners:
+            self._pinned.pop(key, None)
 
     def _make_room(self, nbytes: int) -> bool:  # call under the lock
         if self._budget is None:
@@ -557,9 +702,7 @@ class ChunkPool:
         while self._bytes + nbytes > self._budget:
             # Evict the LRU slot that is ready *and* unreferenced; a not-ready slot is
             # an in-flight fetch and a refcounted slot is held by a live block.
-            victim = next(
-                (k for k, s in self._slots.items() if k not in self._pinned and s.ready), None
-            )
+            victim = next((k for k, sl in self._slots.items() if self._evictable(k, sl)), None)
             if victim is None:  # everything resident is in-flight or pinned -> no room
                 return False
             self._drop(victim)
@@ -573,7 +716,7 @@ class ChunkPool:
         # .npy on disk so a later epoch/run can revive it. It was already recorded in the log at
         # completion (see scatter -> _record_completed), so eviction touches only the backing.
         # A not-ready partial is garbage either way -> unlink it.
-        keep = self._persistent and slot.ready
+        keep = self._persistent and slot.state is SlotState.READY
         self._free(slot, keep_file=keep)
 
     def _alloc(
@@ -584,37 +727,117 @@ class ChunkPool:
         path = self._dir / f"{_safe(array)}__{chunk_index}.npy"
         return np.lib.format.open_memmap(path, mode="w+", dtype=dtype, shape=shape)
 
-    def scatter(
-        self, array: str, chunk_index: int, inner_coord: tuple[int, ...], tile: np.ndarray
-    ) -> None:
-        """Copy one decoded tile into its slot; complete the chunk if it was the last.
+    @contextlib.contextmanager
+    def tile_write(
+        self, array: str, chunk_index: int, inner_coord: tuple[int, ...]
+    ) -> Iterator[_TileWrite]:
+        """Scope one tile task's write, guaranteeing the slot hears about its end.
 
-        The memcpy happens *before* the lock (rule 1); the completion counter and
-        ``ready`` flip happen *under* the lock (rule 2). Completion (chunk
-        transforms on the assembled array) runs outside the lock -- no other thread
-        touches the slot once ``remaining`` hits 0 -- then ``ready`` is published.
+        The pool owns the guarantee; the caller only has to *be inside the scope*::
+
+            with pool.tile_write(array, cid, coord) as w:
+                tile = await fetch_decode(...)     # cancellation here is covered
+                w.deliver(tile)                    # or w.fail(exc)
+
+        A bare decrement at the end of the task would not do: a tile task can end
+        without ever reaching the pool -- a fetch/decode error takes an early return,
+        and a **cancellation** (an early ``break`` closes the scheduler with
+        ``cancel_futures=True``) can unwind at any ``await``. ``writers`` is what
+        eviction reads, so a missed decrement is a slot that is never safe to take away
+        and a budget that never recovers. ``__exit__`` is the only construct that
+        cannot be forgotten by a future early return.
+
+        ``deliver`` / ``fail`` / scope exit all funnel into one release, and the
+        release is idempotent -- so a delivered tile does not double-decrement.
         """
         key = (array, chunk_index)
-        slot = self._slots[key]  # allocated by the scheduler before any scatter
+        with self._cv:
+            slot = self._slots.get(key)
+            if slot is not None:
+                slot.writers += 1  # this task is now running: the slot is not quiescent
+        writer = _TileWrite(self, array, chunk_index, inner_coord)
+        try:
+            yield writer
+        finally:
+            writer.release()
+
+    def deliver_tile(
+        self, array: str, chunk_index: int, inner_coord: tuple[int, ...], tile: np.ndarray
+    ) -> None:
+        """Synchronous convenience: scope one tile write and deliver it in one call.
+
+        Sugar over :meth:`tile_write`, not a second lever -- it opens the same scope, so
+        the writer count still moves in exactly one place. Use it when there is nothing
+        to await between reserving the write and having the tile. The scheduler cannot:
+        it awaits the fetch inside the scope, so it uses :meth:`tile_write` directly.
+        """
+        with self.tile_write(array, chunk_index, inner_coord) as writer:
+            writer.deliver(tile)
+
+    def _deliver(
+        self, array: str, chunk_index: int, inner_coord: tuple[int, ...], tile: np.ndarray
+    ) -> None:
+        """Copy one decoded tile into its slot (called by :class:`_TileWrite`).
+
+        The memcpy happens *before* the lock (rule 1); the counter moves *under* it
+        (rule 2). Publication is :meth:`_advance`'s business, not this method's.
+        """
+        key = (array, chunk_index)
+        slot = self._slots[key]  # allocated by the scheduler before any delivery
         dst, src = self._by_path[array].tile_placement(chunk_index, inner_coord)
         # Tiles assemble at the SOURCE shape: into scratch on a reshaping path, else straight
         # into the slot (which is then both buffer and cache). Disjoint, fixed-shape, lock-free.
         buffer = slot.data if slot.scratch is None else slot.scratch
         buffer[dst] = tile[src]  # disjoint, fixed-shape: lock-free (rule 1)
-
         with self._cv:
-            slot.remaining -= 1
-            last = slot.remaining == 0
-        if not last:
-            return
+            slot.pending -= 1
 
-        # Sole owner now: assemble-stage transforms on the whole (source-shaped) outer chunk,
-        # then land the (possibly reshaped) result in the output-sized slot.
+    def _advance(self, array: str, chunk_index: int) -> None:
+        """The **only** function that moves a slot's state. Called once per tile release.
+
+        Everything the old code spread across ``scatter``'s tail, ``fail`` and
+        ``unpin_all`` lives here, so there is exactly one lever:
+
+        * still has writers -> nothing to decide yet.
+        * quiesced + FAILED -> **drop it**. A poisoned slot must not survive as a
+          resident entry: ``try_admit`` would take the resident branch next epoch and
+          return ``True`` without refetching, and ``wait_ready`` would re-raise the
+          stale error forever (#33's second half).
+        * quiesced + everything delivered -> ASSEMBLED, then run the chunk transform and
+          the persist write-back **outside** the lock (no other thread can touch the
+          slot once it is quiescent), then publish READY.
+        * quiesced + tiles still pending -> an abandoned partial (cancelled fetch). Leave
+          it FILLING; ``unpin_all`` drops it once unreferenced.
+        """
+        key = (array, chunk_index)
+        with self._cv:
+            slot = self._slots.get(key)
+            if slot is None or not slot.quiescent:
+                return
+            if slot.state is SlotState.FAILED:
+                # Deliberately NOT dropped here: a consumer still has to observe the
+                # error, and this slot may be the only thing holding it. It is not
+                # evictable (that needs READY) and it does not survive the pass --
+                # `release_owner` drops it at teardown, so the next epoch refetches
+                # instead of re-raising a stale error forever (#33).
+                self._cv.notify_all()
+                return
+            if slot.pending > 0 or slot.state is not SlotState.FILLING:
+                # Either tiles are still to come (quiescent only because no task happens
+                # to be running right now, or because the pass was cancelled and left an
+                # abandoned partial), or the slot is already published.
+                return
+            slot.state = SlotState.ASSEMBLED
+            buffer = slot.data if slot.scratch is None else slot.scratch
+
+        # Sole owner now (quiescent, and ASSEMBLED excludes it from eviction): assemble-stage
+        # transforms on the whole (source-shaped) outer chunk, then land the (possibly
+        # reshaped) result in the output-sized slot.
         prepped = self._apply_transforms(array, chunk_index, buffer)
         with self._cv:
             slot.data = self._persist(slot.data, prepped)
             slot.scratch = None  # assembly done -- drop the transient source-shaped buffer
-            slot.ready = True
+            slot.state = SlotState.READY
             # Record the completed entry *now* (not at eviction/close) so a crash still leaves a
             # usable cache. Appending here, under the lock, serializes writes across decode
             # threads and orders them after the slot's data is durable in its .npy.
@@ -643,17 +866,26 @@ class ChunkPool:
         return current
 
     def fail(self, array: str, chunk_index: int, error: BaseException) -> None:
-        """Mark a slot failed so a waiting consumer re-raises instead of hanging.
+        """Poison one chunk so a waiting consumer re-raises instead of hanging.
 
         Fail-fast: a fetch/decode error on any tile poisons its outer chunk; the
         consumer's ``wait_ready`` surfaces it on the main thread.
+
+        It records the error and **nothing else**. The old version also set
+        ``ready = True`` -- because "stop waiting" and "safe to evict" shared one flag,
+        the only way to wake a waiter was to declare the slot a finished cache entry,
+        while sibling tile tasks were still writing into it (#33). ``wait_ready`` keys
+        off ``error`` independently of state, so waiters still wake immediately; the
+        slot is disposed of by :meth:`_advance` once it quiesces.
         """
         with self._cv:
             slot = self._slots.get((array, chunk_index))
-            if slot is not None:
-                slot.error = error
-                slot.ready = True
-                self._cv.notify_all()
+            if slot is None:
+                return
+            slot.error = error
+            slot.state = SlotState.FAILED
+            self._cv.notify_all()
+        self._advance(array, chunk_index)  # may already be quiescent (all tiles returned)
 
     def set_error(self, error: BaseException) -> None:
         """Poison the whole pool (the fetch driver died) so every waiter re-raises.
@@ -678,17 +910,23 @@ class ChunkPool:
 
     # -- consume: wait / gather ---------------------------------------------
 
-    def wait_ready(self, array: str, chunk_index: int) -> None:
-        """Block until the outer chunk is assembled *and claimed this epoch* (or raise).
+    def wait_ready(self, array: str, chunk_index: int, owner: int) -> None:
+        """Block until the chunk is READY *for this owner* (or raise).
 
-        Waiting on ``claimed`` (set by the driver's admit / pin_if_ready) closes a
-        cross-epoch race: a chunk still resident-and-ready from the prior epoch would
-        otherwise be gathered before the driver references it, letting the consumer's
-        last-use release land before the driver's pin -- a lost release that leaks a
-        reference (and, worse, lets the driver evict a chunk mid-gather). Requiring the
-        claim orders pin-before-consume-before-release. Wakes on: ready+claimed, the
-        chunk failed (:meth:`fail`), or the pool was poisoned (:meth:`set_error`, covering
-        a driver death before this chunk was allocated).
+        Requiring **this owner's own reference** (rather than a shared ``claimed``
+        bool) closes a cross-epoch race: a chunk still resident-and-READY from the
+        prior epoch would otherwise be gathered before the driver references it,
+        letting the consumer's last-use release land before the driver's pin -- a lost
+        release that leaks a reference and, worse, lets the driver evict a chunk
+        mid-gather. Owner-scoped because a single bool is satisfied by *another*
+        iteration's claim (#35), which is the same race with a concurrent producer
+        instead of a previous epoch.
+
+        Wakes on: READY and referenced by ``owner``; the chunk failed (:meth:`fail`,
+        which no longer has to fake readiness to get here); or the pool was poisoned
+        (:meth:`set_error`, covering a driver death before this chunk was allocated).
+        A key that is simply absent means the driver has not admitted it yet -- keep
+        waiting, as before.
         """
         key = (array, chunk_index)
         with self._cv:
@@ -699,8 +937,13 @@ class ChunkPool:
                         self._error is not None
                         or (
                             key in self._slots
-                            and self._slots[key].ready
-                            and self._slots[key].claimed
+                            and (
+                                self._slots[key].error is not None
+                                or (
+                                    self._slots[key].state is SlotState.READY
+                                    and self._pinned.get(key, {}).get(owner, 0) > 0
+                                )
+                            )
                         )
                     )
                 )
@@ -916,7 +1159,7 @@ class ChunkPool:
                 self._log = None
             for k in list(self._slots):
                 slot = self._slots.pop(k)
-                self._free(slot, keep_file=self._persistent and slot.ready)
+                self._free(slot, keep_file=self._persistent and slot.state is SlotState.READY)
             self._bytes = 0
             self._pinned.clear()
             self._buffers.clear()  # batch outputs too; a big-payload pool holds GBs of them

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -393,6 +393,10 @@ class ChunkPool:
         # single `claimed` bool lets one iteration's claim satisfy another's wait_ready.
         self._pinned: dict[tuple[str, int], dict[int, int]] = {}
         self._owner_seq = 0  # monotonic; owners are opaque tokens minted by new_owner()
+        # Owners live from mint to release_owner, NOT from their first pin: an iteration
+        # that starves before it can pin anything is exactly the case the starvation
+        # diagnostic has to name, and counting pin-holders would miss it.
+        self._owners: set[int] = set()
         self._cv = threading.Condition(threading.Lock())
         self._error: BaseException | None = None  # global poison (driver death)
         self.max_resident = 0  # peak distinct outer chunk positions held at once
@@ -414,6 +418,7 @@ class ChunkPool:
         """
         with self._cv:
             self._owner_seq += 1
+            self._owners.add(self._owner_seq)
             return self._owner_seq
 
     def _refs(self, key: tuple[str, int]) -> int:  # call under the lock
@@ -451,6 +456,22 @@ class ChunkPool:
     def budget_bytes(self) -> int | None:
         """The residency ceiling, or ``None`` for an unbounded pool."""
         return self._budget
+
+    @property
+    def active_owners(self) -> int:
+        """How many iterations are live on this pool right now.
+
+        Live means minted and not yet released -- *not* "currently holds a pin". An
+        iteration that starves before it can pin anything is precisely the case the
+        starvation diagnostic exists to name, and counting pin-holders would miss it.
+
+        More than one means several iterations share this pool (``zip(ds.train,
+        ds.val)``, two DataLoaders) and each needs its own working set resident at the
+        same time -- the most common reason a budget auto-sized for one cannot admit.
+        Read-only snapshot.
+        """
+        with self._cv:
+            return len(self._owners)
 
     def blocked_waiters(self) -> list[tuple[str, int]]:
         """``(path, chunk_index)`` keys some thread is currently blocked on in
@@ -663,6 +684,7 @@ class ChunkPool:
                 if slot.state is not SlotState.READY and slot.quiescent and self._refs(k) == 0
             ]:
                 self._drop(key)  # an abandoned partial can never be a valid cache entry
+            self._owners.discard(owner)  # this iteration is done; it no longer counts
             self._cv.notify_all()  # freed budget may unpark an admission
 
     def reset_epoch_counters(self) -> None:

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -172,6 +172,7 @@ class Scheduler:
         geometries: dict[str, ArrayGeometry],
         pool: ChunkPool,
         config: SchedulerConfig | None = None,
+        owner: int | None = None,
     ) -> None:
         self._store = store
         self._geometries = geometries
@@ -181,6 +182,11 @@ class Scheduler:
                 f"on_bad_chunk must be 'raise' or 'nan', got {self._config.on_bad_chunk!r}"
             )
         self.pool = pool  # caller-owned: persists across epochs (the cache)
+        # One iteration = one owner: this scheduler's admission pins and its producer's
+        # block pins share a token, so the next epoch's prologue releases exactly this
+        # iteration's references and leaves a concurrent iteration's alone. Minted here
+        # when the caller does not supply one, so a standalone Scheduler still works.
+        self._owner = pool.new_owner() if owner is None else owner
         self.bad_chunks: list[StoredChunkRead] = []  # tiles NaN-filled this run (observability)
         self._proto = default_buffer_prototype()
         self._arrays: dict[str, _ArrayCtx] = {}
@@ -250,6 +256,17 @@ class Scheduler:
 
     # -- public, synchronous surface ---------------------------------------
 
+    @property
+    def owner(self) -> int:
+        """This scheduler's reference token, for the consumer's ``pool.wait_ready``.
+
+        One iteration = one owner: whoever drains this scheduler must wait under the
+        same token the scheduler admits under, or its wait can never be satisfied.
+        ``InSituDataset._iterate`` mints the token and hands it to both sides; a
+        caller driving a ``Scheduler`` directly reads it here.
+        """
+        return self._owner
+
     def start(self, chunk_ids: Sequence[int] | np.ndarray, ref_spc: int) -> Future:
         """Begin streaming the stored chunks of ``chunk_ids`` (priority order).
 
@@ -267,7 +284,7 @@ class Scheduler:
         """Release references on a set of drained ``(path, chunk_index)`` slots
         (thread-safe): the slots that hit refcount 0 become LRU-evictable; wake any
         admit parked on a full budget so it can evict them and proceed."""
-        self.pool.unpin_keys(keys)
+        self.pool.unpin_keys(keys, self._owner)
         if self._capacity is not None:
             self._loop.call_soon_threadsafe(self._capacity.set)
 
@@ -297,7 +314,7 @@ class Scheduler:
                 key = (read.array, read.chunk_index)
                 hit = decided.get(key)
                 if hit is None:
-                    hit = self.pool.pin_if_ready(read.array, read.chunk_index)
+                    hit = self.pool.pin_if_ready(read.array, read.chunk_index, self._owner)
                     if not hit:
                         await self._admit(read.array, read.chunk_index)  # may await an unpin
                     decided[key] = hit
@@ -322,9 +339,9 @@ class Scheduler:
         (:meth:`_starvation`); a timeout by itself means nothing and just loops.
         """
         assert self._capacity is not None
-        while not self.pool.try_admit(array, chunk_index):
+        while not self.pool.try_admit(array, chunk_index, self._owner):
             self._capacity.clear()
-            if self.pool.try_admit(array, chunk_index):
+            if self.pool.try_admit(array, chunk_index, self._owner):
                 return
             try:
                 await asyncio.wait_for(self._capacity.wait(), STARVATION_POLL_S)
@@ -427,13 +444,19 @@ class Scheduler:
                 )
 
     async def _one(self, read: StoredChunkRead) -> None:
-        """Fetch + decode + scatter one stored tile, holding one in-flight slot.
+        """Fetch + decode + deliver one stored tile, holding one in-flight slot.
 
         The in-flight slot is held across all three stages, so ``max_inflight`` is
-        total concurrency. Decode and the scatter memcpy run on the decode pool (GIL
+        total concurrency. Decode and the delivery memcpy run on the decode pool (GIL
         released); the loop only awaits. A *fetch/decode* failure is a bad/truncated
         chunk -> the ``on_bad_chunk`` policy decides (poison, or NaN-fill and carry
-        on). A failure *during scatter* is a genuine bug and always poisons.
+        on). A failure *during delivery* is a genuine bug and always poisons.
+
+        The whole body runs inside ``pool.tile_write``, which owns the obligation to
+        tell the slot this task ended. That matters on the paths that never reach the
+        pool: the ``return`` below, and cancellation at either ``await`` (an early
+        ``break`` closes the scheduler with ``cancel_futures=True``). Without it a
+        slot keeps a writer forever and can never be evicted.
         """
         assert self._inflight is not None
         ctx = self._arrays[read.array]
@@ -441,25 +464,19 @@ class Scheduler:
             self._inflight_now += 1
             self.inflight_peak = max(self.inflight_peak, self._inflight_now)
             try:
-                try:
-                    tile = await self._fetch_decode(read, ctx)
-                except Exception as exc:  # noqa: BLE001 - bad/truncated stored chunk
-                    if self._config.on_bad_chunk != "nan":
-                        self.pool.fail(read.array, read.chunk_index, exc)
-                        return
-                    self.bad_chunks.append(read)
-                    tile = np.full(ctx.chunk_shape, _bad_fill(ctx), dtype=ctx.dtype)
-                try:
-                    await self._loop.run_in_executor(
-                        None,
-                        self.pool.scatter,
-                        read.array,
-                        read.chunk_index,
-                        read.inner_coord,
-                        tile,
-                    )
-                except Exception as exc:  # noqa: BLE001 - a scatter failure is a real bug
-                    self.pool.fail(read.array, read.chunk_index, exc)
+                with self.pool.tile_write(read.array, read.chunk_index, read.inner_coord) as w:
+                    try:
+                        tile = await self._fetch_decode(read, ctx)
+                    except Exception as exc:  # noqa: BLE001 - bad/truncated stored chunk
+                        if self._config.on_bad_chunk != "nan":
+                            w.fail(exc)
+                            return
+                        self.bad_chunks.append(read)
+                        tile = np.full(ctx.chunk_shape, _bad_fill(ctx), dtype=ctx.dtype)
+                    try:
+                        await self._loop.run_in_executor(None, w.deliver, tile)
+                    except Exception as exc:  # noqa: BLE001 - a delivery failure is a real bug
+                        w.fail(exc)
             finally:
                 self._inflight_now -= 1
 

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -380,6 +380,17 @@ class Scheduler:
         if not waiting:
             return None
         budget = self.pool.budget_bytes
+        # A budget sized for ONE iteration cannot serve several: each holds its own
+        # references, so the requirement multiplies. Name it rather than leave the caller
+        # to rediscover it -- it is the likeliest cause once more than one owner is live.
+        owners = self.pool.active_owners
+        concurrent = (
+            f" NOTE: {owners} iterations are sharing this pool (e.g. `zip(ds.train, "
+            f"ds.val)`, or two DataLoaders); each needs its own working set resident at "
+            f"once, so the budget must cover all {owners}."
+            if owners > 1
+            else ""
+        )
         return RuntimeError(
             f"residency budget exhausted: cannot admit chunk {chunk_index} of {array!r}. "
             f"The pool holds {self.pool.resident_chunks} chunk(s) "
@@ -387,7 +398,7 @@ class Scheduler:
             f"in flight; no tile is in flight; and the consumer is blocked waiting on "
             f"{sorted(waiting)[:4]}. Nothing can free a slot, so this would hang. The "
             f"working set is larger than the budget it was sized for -- raise "
-            f"cache_budget_bytes, or lower batch_size / block_chunks."
+            f"cache_budget_bytes, or lower batch_size / block_chunks.{concurrent}"
         )
 
     async def _io(self, coro: Coroutine[Any, Any, _T]) -> _T:

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -257,6 +257,13 @@ class InSituDataset:
                 train_samples = len(self.manifest.chunks[SplitName.TRAIN.value]) * self._ref_spc
                 train_ws = sum(var_bytes(g, o, train_samples) for g, o in pairs)
                 working_set = max(working_set, train_ws)
+        # Sized for ONE iteration, deliberately. Every active iteration shares this pool and
+        # holds its own references, so N concurrent iterations need ~N x this -- but the engine
+        # cannot know N, and guessing high would cost memory in the single-iteration case that
+        # is almost every case. Running several is an explicit choice, so sizing for it is the
+        # caller's: pass `cache_budget_bytes`. Under-sizing is not silent -- admission raises
+        # and names how many iterations are sharing the pool (`Scheduler._starvation`).
+        # See docs/tuning.md, "Several iterations at once multiply the budget".
         self.cache_budget_bytes = max(int(cache_budget_bytes or 0), working_set)
         # persist turns the cache_dir mmap tier into a cross-run cache (files + manifest
         # survive close; reopen revives them as hits). It needs a dir to keep files in;

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -377,11 +377,17 @@ class InSituDataset:
         blocks = _partition_blocks(order, self.block_chunks)
         ordered_chunks = [int(c) for _rstart, _rstop, cids in blocks for c in cids]
 
-        # Start clean: release any pins a prior epoch leaked (an early break leaves its
-        # read-ahead pinned in the persistent pool -> would shrink this epoch's budget
-        # until admission deadlocks). The prior scheduler is fully closed here, so no
-        # pin/unpin can race. Resident chunks stay (unpinned) for cross-epoch reuse.
-        self._pool.unpin_all()
+        # One owner per pass, minted here and threaded through this iteration's scheduler
+        # (admission pins) and its producer (block pins). Scoping references this way is
+        # what lets two iterations share a pool: the prologue below releases only *our*
+        # leftovers, and `wait_ready` is satisfied only by *our* reference.
+        owner = self._pool.new_owner()
+
+        # Per-pass observability starts clean. Releasing this pass's references is NOT
+        # done here: it happens in our own teardown below, so an abandoned pass cleans up
+        # after itself instead of relying on the next pass's prologue -- which, now that
+        # references are owner-scoped, would be a different owner and could not.
+        self._pool.reset_epoch_counters()
 
         out_q: queue.Queue = queue.Queue(maxsize=self.prefetch_depth)
         stop = threading.Event()
@@ -430,7 +436,7 @@ class InSituDataset:
                     # ChunkPool.wait_ready -- before gathering. Each wait is cheap once ready.
                     while ready < len(blocks) and blocks[ready][0] < stop_row:
                         for path, cid in block_keys[ready]:
-                            sched.pool.wait_ready(path, cid)
+                            sched.pool.wait_ready(path, cid, owner)
                         ready += 1
                     batch = sched.pool.gather(order[start:stop_row], self.variables, spc)
                     # Release the driver's reference on chunks whose *last* use is a block now
@@ -460,6 +466,7 @@ class InSituDataset:
             self.geometries,
             self._pool,
             self.scheduler_config,
+            owner=owner,
         ) as sched:
             producer = threading.Thread(
                 target=produce, args=(sched,), name="insitu-prefetch", daemon=True
@@ -501,6 +508,11 @@ class InSituDataset:
                         pool.revive_mismatch,
                         pool.revive_missing,
                     )
+                # Last: drop this pass's references (and any partial its cancelled
+                # fetches abandoned), after every counter above has been read. An
+                # early `break` finalizes this generator, so this runs then too --
+                # which is what keeps an abandoned pass from leaking budget.
+                self._pool.release_owner(owner)
 
     def _log_epoch_summary(self, pool: ChunkPool, split: SplitName | None) -> None:
         """One INFO line per epoch *per split*: what the chunk cache and the batch buffers did.

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -101,14 +101,15 @@ def test_pool_aliased_labels_decode_once(tiled_store):
     reads = build_stored_chunk_reads(range(base.n_chunks), {array: base}, base.sample_chunk_size)
 
     pool = ChunkPool(geoms)
+    owner = pool.new_owner()
     for cid in range(base.n_chunks):
-        pool.try_admit(array, cid)  # admit by array name
+        pool.try_admit(array, cid, owner)  # admit by array name
     for read in reads:
-        pool.scatter(read.array, read.chunk_index, read.inner_coord, tiles[read.coords])
+        pool.deliver_tile(read.array, read.chunk_index, read.inner_coord, tiles[read.coords])
 
     spc = base.sample_chunk_size
     for cid in range(base.n_chunks):
-        pool.wait_ready(array, cid)
+        pool.wait_ready(array, cid, owner)
     n0 = len(base.samples_in_chunk(0))
     rows = np.array([[0, w] for w in range(n0)], dtype=np.int64)
     batch = pool.gather(rows, ["now", "next"], spc)
@@ -128,20 +129,21 @@ def test_pool_scatter_reconstructs_array(tiled_store, var):
     reads = build_stored_chunk_reads(range(geom.n_chunks), geoms, geom.sample_chunk_size)
 
     pool = ChunkPool(geoms)
+    owner = pool.new_owner()
     for cid in range(geom.n_chunks):
-        pool.try_admit(var, cid)
+        pool.try_admit(var, cid, owner)
 
     # Scatter every tile from a thread pool: two tiles of one slot land at once,
     # so this exercises the disjoint-lock-free-copy / lock-published-ready rule.
     def scatter(read: StoredChunkRead) -> None:
-        pool.scatter(read.array, read.chunk_index, read.inner_coord, tiles[read.coords])
+        pool.deliver_tile(read.array, read.chunk_index, read.inner_coord, tiles[read.coords])
 
     with ThreadPoolExecutor(max_workers=8) as ex:
         list(ex.map(scatter, reads))
 
     spc = geom.sample_chunk_size
     for cid in range(geom.n_chunks):
-        pool.wait_ready(var, cid)
+        pool.wait_ready(var, cid, owner)
         n0 = len(geom.samples_in_chunk(cid))
         rows = np.array([[cid, w] for w in range(n0)], dtype=np.int64)
         batch = pool.gather(rows, [var], spc)
@@ -167,16 +169,17 @@ def test_pool_concurrent_scatter_is_race_free() -> None:
 
     for _round in range(8):  # repeated admit -> concurrent scatter -> gather (fresh pool)
         pool = ChunkPool(geoms)
-        pool.try_admit("v", 0)
+        owner = pool.new_owner()
+        pool.try_admit("v", 0, owner)
 
         def scatter(ic, pool=pool, geom=geom, ref=ref) -> None:  # default-bind per round
             dst, _src = geom.tile_placement(0, ic)
-            pool.scatter("v", 0, ic, ref[dst].copy())  # full chunk-shaped tile
+            pool.deliver_tile("v", 0, ic, ref[dst].copy())  # full chunk-shaped tile
 
         with ThreadPoolExecutor(max_workers=32) as ex:
             list(ex.map(scatter, coords))
 
-        pool.wait_ready("v", 0)
+        pool.wait_ready("v", 0, owner)
         rows = np.array([[0, w] for w in range(4)], dtype=np.int64)
         got = pool.gather(rows, ["v"], geom.sample_chunk_size).arrays["v"]
         assert np.array_equal(got, ref)
@@ -193,15 +196,16 @@ def test_pool_mmap_backing_parity_and_cleanup(tiled_store, tmp_path, var):
     backing = tmp_path / "slots"
 
     pool = ChunkPool(geoms, backing_dir=backing)
+    owner = pool.new_owner()
     for cid in range(geom.n_chunks):
-        pool.try_admit(var, cid)
+        pool.try_admit(var, cid, owner)
         for inner in geom.inner_coords():
-            pool.scatter(var, cid, inner, tiles[(cid, *inner)])
+            pool.deliver_tile(var, cid, inner, tiles[(cid, *inner)])
 
     assert list(backing.glob("*.npy")), "slots should live as .npy files on disk"
     spc = geom.sample_chunk_size
     for cid in range(geom.n_chunks):
-        pool.wait_ready(var, cid)
+        pool.wait_ready(var, cid, owner)
         n0 = len(geom.samples_in_chunk(cid))
         rows = np.array([[cid, w] for w in range(n0)], dtype=np.int64)
         got = pool.gather(rows, [var], spc).arrays[var]
@@ -223,10 +227,11 @@ def test_pool_mmap_backing_with_transform(tiled_store, tmp_path):
         return chunk
 
     pool = ChunkPool(geoms, backing_dir=tmp_path / "s", chunk_transforms=[scale])
-    pool.try_admit("single_inner", 0)
+    owner = pool.new_owner()
+    pool.try_admit("single_inner", 0, owner)
     for inner in geom.inner_coords():
-        pool.scatter("single_inner", 0, inner, tiles[(0, *inner)])
-    pool.wait_ready("single_inner", 0)
+        pool.deliver_tile("single_inner", 0, inner, tiles[(0, *inner)])
+    pool.wait_ready("single_inner", 0, owner)
 
     spc = geom.sample_chunk_size
     rows = np.array([[0, w] for w in range(spc)], dtype=np.int64)
@@ -268,8 +273,9 @@ def test_pool_reshaping_transform_heap_gather(tiled_store):
     spc = geom.sample_chunk_size
 
     pool = ChunkPool(geoms, chunk_transforms=[MeanLastAxis()])
+    owner = pool.new_owner()
     for cid in range(geom.n_chunks):
-        _fill_chunk(pool, "single_inner", cid, geom, tiles)
+        _fill_chunk(pool, "single_inner", cid, geom, tiles, owner)
         got = _gather_chunk(pool, "single_inner", cid, geom, spc)
         n0 = len(geom.samples_in_chunk(cid))
         expected = srcs["single_inner"][cid * spc : cid * spc + n0].mean(axis=-1)
@@ -286,7 +292,8 @@ def test_pool_reshaping_transform_dtype_recast(tiled_store):
     spc = geom.sample_chunk_size
 
     pool = ChunkPool(geoms, chunk_transforms=[MeanLastAxis(out_dtype="f8")])
-    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    owner = pool.new_owner()
+    _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)
     got = _gather_chunk(pool, "single_inner", 0, geom, spc)
     assert got.dtype == np.dtype("f8")
     np.testing.assert_allclose(got, srcs["single_inner"][:spc].mean(axis=-1), rtol=1e-12)
@@ -315,16 +322,20 @@ def test_pool_reshaping_transform_mmap_persist_roundtrip(
     backing = tmp_path / "cache"
 
     pool = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[MeanLastAxis()])
+    owner = pool.new_owner()
     for cid in range(geom.n_chunks):
-        _fill_chunk(pool, "single_inner", cid, geom, tiles)
+        _fill_chunk(pool, "single_inner", cid, geom, tiles, owner)
     assert pool.misses == geom.n_chunks and pool.hits == 0
     pool.close()
     assert list(backing.glob("*.npy")) and (backing / "insitu_cache.jsonl").exists()
 
     pool2 = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[MeanLastAxis()])
+    owner = pool2.new_owner()
     assert pool2.manifest_entries == geom.n_chunks
     for cid in range(geom.n_chunks):
-        assert pool2.pin_if_ready("single_inner", cid), "regridded chunk must revive as a hit"
+        assert pool2.pin_if_ready("single_inner", cid, owner), (
+            "regridded chunk must revive as a hit"
+        )
         n0 = len(geom.samples_in_chunk(cid))
         got = _gather_chunk(pool2, "single_inner", cid, geom, spc)
         expected = srcs["single_inner"][cid * spc : cid * spc + n0].mean(axis=-1)
@@ -357,14 +368,16 @@ def test_pool_reshaping_transform_structural_mismatch_is_miss(tiled_store, tmp_p
     t_old = MeanLastAxis()
     t_old.cache_key = "k"  # type: ignore[attr-defined]
     pool = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[t_old])
-    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    owner = pool.new_owner()
+    _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)
     pool.close()
 
     t_new = MeanBothAxes()
     t_new.cache_key = "k"  # type: ignore[attr-defined]
     pool2 = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[t_new])
+    owner = pool2.new_owner()
     assert pool2.manifest_entries == 1, "same fingerprint -> entry is consulted"
-    assert not pool2.pin_if_ready("single_inner", 0), "output-geometry drift must invalidate"
+    assert not pool2.pin_if_ready("single_inner", 0, owner), "output-geometry drift must invalidate"
     assert pool2.revive_mismatch == 1 and pool2.hits == 0
     pool2.close()
 
@@ -374,10 +387,11 @@ def test_pool_wait_ready_raises_on_failure(tiled_store):
     url, _ = tiled_store
     geoms = open_geometries(obstore_store(url), variables=["spatial"])
     pool = ChunkPool(geoms)
-    pool.try_admit("spatial", 0)
+    owner = pool.new_owner()
+    pool.try_admit("spatial", 0, owner)
     pool.fail("spatial", 0, RuntimeError("boom"))
     with pytest.raises(RuntimeError, match="boom"):
-        pool.wait_ready("spatial", 0)
+        pool.wait_ready("spatial", 0, owner)
 
 
 def test_pool_lru_evicts_unpinned_under_budget(tiled_store):
@@ -390,23 +404,24 @@ def test_pool_lru_evicts_unpinned_under_budget(tiled_store):
     spc = geom.sample_chunk_size
     full_nbytes = spc * int(np.prod(geom.inner_shape)) * geom.dtype.itemsize
     pool = ChunkPool(geoms, budget_bytes=2 * full_nbytes)  # holds two full chunks
+    owner = pool.new_owner()
 
     def fill(cid):
-        assert pool.try_admit("single_inner", cid)
+        assert pool.try_admit("single_inner", cid, owner)
         for inner in geom.inner_coords():
-            pool.scatter("single_inner", cid, inner, tiles[(cid, *inner)])
-        pool.wait_ready("single_inner", cid)
+            pool.deliver_tile("single_inner", cid, inner, tiles[(cid, *inner)])
+        pool.wait_ready("single_inner", cid, owner)
 
     fill(0)
     fill(1)
     assert pool.resident_chunks == 2
     # Budget full of *referenced* slots -> a third miss can't be admitted yet.
-    assert not pool.try_admit("single_inner", 2)
-    pool.unpin_keys({("single_inner", 0), ("single_inner", 1)})  # release -> LRU-evictable
-    assert pool.try_admit("single_inner", 2)  # evicts chunk 0
+    assert not pool.try_admit("single_inner", 2, owner)
+    pool.unpin_keys({("single_inner", 0), ("single_inner", 1)}, owner)  # release -> LRU-evictable
+    assert pool.try_admit("single_inner", 2, owner)  # evicts chunk 0
     for inner in geom.inner_coords():
-        pool.scatter("single_inner", 2, inner, tiles[(2, *inner)])
-    pool.wait_ready("single_inner", 2)
+        pool.deliver_tile("single_inner", 2, inner, tiles[(2, *inner)])
+    pool.wait_ready("single_inner", 2, owner)
 
     assert not pool.is_ready("single_inner", 0)  # LRU victim, gone
     assert pool.is_ready("single_inner", 1)  # retained
@@ -425,19 +440,20 @@ def test_pool_pin_is_reference_counted_not_boolean(tiled_store):
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     full = geom.sample_chunk_size * int(np.prod(geom.inner_shape)) * geom.dtype.itemsize
     pool = ChunkPool(geoms, budget_bytes=full)  # holds exactly one chunk
+    owner = pool.new_owner()
 
-    pool.try_admit("single_inner", 0)  # admission references it -> refcount 1
+    pool.try_admit("single_inner", 0, owner)  # admission references it -> refcount 1
     for inner in geom.inner_coords():
-        pool.scatter("single_inner", 0, inner, tiles[(0, *inner)])
-    pool.wait_ready("single_inner", 0)
+        pool.deliver_tile("single_inner", 0, inner, tiles[(0, *inner)])
+    pool.wait_ready("single_inner", 0, owner)
 
-    pool.pin_keys({("single_inner", 0)})  # a second block references it -> 2
-    assert pool._pinned[("single_inner", 0)] == 2
-    pool.unpin_keys({("single_inner", 0)})  # one block done -> 1, still pinned
-    assert not pool.try_admit("single_inner", 1)  # budget full, chunk 0 not evictable
-    pool.unpin_keys({("single_inner", 0)})  # last block done -> 0, now evictable
+    pool.pin_keys({("single_inner", 0)}, owner)  # a second block references it -> 2
+    assert pool._refs(("single_inner", 0)) == 2  # total refs, across owners
+    pool.unpin_keys({("single_inner", 0)}, owner)  # one block done -> 1, still pinned
+    assert not pool.try_admit("single_inner", 1, owner)  # budget full, chunk 0 not evictable
+    pool.unpin_keys({("single_inner", 0)}, owner)  # last block done -> 0, now evictable
     assert ("single_inner", 0) not in pool._pinned
-    assert pool.try_admit("single_inner", 1)  # evicts chunk 0
+    assert pool.try_admit("single_inner", 1, owner)  # evicts chunk 0
     assert ("single_inner", 0) not in pool._slots
 
 
@@ -454,18 +470,19 @@ def test_pool_unpin_all_drops_abandoned_partial_keeps_ready(tiled_store):
     assert len(inner) > 1  # need a multi-tile chunk to leave a real partial
 
     pool = ChunkPool(geoms)
+    owner = pool.new_owner()
     # chunk 0: only the first tile scattered -> not ready (abandoned partial)
-    pool.try_admit("spatial", 0)
-    pool.scatter("spatial", 0, inner[0], tiles[(0, *inner[0])])
+    pool.try_admit("spatial", 0, owner)
+    pool.deliver_tile("spatial", 0, inner[0], tiles[(0, *inner[0])])
     assert not pool.is_ready("spatial", 0)
     # chunk 1: fully scattered -> ready (a valid cache entry)
-    pool.try_admit("spatial", 1)
+    pool.try_admit("spatial", 1, owner)
     for ic in inner:
-        pool.scatter("spatial", 1, ic, tiles[(1, *ic)])
-    pool.wait_ready("spatial", 1)
+        pool.deliver_tile("spatial", 1, ic, tiles[(1, *ic)])
+    pool.wait_ready("spatial", 1, owner)
     bytes_ready = pool._slots[("spatial", 1)].nbytes
 
-    pool.unpin_all()
+    pool.release_owner(owner)
 
     assert pool._pinned == {}  # every refcount cleared
     assert ("spatial", 0) not in pool._slots  # abandoned partial dropped
@@ -481,11 +498,11 @@ def test_pool_persist_requires_cache_dir(tiled_store):
         ChunkPool(geoms, persist=True)
 
 
-def _fill_chunk(pool, var, cid, geom, tiles):
-    pool.try_admit(var, cid)
+def _fill_chunk(pool, var, cid, geom, tiles, owner):
+    pool.try_admit(var, cid, owner)
     for inner in geom.inner_coords():
-        pool.scatter(var, cid, inner, tiles[(cid, *inner)])
-    pool.wait_ready(var, cid)
+        pool.deliver_tile(var, cid, inner, tiles[(cid, *inner)])
+    pool.wait_ready(var, cid, owner)
 
 
 def test_pool_cross_run_persistence(tiled_store, tmp_path):
@@ -500,8 +517,9 @@ def test_pool_cross_run_persistence(tiled_store, tmp_path):
 
     # Run 1: populate + close. persist must KEEP the files and write a manifest.
     pool = ChunkPool(geoms, backing_dir=backing, persist=True)
+    owner = pool.new_owner()
     for cid in range(geom.n_chunks):
-        _fill_chunk(pool, "single_inner", cid, geom, tiles)
+        _fill_chunk(pool, "single_inner", cid, geom, tiles, owner)
     assert pool.misses == geom.n_chunks and pool.hits == 0  # cold: every chunk a miss
     pool.close()
     assert list(backing.glob("*.npy")), "persist=True must keep slot files after close()"
@@ -509,9 +527,10 @@ def test_pool_cross_run_persistence(tiled_store, tmp_path):
 
     # Run 2: same dir -> every chunk a ready hit, no fetch/scatter.
     pool2 = ChunkPool(geoms, backing_dir=backing, persist=True)
+    owner = pool2.new_owner()
     assert pool2.manifest_entries == geom.n_chunks
     for cid in range(geom.n_chunks):
-        assert pool2.pin_if_ready("single_inner", cid), "persisted chunk must be a hit"
+        assert pool2.pin_if_ready("single_inner", cid, owner), "persisted chunk must be a hit"
         n0 = len(geom.samples_in_chunk(cid))
         rows = np.array([[cid, w] for w in range(n0)], dtype=np.int64)
         got = pool2.gather(rows, ["single_inner"], spc).arrays["single_inner"]
@@ -535,16 +554,20 @@ def test_pool_persist_crash_recovery_without_close(tiled_store, tmp_path):
     # Run 1: populate every chunk but NEVER close() -- simulate a killed process. The log must
     # already carry every completed entry (flushed on completion, not at close).
     pool = ChunkPool(geoms, backing_dir=backing, persist=True)
+    owner = pool.new_owner()
     for cid in range(geom.n_chunks):
-        _fill_chunk(pool, "single_inner", cid, geom, tiles)
+        _fill_chunk(pool, "single_inner", cid, geom, tiles, owner)
     log = (backing / "insitu_cache.jsonl").read_text().splitlines()
     assert len(log) == geom.n_chunks + 1  # header + one entry per completed chunk
 
     # Run 2: same dir, fresh pool -> every chunk a ready hit despite the missing close().
     pool2 = ChunkPool(geoms, backing_dir=backing, persist=True)
+    owner = pool2.new_owner()
     assert pool2.manifest_entries == geom.n_chunks
     for cid in range(geom.n_chunks):
-        assert pool2.pin_if_ready("single_inner", cid), "crashed-run chunk must revive as a hit"
+        assert pool2.pin_if_ready("single_inner", cid, owner), (
+            "crashed-run chunk must revive as a hit"
+        )
         n0 = len(geom.samples_in_chunk(cid))
         rows = np.array([[cid, w] for w in range(n0)], dtype=np.int64)
         got = pool2.gather(rows, ["single_inner"], spc).arrays["single_inner"]
@@ -563,13 +586,18 @@ def test_pool_persist_partial_iteration_recovers_completed_subset(tiled_store, t
     backing = tmp_path / "cache"
 
     pool = ChunkPool(geoms, backing_dir=backing, persist=True)
-    _fill_chunk(pool, "single_inner", 0, geom, tiles)  # only chunk 0 completes before the "crash"
+    owner = pool.new_owner()
+    # only chunk 0 completes before the "crash"
+    _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)
     # no close()
 
     pool2 = ChunkPool(geoms, backing_dir=backing, persist=True)
+    owner = pool2.new_owner()
     assert pool2.manifest_entries == 1
-    assert pool2.pin_if_ready("single_inner", 0), "the completed chunk revives"
-    assert not pool2.pin_if_ready("single_inner", 1), "an un-reached chunk is a miss, not a hit"
+    assert pool2.pin_if_ready("single_inner", 0, owner), "the completed chunk revives"
+    assert not pool2.pin_if_ready("single_inner", 1, owner), (
+        "an un-reached chunk is a miss, not a hit"
+    )
     pool2.close()
 
 
@@ -588,11 +616,12 @@ def test_pool_persist_log_dedups_across_epochs_and_runs(tiled_store, tmp_path):
     # re-completing the same key. The _recorded gate must prevent a duplicate log line.
     one_slot = int(np.prod(geom.slot_shape(0)) * geom.dtype.itemsize)
     pool = ChunkPool(geoms, backing_dir=backing, persist=True, budget_bytes=one_slot)
-    _fill_chunk(pool, "single_inner", 0, geom, tiles)
-    pool.unpin_all()  # drop the pin so chunk 0 is evictable
-    _fill_chunk(pool, "single_inner", 1, geom, tiles)  # evicts (demotes) chunk 0
-    pool.unpin_all()
-    _fill_chunk(pool, "single_inner", 0, geom, tiles)  # refetch + re-complete chunk 0
+    owner = pool.new_owner()
+    _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)
+    pool.release_owner(owner)  # drop the pin so chunk 0 is evictable
+    _fill_chunk(pool, "single_inner", 1, geom, tiles, owner)  # evicts (demotes) chunk 0
+    pool.release_owner(owner)
+    _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)  # refetch + re-complete chunk 0
     pool.close()
 
     header_plus_entries = logpath.read_text().splitlines()
@@ -600,6 +629,7 @@ def test_pool_persist_log_dedups_across_epochs_and_runs(tiled_store, tmp_path):
 
     # Reopen and re-complete an already-logged chunk: still no new line.
     pool2 = ChunkPool(geoms, backing_dir=backing, persist=True)
+    owner = pool2.new_owner()
     assert pool2.manifest_entries == 2
     pool2.close()
     assert len(logpath.read_text().splitlines()) == 3, "reopen must not duplicate lines"
@@ -616,7 +646,8 @@ def test_pool_close_is_idempotent(tiled_store, tmp_path):
     backing = tmp_path / "cache"
 
     pool = ChunkPool(geoms, backing_dir=backing, persist=True)
-    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    owner = pool.new_owner()
+    _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)
     pool.close()
     assert pool._log is None  # handle released
     pool.close()  # idempotent -- no double-close error on the file handle or slots
@@ -633,7 +664,8 @@ def test_pool_persist_missing_file_is_miss_not_raise(tiled_store, tmp_path):
     backing = tmp_path / "cache"
 
     pool = ChunkPool(geoms, backing_dir=backing, persist=True)
-    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    owner = pool.new_owner()
+    _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)
     pool.close()
 
     # Delete the data file but leave the log referencing it (a torn cache, not eviction).
@@ -641,8 +673,9 @@ def test_pool_persist_missing_file_is_miss_not_raise(tiled_store, tmp_path):
         f.unlink()
 
     pool2 = ChunkPool(geoms, backing_dir=backing, persist=True)
+    owner = pool2.new_owner()
     assert pool2.manifest_entries == 1  # the log still lists the (now-missing) entry
-    assert not pool2.pin_if_ready("single_inner", 0), "a missing .npy is a miss, not a hit"
+    assert not pool2.pin_if_ready("single_inner", 0, owner), "a missing .npy is a miss, not a hit"
     assert pool2.revive_missing == 1 and pool2.hits == 0
     assert ("single_inner", 0) not in pool2._persisted  # the dangling entry is dropped
     pool2.close()
@@ -660,14 +693,17 @@ def test_pool_persist_evicted_chunk_revives_from_kept_file(tiled_store, tmp_path
 
     one_slot = int(np.prod(geom.slot_shape(0)) * geom.dtype.itemsize)
     pool = ChunkPool(geoms, backing_dir=backing, persist=True, budget_bytes=one_slot)
-    _fill_chunk(pool, "single_inner", 0, geom, tiles)
-    pool.unpin_all()  # make chunk 0 evictable
-    _fill_chunk(pool, "single_inner", 1, geom, tiles)  # admits 1 -> demotes 0 (file KEPT)
-    pool.unpin_all()  # make chunk 1 evictable so reviving 0 can free room
+    owner = pool.new_owner()
+    _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)
+    pool.release_owner(owner)  # make chunk 0 evictable
+    _fill_chunk(pool, "single_inner", 1, geom, tiles, owner)  # admits 1 -> demotes 0 (file KEPT)
+    pool.release_owner(owner)  # make chunk 1 evictable so reviving 0 can free room
 
     assert ("single_inner", 0) not in pool._slots  # 0 was evicted from memory
     assert (backing / pool._persisted[("single_inner", 0)]).exists()  # but its file survives
-    assert pool.pin_if_ready("single_inner", 0), "the demoted chunk revives from its kept file"
+    assert pool.pin_if_ready("single_inner", 0, owner), (
+        "the demoted chunk revives from its kept file"
+    )
     assert pool.revive_missing == 0  # nothing was lost by the eviction
     pool.close()
 
@@ -683,13 +719,15 @@ def test_pool_persist_invalidates_on_geometry_mismatch(tiled_store, tmp_path):
     backing = tmp_path / "cache"
 
     pool = ChunkPool(geoms, backing_dir=backing, persist=True)
-    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    owner = pool.new_owner()
+    _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)
     pool.close()
 
     # Reopen with a structurally different dtype for the same array -> mismatch -> miss.
     drifted = {"single_inner": replace(geom, dtype=np.dtype("f8"))}
     pool2 = ChunkPool(drifted, backing_dir=backing, persist=True)
-    assert not pool2.pin_if_ready("single_inner", 0), "geometry drift must invalidate"
+    owner = pool2.new_owner()
+    assert not pool2.pin_if_ready("single_inner", 0, owner), "geometry drift must invalidate"
     assert pool2.revive_mismatch == 1 and pool2.hits == 0  # the mismatch is counted
     pool2.close()
 
@@ -709,11 +747,13 @@ def test_pool_persist_invalidates_on_transform_change(tiled_store, tmp_path):
         return chunk
 
     pool = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[scale_a])
-    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    owner = pool.new_owner()
+    _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)
     pool.close()
 
     same = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[scale_a])
-    assert same.manifest_entries == 1 and same.pin_if_ready("single_inner", 0)  # same fp -> hit
+    # same fp -> hit
+    assert same.manifest_entries == 1 and same.pin_if_ready("single_inner", 0, owner)
     same.close()
 
     def scale_b(chunk):  # different body -> different fingerprint
@@ -738,7 +778,8 @@ def test_pool_persist_reset_stale_cache_gcs_and_rebuilds(tiled_store, tmp_path):
         return chunk
 
     pool = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[scale_a])
-    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    owner = pool.new_owner()
+    _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)
     pool.close()
     stale_file = pool._persisted[("single_inner", 0)]
     assert (backing / stale_file).exists()
@@ -752,7 +793,7 @@ def test_pool_persist_reset_stale_cache_gcs_and_rebuilds(tiled_store, tmp_path):
     )
     assert reset.manifest_entries == 0  # stale cache wiped -> cold start
     assert not (backing / stale_file).exists(), "the stale .npy must be GC'd"
-    assert not reset.pin_if_ready("single_inner", 0)  # nothing to revive -> a miss
+    assert not reset.pin_if_ready("single_inner", 0, owner)  # nothing to revive -> a miss
     reset.close()
 
 
@@ -770,7 +811,8 @@ def test_pool_persist_cache_key_overrides_fingerprint(tiled_store, tmp_path):
 
     t1.cache_key = "v1"  # type: ignore[attr-defined]
     pool = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[t1])
-    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    owner = pool.new_owner()
+    _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)
     pool.close()
 
     def t2(chunk):  # a different object/body, same declared key -> treated as identical
@@ -778,7 +820,7 @@ def test_pool_persist_cache_key_overrides_fingerprint(tiled_store, tmp_path):
 
     t2.cache_key = "v1"  # type: ignore[attr-defined]
     same = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[t2])
-    assert same.pin_if_ready("single_inner", 0)
+    assert same.pin_if_ready("single_inner", 0, owner)
     same.close()
 
     t2.cache_key = "v2"  # type: ignore[attr-defined]  # bump the key -> invalidate (stale -> raise)
@@ -804,7 +846,8 @@ def test_pool_persist_cloudpickle_catches_closure_change(tiled_store, tmp_path):
         return scale
 
     pool = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[make_scaler(2.0)])
-    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    owner = pool.new_owner()
+    _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)
     pool.close()
 
     with pytest.raises(ValueError, match="stale|reset_stale_cache"):  # closure change -> stale
@@ -829,12 +872,13 @@ def test_pool_persist_without_cloudpickle_warns_and_falls_back(
 
     with caplog.at_level(logging.WARNING, logger="insitubatch.pool"):
         pool = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[scale])
+        owner = pool.new_owner()
     assert any("best-effort" in r.message for r in caplog.records), caplog.text
-    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)
     pool.close()
 
     same = ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=[scale])
-    assert same.pin_if_ready("single_inner", 0)  # source hash matches -> hit
+    assert same.pin_if_ready("single_inner", 0, owner)  # source hash matches -> hit
     same.close()
 
 
@@ -847,8 +891,9 @@ def _persist_two(tiled_store, backing):
     geom = geoms["single_inner"]
     tiles = asyncio.run(_decode_tiles(url, "single_inner"))
     pool = ChunkPool(geoms, backing_dir=backing, persist=True)
+    owner = pool.new_owner()
     for cid in (0, 1):
-        _fill_chunk(pool, "single_inner", cid, geom, tiles)
+        _fill_chunk(pool, "single_inner", cid, geom, tiles, owner)
     pool.close()
     return geoms, backing / "insitu_cache.jsonl"
 
@@ -912,8 +957,10 @@ def test_pool_manifest_tolerates_torn_tail(tiled_store, tmp_path):
     with mpath.open("a") as f:
         f.write('{"array": "single_inner", "chunk_ind')  # torn tail, no newline
     pool = ChunkPool(geoms, backing_dir=backing, persist=True)
+    owner = pool.new_owner()
     assert pool.manifest_entries == 2  # both complete entries survived; the torn tail dropped
-    assert pool.pin_if_ready("single_inner", 0) and pool.pin_if_ready("single_inner", 1)
+    assert pool.pin_if_ready("single_inner", 0, owner)
+    assert pool.pin_if_ready("single_inner", 1, owner)
     pool.close()
 
 
@@ -941,7 +988,8 @@ def test_pool_spill_unlinks_without_persist(tiled_store, tmp_path):
     backing = tmp_path / "spill"
 
     pool = ChunkPool(geoms, backing_dir=backing)
-    _fill_chunk(pool, "single_inner", 0, geom, tiles)
+    owner = pool.new_owner()
+    _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)
     pool.close()
     assert not list(backing.glob("*.npy")), "spill must unlink slot files on close()"
     assert not (backing / "insitu_cache.jsonl").exists(), "no manifest without persist"

--- a/tests/test_pool_lifecycle.py
+++ b/tests/test_pool_lifecycle.py
@@ -1,0 +1,272 @@
+"""Slot lifecycle: "safe to take away" must be true, not approximately true.
+
+Regression tests for #33/#34/#35 -- three ways the pool's eviction predicate used to
+lie. They are grouped in one file because they shared a root cause: "may this slot be
+taken away" was spread across five loosely-coupled fields (``remaining``, ``ready``,
+``claimed``, ``error``, ``_pinned``), and each issue was a different field lying.
+
+The predicate now lives in one place -- ``ChunkPool._evictable`` over one ``SlotState``
+plus two counters -- so these tests ask *it* rather than re-implementing it, and a
+future change that reintroduces a second lever fails here.
+
+They are written to fail *loudly and for the stated reason* -- a wrong answer or a
+stale raise, never a hang -- so a regression is legible. End-to-end cases run under the
+``run_by`` deadline for that reason.
+
+Why byte fingerprints rather than "it ran": the failure mode these guard against is a
+consumer reading a slot that was recycled or evicted underneath it. That produces
+*plausible* data, which throughput, shapes, and smoke tests all pass. Only comparing
+delivered bytes against a single-producer reference catches it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import numpy as np
+import pytest
+
+from insitubatch import obstore_store, open_geometries, split_by_chunk
+from insitubatch.pool import ChunkPool
+from insitubatch.source import InSituDataset
+
+DEADLINE = 30.0
+CHUNK_BYTES = 8 * 2 * 2 * 4  # spc * inner * f4, for the write_zarr defaults used here
+
+
+def _dataset(url: str, **kwargs: Any) -> InSituDataset:
+    geom = open_geometries(obstore_store(url))["t2m"]
+    manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
+    return InSituDataset(obstore_store(url), manifest, **kwargs)
+
+
+def _fingerprint(batches: list) -> str:
+    """SHA-256 over delivered bytes, in sample order (shuffle-independent)."""
+    idx = np.concatenate([b.sample_indices for b in batches])
+    out = np.concatenate([b.arrays["t2m"] for b in batches])[np.argsort(idx)]
+    h = hashlib.sha256()
+    h.update(np.ascontiguousarray(out).tobytes())
+    h.update(np.sort(idx).astype(np.int64).tobytes())
+    return h.hexdigest()
+
+
+def _chunk_path(url: str, index: int, inner_dims: int) -> Path:
+    return Path(urlparse(url).path).joinpath("t2m", "c", str(index), *(["0"] * inner_dims))
+
+
+# -- #33: fail() marks a slot ready while tile tasks are still writing ------------
+
+
+def test_failed_chunk_does_not_poison_the_next_epoch(write_zarr, run_by) -> None:
+    """A transient bad chunk must not wedge every later epoch.
+
+    ``fail()`` sets ``ready = True`` (``pool.py:651-656``) so a waiter stops hanging.
+    But ``ready`` is also "safe to cache", so the poisoned slot survives the epoch
+    boundary -- ``unpin_all`` drops only ``not slot.ready`` (``pool.py:531``). Next
+    epoch ``pin_if_ready`` rejects it (``:420``) but ``try_admit`` takes the resident
+    branch (``:375``) and returns True *without refetching*, so ``wait_ready``
+    re-raises the stale error forever.
+
+    Here the corruption is repaired between epochs, so epoch 1 has nothing wrong with
+    it and must succeed. Pre-fix it re-raises epoch 0's error.
+    """
+    url, srcs = write_zarr(n=40, spc=8, inner=(2, 2))
+    chunk = _chunk_path(url, 1, 2)
+    assert chunk.exists(), f"chunk file not found: {chunk}"
+    good_bytes = chunk.read_bytes()
+    chunk.write_bytes(b"\x00\x01\x02\x03")
+
+    ds = _dataset(url, shuffle=False, batch_size=8)
+    ds.set_epoch(0)
+    with pytest.raises(Exception):  # noqa: B017 - codec-specific decode failure
+        list(ds.train)
+
+    chunk.write_bytes(good_bytes)  # the store is healthy again
+
+    # Discriminator: a FRESH pool reads the repaired store fine, so any failure below
+    # is the stale slot, not the data. Without this the test could pass or fail for
+    # the wrong reason (a repair that silently did not take).
+    fresh = _dataset(url, shuffle=False, batch_size=8)
+    fresh.set_epoch(0)
+    assert run_by(DEADLINE, lambda: list(fresh.train)), "repair did not take"
+
+    ds.set_epoch(1)
+    try:
+        batches = run_by(DEADLINE, lambda: list(ds.train))
+    except Exception as exc:  # noqa: BLE001 - the regression IS the stale raise
+        pytest.fail(
+            "epoch 1 re-raised the poisoned slot's stored error instead of refetching "
+            f"the (now repaired) chunk: {exc!r}"
+        )
+    assert ds.cache_misses > 0, (
+        "epoch 1 served the poisoned chunk from the resident slot without refetching: "
+        "try_admit took the resident branch (pool.py:375) and wait_ready re-raised the "
+        "cached exception object"
+    )
+    idx = np.concatenate([b.sample_indices for b in batches])
+    out = np.concatenate([b.arrays["t2m"] for b in batches])[np.argsort(idx)]
+    np.testing.assert_array_equal(out, srcs["t2m"])
+
+
+def test_failed_slot_is_not_evictable_while_tiles_are_outstanding(write_zarr) -> None:
+    """``fail()`` must not make a half-written slot an eviction candidate.
+
+    Unit-level statement of the invariant: after ``fail()``, sibling tile tasks may
+    still be scattering into the slot (``scheduler.py:429-459``), so it is not
+    quiescent and must not be selectable by ``_make_room``. Today ``ready`` is set
+    regardless of ``remaining``, so it is selectable.
+    """
+    geoms = open_geometries(obstore_store(write_zarr(n=40, spc=8, inner=(2, 2))[0]))
+    pool = ChunkPool(geoms, budget_bytes=None)
+    owner = pool.new_owner()
+    key = ("t2m", 0)
+    pool.try_admit("t2m", 0, owner)
+    pool.unpin_keys({key}, owner)  # drop the admit ref: only quiescence protects it now
+    slot = pool._slots[key]
+
+    # An open write scope IS a sibling tile task still running: `writers` counts STARTED
+    # tasks, so the scope is what makes the slot non-quiescent.
+    coord = next(iter(geoms["t2m"].inner_coords()))
+    with pool.tile_write("t2m", 0, coord):
+        assert slot.writers > 0, "the open scope must register an outstanding writer"
+        pool.fail("t2m", 0, ValueError("a sibling tile failed"))
+        # Ask the real predicate, not a copy of it: the whole point of this work is that
+        # "may this be taken away" is answered in exactly one place.
+        assert not pool._evictable(key, slot), (
+            "a failed slot with an outstanding tile task is quiescent-unsafe: the "
+            "sibling is still writing into it, so it must not be evictable"
+        )
+    assert slot.error is not None, "the error must be recorded so a waiter can re-raise"
+    assert not pool.is_ready(*key), "a poisoned chunk must never be published"
+
+
+# -- #34/#35: references are per owner ------------------------------------------
+
+
+def test_one_owners_teardown_leaves_another_owners_pins_intact(write_zarr) -> None:
+    """Releasing one iteration's references must not touch another's.
+
+    The old ``unpin_all()`` cleared the whole map, so with two producers over one pool
+    -- a supported configuration (``buffers.py:238-247``) -- one iteration's epoch
+    boundary stripped the other's pins and its in-use chunks became eviction
+    candidates mid-gather.
+
+    Stated at the pool rather than end to end on purpose. The end-to-end version is a
+    race: a live iteration's producer keeps draining in the background and releases
+    those same pins on its own, so "A's pins vanished" cannot distinguish the bug from
+    A's normal progress (measured: they vanish within ~0.3 s whether or not B ever
+    starts). The byte-level statement is the fingerprint test below.
+    """
+    geoms = open_geometries(obstore_store(write_zarr(n=40, spc=8, inner=(2, 2))[0]))
+    pool = ChunkPool(geoms, budget_bytes=None)
+    a, b = pool.new_owner(), pool.new_owner()
+    shared, a_only, b_only = ("t2m", 0), ("t2m", 1), ("t2m", 2)
+
+    pool.pin_keys({shared, a_only}, a)
+    pool.pin_keys({shared, b_only}, b)
+    assert pool._refs(shared) == 2, "both owners reference the shared chunk"
+
+    pool.release_owner(b)
+
+    assert pool._refs(a_only) == 1, "A's exclusive pin must survive B's teardown"
+    assert pool._refs(shared) == 1, "only B's reference to the shared chunk may go"
+    assert pool._refs(b_only) == 0, "B's own pins must be released"
+
+    pool.release_owner(a)
+    assert pool._pinned == {}, "the last owner's teardown clears the map"
+
+
+def test_another_owners_reference_does_not_satisfy_this_owners_wait(write_zarr) -> None:
+    """#35: ``claimed`` was one bool, so one iteration's claim satisfied another's wait.
+
+    ``wait_ready`` must be satisfied only by *this* owner's reference. With a shared
+    flag A could gather a chunk it never referenced -- and A's later release then
+    decremented B's count, making B's in-use chunk evictable underneath it.
+    """
+    geoms = open_geometries(obstore_store(write_zarr(n=40, spc=8, inner=(2, 2))[0]))
+    geom = geoms["t2m"]
+    pool = ChunkPool(geoms, budget_bytes=None)
+    a, b = pool.new_owner(), pool.new_owner()
+
+    pool.try_admit("t2m", 0, b)  # only B fills and references chunk 0
+    for ic in geom.inner_coords():
+        pool.deliver_tile("t2m", 0, ic, np.zeros(geom.chunks, dtype=geom.dtype))
+    pool.wait_ready("t2m", 0, b)  # B's own wait is satisfied
+
+    waited = threading.Event()
+
+    def wait_as_a() -> None:
+        pool.wait_ready("t2m", 0, a)
+        waited.set()
+
+    t = threading.Thread(target=wait_as_a, daemon=True)
+    t.start()
+    assert not waited.wait(timeout=0.5), (
+        "A's wait_ready returned on a chunk A never referenced: B's claim satisfied it, "
+        "so A would gather a chunk the driver has not pinned for A"
+    )
+    pool.pin_keys({("t2m", 0)}, a)  # now A references it too
+    assert waited.wait(timeout=5), "A's own reference must satisfy A's wait"
+    t.join(timeout=5)
+
+
+# -- #34 + #35 end to end --------------------------------------------------------
+
+
+def test_concurrent_iterations_each_deliver_correct_data(write_zarr, run_by) -> None:
+    """Two interleaved iterations over one pool must each deliver correct bytes.
+
+    The end-to-end statement of #34 (global unpin) and #35 (``claimed`` is one bool,
+    so one iteration's claim satisfies another's ``wait_ready``). The budget is tight
+    enough that admissions must evict, which is what turns a lost pin into a slot
+    recycled underneath a live reader.
+    """
+    url, _ = write_zarr(n=256, spc=8, inner=(2, 2))  # 32 chunks: room to evict
+
+    ref_ds = _dataset(url, shuffle=False, batch_size=8, block_chunks=2)
+    ref_ds.set_epoch(0)
+    expected = _fingerprint(list(ref_ds.train))
+
+    # Tight enough that admissions must evict (32 chunks total), loose enough to hold
+    # both iterations' working sets (~4 chunks each) so a starvation raise cannot
+    # masquerade as the bug under test.
+    ds = _dataset(
+        url,
+        shuffle=False,
+        batch_size=8,
+        block_chunks=2,
+        # Sized for BOTH iterations: two owners each need their working set resident at
+        # once. The old global unpin hid this by spuriously freeing the other's pins, so
+        # a budget that "worked" before was relying on the bug. Measured: two concurrent
+        # iterations over this store deadlock below 32 chunks; one iteration does not.
+        cache_budget_bytes=32 * CHUNK_BYTES,
+    )
+    ds.set_epoch(0)
+
+    def interleaved() -> tuple[str, str]:
+        a, b = iter(ds.train), iter(ds.train)
+        interleaved._a, interleaved._b = a, b  # so teardown can close them deterministically
+        got_a, got_b = [], []
+        while True:
+            done = 0
+            for it, sink in ((a, got_a), (b, got_b)):
+                try:
+                    sink.append(next(it))
+                except StopIteration:
+                    done += 1
+            if done == 2:
+                break
+        return _fingerprint(got_a), _fingerprint(got_b)
+
+    try:
+        fp_a, fp_b = run_by(DEADLINE, interleaved)
+    finally:
+        for it in (getattr(interleaved, "_a", None), getattr(interleaved, "_b", None)):
+            if it is not None:
+                it.close()
+    assert fp_a == expected, "first iteration delivered different bytes when interleaved"
+    assert fp_b == expected, "second iteration delivered different bytes when interleaved"

--- a/tests/test_residency.py
+++ b/tests/test_residency.py
@@ -168,3 +168,49 @@ def test_slow_consumer_is_not_mistaken_for_starvation(small_store, run_by) -> No
     with Scheduler(obstore_store(small_store), geoms, pool, SchedulerConfig()) as sched:
         sched.start(list(range(geom.n_chunks)), geom.sample_chunk_size)
         assert run_by(DEADLINE, lambda: drain(sched)) == geom.n_chunks
+
+
+def test_starvation_names_concurrent_iterations_as_the_cause(small_store, run_by) -> None:
+    """Under-sizing for concurrent iterations must say so, not just "raise the budget".
+
+    Sizing for one iteration is the deliberate default (the engine cannot know how many
+    you intend to run), so the *diagnostic* is what has to carry the cost. Every resident
+    chunk here is legitimately referenced -- by one of two iterations -- which is exactly
+    the case a caller cannot infer from "every one of them pinned or in flight".
+
+    Guards the number too: reporting a count means it has to be the count of distinct
+    owners, not of pins or of resident chunks.
+    """
+    geoms = open_geometries(obstore_store(small_store))
+    geom = geoms["t2m"]
+    manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
+    chunk_bytes = geom.sample_chunk_size * 2 * 2 * 4
+    ds = InSituDataset(
+        obstore_store(small_store),
+        manifest,
+        shuffle=False,
+        batch_size=geom.sample_chunk_size,
+        block_chunks=2,
+        cache_budget_bytes=2 * chunk_bytes,  # fits one iteration, not two
+    )
+    ds.set_epoch(0)
+
+    def interleave() -> None:
+        a, b = iter(ds.train), iter(ds.train)
+        try:
+            for _ in range(geom.n_chunks):
+                next(a)
+                next(b)
+        finally:
+            for it in (a, b):
+                it.close()
+
+    with pytest.raises(RuntimeError, match="residency budget exhausted") as exc:
+        run_by(DEADLINE, interleave)
+
+    msg = str(exc.value)
+    assert "2 iterations are sharing this pool" in msg, (
+        "the diagnostic must name concurrent iterations as the cause -- every chunk is "
+        f"legitimately referenced, so 'raise the budget' alone is not actionable: {msg}"
+    )
+    assert "zip(ds.train, ds.val)" in msg, "point at the pattern that produces this"

--- a/tests/test_residency.py
+++ b/tests/test_residency.py
@@ -144,7 +144,7 @@ def test_starved_admission_raises_instead_of_hanging(small_store, run_by) -> Non
         sched.start(list(range(geom.n_chunks)), geom.sample_chunk_size)
         # Wait on the last chunk and never unpin the earlier ones.
         with pytest.raises(RuntimeError, match="residency budget"):
-            run_by(DEADLINE, lambda: pool.wait_ready("t2m", 7))
+            run_by(DEADLINE, lambda: pool.wait_ready("t2m", 7, sched.owner))
 
 
 def test_slow_consumer_is_not_mistaken_for_starvation(small_store, run_by) -> None:
@@ -159,7 +159,7 @@ def test_slow_consumer_is_not_mistaken_for_starvation(small_store, run_by) -> No
     def drain(sched: Scheduler) -> int:
         n = 0
         for cid in range(geom.n_chunks):
-            pool.wait_ready("t2m", cid)
+            pool.wait_ready("t2m", cid, sched.owner)
             time.sleep(0.25)  # longer than the starvation poll interval
             sched.unpin_block({(geom.path, cid)})
             n += 1

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -47,7 +47,7 @@ def _drain_in_order(sched: Scheduler, geom: ArrayGeometry, var: str, *, unpin: b
     spc = geom.sample_chunk_size
     out = []
     for cid in range(geom.n_chunks):
-        sched.pool.wait_ready(var, cid)
+        sched.pool.wait_ready(var, cid, sched.owner)
         n0 = len(geom.samples_in_chunk(cid))
         rows = np.array([[cid, w] for w in range(n0)], dtype=np.int64)
         out.append(sched.pool.gather(rows, [var], spc).arrays[var])
@@ -127,7 +127,7 @@ def test_scheduler_windowed_views_decode_once_and_lead(tiled_store):
     with _make(url, geoms) as sched:
         fut = sched.start(range(base.n_chunks), base.sample_chunk_size)
         for cid in range(base.n_chunks):
-            sched.pool.wait_ready(base.path, cid)  # slots are keyed by path
+            sched.pool.wait_ready(base.path, cid, sched.owner)  # slots are keyed by path
         batch = sched.pool.gather(rows, ["now", "next"], spc)
         fut.result(timeout=30)  # surface any driver error
         assert len(sched._arrays) == 1  # opened once: deduped by path
@@ -147,4 +147,4 @@ def test_scheduler_poisons_pool_on_driver_failure(tiled_store):
         with pytest.raises(Exception):  # noqa: B017 - zarr surfaces a store-specific error type
             fut.result(timeout=30)
         with pytest.raises(Exception):  # noqa: B017 - same error re-raised to the consumer
-            sched.pool.wait_ready("ghost", 0)
+            sched.pool.wait_ready("ghost", 0, sched.owner)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -492,7 +492,7 @@ def test_a_completed_epoch_leaves_no_block_pinned(
     raise, it would starve the next epoch's admission, which parks on a full budget awaiting
     a release that never comes.
 
-    Asserting that is harder than it looks. ``_iterate`` calls ``pool.unpin_all()`` at the
+    Asserting that is harder than it looks. ``_iterate`` calls ``pool.release_owner(owner)`` at the
     *start* of every epoch precisely to absorb pins an aborted epoch leaked, so any test that
     merely runs two epochs passes whether the frontier released anything or not -- it exercises
     the backstop, not the frontier. So this reads the pin table between epochs, where the

--- a/tests/test_window.py
+++ b/tests/test_window.py
@@ -219,7 +219,7 @@ def test_windowed_partial_iteration_then_clean_epoch(write_zarr) -> None:
 
     # counters/slots clean: all references released, no abandoned not-ready slot.
     assert ds._pool._pinned == {}
-    assert all(slot.ready for slot in ds._pool._slots.values())
+    assert all(ds._pool.is_ready(*k) for k in ds._pool._slots)
     ds.close()
 
 


### PR DESCRIPTION
## Summary

Closes #33, closes #34, closes #35 — three bugs with one root cause. Also closes #38
(the sizing decision and the diagnostic that follows from it; second commit). Eviction eligibility
was `k not in self._pinned and s.ready`, spread across five loosely-coupled fields
(`remaining`, `ready`, `claimed`, `error`, `_pinned`), and each issue is a different field
lying:

- **#33** — `fail()` had to set `ready = True` to wake a waiter, because that was the only
  lever available. That simultaneously declared a half-written slot a finished cache entry
  while sibling tile tasks were still writing into it, *and* left the poisoned slot resident,
  so the next epoch took `try_admit`'s resident branch and re-raised the stale error forever
  instead of refetching.
- **#34** — `unpin_all()` cleared the pin map globally. With two producers over one pool
  (`zip(ds.train, ds.val)`, documented in `buffers.py:238-247`), one iteration's epoch
  boundary stripped the other's pins and its in-use chunks became eviction candidates
  mid-gather.
- **#35** — `claimed` was a single bool, so one iteration's claim satisfied another's
  `wait_ready`. That iteration then gathered a chunk it never referenced, and its release
  decremented someone else's count.

All three produce **plausible** data, which throughput, shapes and smoke tests all pass —
only byte fingerprints catch them.

### The shape

A slot now carries one explicit `SlotState` (`FILLING → ASSEMBLED → READY`, `FAILED`
terminal) advanced in exactly one place (`_advance`), plus two counters that answer one
question each:

- `writers` — tile tasks **running**, so eviction is never racing a live write.
- `pending` — tiles not yet delivered, so completeness is separate from quiescence.

References become owner-scoped (`dict[key, dict[owner, int]]`) and **a reference *is* that
owner's claim**, so `claimed` is deleted. One iteration = one owner, minted by `_iterate` and
shared with its scheduler (`Scheduler.owner`).

Every tile write happens inside `pool.tile_write`, a scope that releases on **every** exit
path — including cancellation at an `await`, which an early `break` triggers via
`cancel_futures=True` and which no explicit call site can cover.

`unpin_all()` splits into `release_owner()` and `reset_epoch_counters()`. Releasing
references and zeroing counters are unrelated jobs on different clocks, and bundling them is
*why* the reset had to unpin globally. Cleanup also moves into `_iterate`'s own teardown, so
an abandoned pass cleans up after itself rather than relying on the next pass's prologue —
which, now that owners are scoped, would be a different owner and could not.

## For reviewers

**Behavior is meant to be unchanged for a single iteration.** The one intended behavioral
change is for concurrent iterations, below.

Most valuable second look, in order:

1. **`ChunkPool._advance`** — the only function that moves state. Worth checking the
   quiesced-but-incomplete case (a cancelled pass leaves an abandoned partial: stays
   `FILLING`, dropped by `release_owner`) and that a `FAILED` slot is deliberately *not*
   dropped there, because a consumer still has to observe the error.
2. **`ASSEMBLED` is load-bearing, not ceremony.** The chunk transform and the persist
   write-back run *outside* the lock between the last tile landing and publication, and
   another thread can observe that window. A predicate derived from a tile counter alone
   would call it evictable. This is the one place the design note's proposed
   `assembled = writers == 0 and error is None` would have introduced a bug.
3. **`writers` counts *started* tasks, not planned ones.** Initialising it to the tile count
   at admit is wrong: a cancelled pass leaves tiles never started, so the slot would never
   quiesce and its budget would never be reclaimable.
4. **`pin_keys` now notifies.** Now that a reference is the claim, pinning can be the event
   that satisfies a parked `wait_ready`; under the old shared flag it never could.

Two notes on the tests:

- The original #34 reproducer asserted that A's pins survive B's prologue. **It was not a
  valid discriminator** — A's own producer releases those pins in the background within
  ~0.3 s whether or not B ever starts (measured), so it would fail with the bug *fixed*. It
  is replaced by a deterministic pool-level test of owner-scoped release; the byte-fingerprint
  test remains the end-to-end statement.
- `deliver_tile` is sugar over `tile_write`, not a second lever — it opens the same scope, so
  the writer count still moves in exactly one place.

### Intended behavioral change: concurrent iterations need a larger budget

Two concurrent iterations now need a budget covering **both** working sets; the concurrent
test went from 20 → 32 chunks. This is not a leak — verified that a *single* iteration grows
peak-pinned to whatever budget it is given and works at every size, unchanged. The old global
unpin was spuriously freeing the other iteration's pins, so any budget that "worked" for
`zip(ds.train, ds.val)` before was relying on the bug.

The auto-sized default is still sized for one iteration, **and that is now the settled
decision** (#38): the engine cannot know how many iterations a caller intends to run, so an
automatic multiplier would silently cost memory in the single-iteration case that is almost
every case. Running several is an explicit choice, so sizing for it is the caller's.

The second commit makes that decision liveable, since the whole cost then falls on the
diagnostic. Starvation previously advised *"raise cache_budget_bytes, or lower batch_size /
block_chunks"* — correct, but not actionable when **every** resident chunk is legitimately
referenced and the caller cannot see why. It now names the cause:

```
... Nothing can free a slot, so this would hang. The working set is larger than the budget it
was sized for -- raise cache_budget_bytes, or lower batch_size / block_chunks. NOTE: 2
iterations are sharing this pool (e.g. `zip(ds.train, ds.val)`, or two DataLoaders); each
needs its own working set resident at once, so the budget must cover all 2.
```

Plus `docs/tuning.md` §"Several iterations at once multiply the budget" with the sizing rule
and why the default is not multiplied, and the same caveat at the auto-sizing site and on the
docstring that advertises the shared-pool configuration — so it is not carried by prose alone.
No example uses `zip(ds.train, ds.val)` as a runnable pattern; the mentions are the docstrings
and tests that advertise it, which is where a reader learns it is supported, so those are what
carry the caveat.

**`active_owners` counts from mint to release, not from first pin.** My first implementation
counted owners currently holding a reference and the note never fired — the second iteration
starves *before* it pins anything, which is exactly the case the message exists for. The test
caught it.

## Author attestation

- [x] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

**Left unchecked deliberately — this was drafted by Claude, and that box is the human
author's to tick.**

## Checklist

- [x] Tests added or updated — `tests/test_pool_lifecycle.py` reproduces all three; confirmed
      failing before the change for the documented reasons
- [x] `uv run ruff check src tests bench examples`, `uv run mypy src bench examples` and
      `uv run pytest -q` are green locally (313 passed, 12 skipped)
- [x] Docstrings and API docs for any new or changed public surface
- [x] User-facing behavior documented in `docs/*.md` — **not done.** The concurrent-iteration
      budget requirement is user-facing and belongs in `docs/tuning.md`; deferred to #38 so the
      guidance and the auto-sizing fix land together rather than documenting a number that is
      about to change.
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] No load-bearing invariant is broken — no hot-path change (the state transition is the
      same lock sections the completion counter already used), `Batch` untouched, parallelism
      still in the event loop
- [x] Touches `ChunkPool`, the scheduler, and cross-thread readiness → free-threaded run
      passes: 80 passed, 1 skipped on 3.13t with `PYTHON_GIL=0` (pool, lifecycle, scheduler,
      residency, prefetch, window); re-run after the second commit, 70 passed / 1 skipped
- No performance claim.


