### PR TITLE
refactor: run on zarr's loop and make the pool's buffer unit the stored chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,16 @@
   shape, which a fixed-shape arena will later need to reuse anything. So residency is
   `n_tiles * chunk_shape`, which exceeds the assembled `slot_shape` wherever the grid does
   not divide the extent: 1.248x on ERA5 721x1440 at 180x360, 1.997x on a short final outer
-  chunk. The budget charges that. Charging the assembled size instead — as the old design
-  did — would let a pool told 2048 MiB resident ~2560 MiB while reporting 2048. Invisible on
-  a grid that divides evenly, which is every store our benchmarks used.
+  chunk. The budget charges that, including on the `chunk_transform` path, which holds the
+  source tiles for its whole fill and only collapses to the assembled output at completion.
+  Charging the assembled size instead — as the old design did — would let a pool told
+  2048 MiB resident ~2560 MiB while reporting 2048. Invisible on a grid that divides evenly,
+  which is every store our benchmarks used.
+
+  A `chunk_transform` still receives the **logical** chunk: assembly clips every tile to its
+  in-bounds region first, so user code never sees stored-chunk padding, never masks an edge,
+  and never has to know the chunk grid. `DecodedChunk` now says so outright, since the pool
+  holding padded tiles internally makes the distinction newly worth stating.
 
 - **`decode_threads` is now a process-wide setting, and says so when ignored.** The decode
   pool outlives every scheduler, so it is sized by the first dataset built in the process; a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,66 @@
 
 ## Unreleased
 
+- **The pool's buffer unit is now the stored chunk, and the scheduler runs on zarr's loop.**
+  Two changes that had to land together, because both rewrite `Scheduler._one`. A slot used
+  to be one assembled ndarray that every decoded tile was memcpy'd into; it is now the
+  decoded tiles themselves, adopted by reference, with placement deferred to `gather`. And
+  orchestration moved from a private per-pass event loop onto zarr's process-global one.
+  What made the second possible was `zarr.core.chunk_utils.ChunkTransform.decode_chunk`
+  (new in zarr 3.3.0) being *synchronous*: the async codec pipeline dispatches to the loop's
+  default executor, so keeping our own decode pool meant claiming that slot — which on a
+  borrowed loop retunes zarr's concurrency process-wide and then breaks it on close. Calling
+  a sync decode ourselves means we never touch it.
+
+  Deleted: the fsspec bridge (`_io`, `_foreign_loop`, `_fsspec_io_loop`) — gcsfs and obstore
+  are now the same inline `await`, because we are already on the loop an async fsspec session
+  binds to; the per-pass loop, scheduler thread and decode pool (three of four execution
+  contexts were rebuilt every epoch); the second executor hop; and the fill-path memcpy.
+  Verified byte-identical on real GCS against both backends, on our zarr-v3 store and on
+  WeatherBench2's zarr-v2.
+
+  **Sold as simplicity, not throughput.** Wall clock is a null in every warm configuration
+  measured on 4 and 16 vCPU; the deleted memcpy is 7.7–10.1% of process CPU and never
+  surfaced, because it was not the bottleneck. Chunked `gather` is *faster* at coarse tile
+  grids (0.83–1.02x at 1–16 tiles per chunk) and slower only at the fine end (1.84–2.20x at
+  256), which restates known chunking guidance rather than indicting the design.
+
+- **A scheduler may no longer tear down anything it shares.** `close()` used to cancel every
+  task on its loop via `asyncio.all_tasks`, then stop and close the loop, then shut down the
+  decode pool. All three were correct while the loop was private and destructive the moment
+  it was not: cancelling the whole task set raises `CancelledError` inside unrelated `zarr`
+  reads in other threads, stopping the loop hangs every later `zarr.core.sync.sync()` call in
+  the process, and shutting the shared pool down makes the next scheduler raise `cannot
+  schedule new futures after shutdown`. The failures are races — the same arm produced them
+  2/3, 3/3 or 0/3 across runs — which is why they are pinned by tests rather than left to
+  review. A scheduler now cancels only the tasks it created and tears down nothing else.
+
+- **Persisted chunks are stored tile-major.** A cache entry's `.npy` now holds
+  `(n_tiles, *tile_shape)` — each stored tile contiguous, in `inner_index` order — instead of
+  one assembled array. File count per chunk is unchanged. This is what keeps one code path:
+  a revived chunk comes back as zero-copy views of the mapping, tiled exactly like a freshly
+  fetched one, so `gather` never asks "assembled or tiled?". Contiguous-on-disk tiles also
+  make a future `decode(out=)` usable on the mmap tier, not just the heap.
+  **Breaking:** the manifest format is bumped to 3, so an existing `cache_dir` is rejected
+  with the usual stale-cache error and rebuilt (`reset_stale_cache=True`, or delete it). A
+  version-2 file read as tile-major would be plausible-looking garbage, so this is refused
+  rather than reinterpreted.
+
+- **A ragged chunk grid is now charged for the padding it actually holds.** A stored chunk
+  decodes whole, and we keep it whole rather than clipping edge tiles — one buffer unit, one
+  shape, which a fixed-shape arena will later need to reuse anything. So residency is
+  `n_tiles * chunk_shape`, which exceeds the assembled `slot_shape` wherever the grid does
+  not divide the extent: 1.248x on ERA5 721x1440 at 180x360, 1.997x on a short final outer
+  chunk. The budget charges that. Charging the assembled size instead — as the old design
+  did — would let a pool told 2048 MiB resident ~2560 MiB while reporting 2048. Invisible on
+  a grid that divides evenly, which is every store our benchmarks used.
+
+- **`decode_threads` is now a process-wide setting, and says so when ignored.** The decode
+  pool outlives every scheduler, so it is sized by the first dataset built in the process; a
+  later, different value is ignored with a warning rather than silently. Thread count is a
+  property of the machine, not of a dataset, so one number per process is the honest shape —
+  and two datasets in one process should not run two pools competing for the same cores.
+
 - **Under-sizing the budget for concurrent iterations now says so.** One `InSituDataset`
   owns one chunk pool and every active iteration shares it — `zip(ds.train, ds.val)`, or
   two `DataLoader`s — but each holds its *own* chunk references, so residency is the sum

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -287,11 +287,18 @@ runs a single budget over it:
 
 - **ReadPlan v2**: deduped stored-chunk reads in draw/priority order.
 - **One semaphore = `max_inflight`** — a slot held from fetch-start to
-  scatter-done, spanning all stages, across inner *and* outer. No nested caps, no
+  delivery, spanning all stages, across inner *and* outer. No nested caps, no
   double sawtooth; total concurrency is dialed directly.
-- **Scatter-assemble**: each decoded tile is copied into its outer chunk's array
-  (pool threads write *disjoint* regions — no data lock, only an atomic completion
-  counter); the tile frees after the copy.
+- **Chunked slots**: a slot's buffer unit is the **stored chunk**. A decoded tile is
+  adopted by reference — no memcpy — and `gather` places each tile into its
+  sub-rectangle of the batch, addressed by zarr's own `ChunkProjection` over a
+  `DimensionGrid`. Stored chunks are kept **whole**, padding included: one buffer unit,
+  one shape. Superseded scatter-assemble (each tile copied into one assembled array)
+  under [#30](https://github.com/emfdavid/insitubatch/issues/30); assembly survives only
+  where something genuinely needs a contiguous array — a `chunk_transform`, which then
+  republishes as a one-tile slot so `gather` still sees a single representation.
+  Argued and merged on **simplicity, not throughput**: the deleted memcpy is 7.7–10.1% of
+  process CPU and wall clock is a null, because it was never the bottleneck.
 - **Two explicit caps**: ≤ `block_chunks` (+read-ahead) outer chunks resident
   (shuffle window); ≤ `max_inflight` inner tiles in flight (pipeline).
 
@@ -299,6 +306,8 @@ Internals are **validated** (`bench/spike_v2_decode.py`, zarr 3.2): key via
 `chunk_key_encoding.encode_chunk_key`, bytes via `store.get`, decode via
 `codec_pipeline.decode([(buf, ArraySpec)])`, scatter into the outer array — matches
 `arr.getitem` exactly for single-inner and spatial layouts incl. partial edge chunks.
+(Decode is now the *synchronous* `ChunkTransform.decode_chunk`, verified byte-identical to
+that pipeline on v3 zstd/none/gzip and on v2; the scatter is gone with chunked slots.)
 The acceptance gate (v1 baseline vs V2, and the flat-residency result that justified
 the rewrite) is recorded in [docs/benchmarks.md](docs/benchmarks.md).
 
@@ -308,8 +317,10 @@ All three steps release the GIL — **fetch** (obstore/tokio, Rust), **decode**
 (numcodecs C), **transform** (vectorized numpy) — so all three run *off* the loop,
 in the bounded pool; the loop only does async fetch + scheduling. Fuse
 decode→transform→scatter into **one** pool task per chunk (one GIL-release window,
-no inter-stage handoff). Transform granularity is the wrinkle, since fetch is at
-*tile* granularity but the `chunk_transform` contract is *per outer chunk*:
+no inter-stage handoff). The scatter half of that is now moot — there is no copy to fuse,
+because the tile *is* the resident buffer. Transform granularity is the wrinkle that
+remains, since fetch is at *tile* granularity but the `chunk_transform` contract is
+*per outer chunk*:
 
 - **elementwise** transforms (e.g. `StandardScaler`) may fuse per tile — earliest
   overlap, lowest peak.
@@ -329,8 +340,9 @@ shuffle_span     = block_chunks
 ```
 
 So `block_chunks` sets shuffle quality + residency; `max_inflight` sets network
-saturation — separately. (Transform output may differ in shape — regrid — so the
-pool slot is sized to the *output*; the input tile frees after.) The honest limit:
+saturation — separately. (Transform output may differ in shape — regrid — so a
+transformed slot is sized to the *output* and publishes as one tile; the source tiles free
+at completion.) The honest limit:
 in-flight memory is `max_inflight × stored_chunk` — cheap when data is inner-chunked
 (small tiles), but for *single-inner* data the stored chunk **is** the outer chunk,
 so concurrency and memory collapse back together (no scheduler escapes it; rechunk
@@ -894,12 +906,15 @@ measurements live in [docs/benchmarks.md](docs/benchmarks.md).
   rests entirely on the **Rapid/zonal gRPC** path obstore cannot reach — still unrun,
   blocked on quota. If it matches or beats obstore there, fsspec earns a core-dep,
   co-equal-fast-path promotion; then the `ops_gcp.md` VERIFY markers come off.
-  Event-loop ownership is shipped and diagrammed in
-  [docs/architecture.md](docs/architecture.md); the follow-up is to run the scheduler's
-  orchestration *on* zarr's loop for all backends and delete the bridge plus the per-pass
-  thread churn. That rewrites the Scheduler concurrency core, so its acceptance gate is a
-  stress test that a consumer-stalled, back-pressured `_drive` sharing zarr's
-  process-global loop cannot starve or deadlock other zarr-sync work.
+  Event-loop consolidation is **done** ([#30](https://github.com/emfdavid/insitubatch/issues/30)):
+  orchestration runs on zarr's loop for all backends, and the bridge, the per-pass thread
+  churn and the second executor hop are deleted — diagrammed in
+  [docs/architecture.md](docs/architecture.md). The acceptance gate (a consumer-stalled,
+  back-pressured `_drive` must not starve other zarr-sync work) passes: ~5,700 unrelated
+  zarr reads complete during the stall at p50 1.69–1.77 ms vs 1.74–1.80 ms on a private
+  loop. The gate as originally written turned out to ask the wrong question — every real
+  failure was in `close()`, not steady state — so it is now also a teardown test
+  (`tests/test_loop_ownership.py`).
 - **M2 — GPU full scale** ⏳ kvikio/cupy/nvCOMP, dlpack→torch; prove GPU saturation with
   bounded host memory. The reference design is to transfer *compressed* bytes and decode on
   the GPU via zarr-python's own GPU codec pipeline rather than hand-rolling nvCOMP; the

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -355,7 +355,7 @@ Once V2 manages the slots itself, the assembly buffer **is** a pool of prepped
 the shuffle-block buffer and the chunk cache collapse into one **`ChunkPool`**
 parameterized by:
 
-- **backing** — heap (numpy) *or* mmap'd `.npy` on NVMe; the scatter writes straight
+- **backing** — heap (the adopted tile) *or* mmap'd `.npy` on NVMe, stored tile-major; delivery writes straight
   into the slot either way. mmap keeps **anon** (real pressure) low while pages stay
   reclaimable (the anon/file split we measure).
 - **policy** — a byte budget + eviction. Epoch-last-use with `budget = block_chunks`
@@ -380,8 +380,8 @@ recovers) + a chunk-transform fingerprint, revived on reopen.
 | `store.py` | per-backend `Store` constructors (`obstore_store`, `fsspec_store`, `arraylake_store`) + geometry introspection |
 | `shuffle.py` | chunk permutation + shuffle-block / sequential order + quality metric |
 | `plan.py` | `build_stored_chunk_reads` — a draw order's chunks → deduped stored-chunk (tile) reads for the scheduler |
-| `scheduler.py` | `Scheduler` — one `max_inflight` budget over stored-chunk reads; fetch→decode→scatter; residency admission |
-| `pool.py` | `ChunkPool` — the assembly buffer *and* the cache: byte budget + pin/unpin + LRU, heap or mmap'd-`.npy` backing (try_admit/scatter/wait_ready/gather/unpin) |
+| `scheduler.py` | `Scheduler` — one `max_inflight` budget over stored-chunk reads; fetch→decode→deliver, on zarr's loop; residency admission |
+| `pool.py` | `ChunkPool` — the residency tier *and* the cache: byte budget + pin/unpin + LRU, heap or mmap'd-`.npy` backing (try_admit/tile_write/wait_ready/gather/unpin) |
 | `source.py` | `InSituDataset` — framework-neutral iterable of numpy `Batch`; prefetch producer over the scheduler+pool, block-granular eviction (inherits nothing) |
 | `frameworks.py` | thin optional DLPack adapters over the numpy `Batch`: `as_torch` (DataLoader subclass), `to_jax`, `to_tf` / `as_tf_dataset` (from_generator) |
 | `transforms.py` | chunk/batch transform hooks, `StandardScaler` (chunk-stage applier; fit over the loader — see `examples/fit_scaler.py`) |
@@ -736,7 +736,7 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   cheaper than adopting a second implementation.
 
   **Expected upside is smaller than the headline.** We call `codec_pipeline.decode`
-  directly (`scheduler.py`) with our own `store.get` and our own scatter, so most of that
+  directly (`scheduler.py`) with our own `store.get` and our own delivery, so most of that
   ~1.9× zarr-python overhead is *already bypassed*. What a Rust pipeline could still win
   for us is the decode call itself plus its buffer handling — a fraction of 3.5×, and
   worth measuring precisely because we cannot infer it from these numbers.
@@ -758,14 +758,14 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   kill the threaded overlap). Treat free-threaded 3.13t as *upside*, not a
   dependency; still must win on stock CPython via async + coalescing.
   - **Validated on 3.13t (B1):** the engine runs correctly GIL-free — the pool's
-    disjoint lock-free scatter + lock-published readiness hold under true parallel
+    non-colliding lock-free delivery + lock-published readiness hold under true parallel
     execution (`test_pool_concurrent_scatter_is_race_free`, the `test-freethreaded`
     CI job). **Caveat (running FT cleanly is gated upstream, not by us):** `numcodecs`
     has not yet declared itself GIL-safe, so importing the codec stack *re-enables*
     the GIL on 3.13t. We override with `PYTHON_GIL=0` (its codecs already release the
     GIL, so this is safe in practice). What numcodecs shipping `Py_MOD_GIL_NOT_USED`
     would buy is running FT *without* the override — **not a speedup**: throughput is
-    GIL-independent by design (fetch/decode/scatter all release the GIL, scheduling is
+    GIL-independent by design (fetch/decode/gather all release the GIL, scheduling is
     one asyncio loop), so 3.13t *matches* the GIL build rather than beating it. Decode
     even parallelizes under the GIL (zstd releases it — the `decode_threads` sweep
     scales on the GIL build). The 3.13t value is correctness + future-proofing; *not
@@ -800,7 +800,7 @@ status, reviewers, or dates; that state lives outside this repo and goes stale h
   integer arithmetic, not complexity worth outsourcing — and consuming `iter_chunk_transforms`
   on the hot path would *add* surface (a `DimensionGridLike` adapter, a per-selection
   transform allocation) while forcing us to discard its `out_indices` scatter map, which is
-  the exact thing our scatter-into-slots design removes. So today it changes nothing.
+  the exact thing our deliver-into-slots design removes. So today it changes nothing.
 
   **There is no adoption trigger from sample indexing — the fancy path is the anti-pattern,
   not a future engine.** It is tempting to read the package's `ArrayMap` `oindex`/`vindex`
@@ -834,11 +834,13 @@ status, reviewers, or dates; that state lives outside this repo and goes stale h
   [#3060](https://github.com/zarr-developers/zarr-python/issues/3060), under the
   codec-pipeline umbrella [#2904](https://github.com/zarr-developers/zarr-python/issues/2904))
   — decoding N chunks directly into N offset slices of one caller-provided buffer. Our
-  decode→slot path is already zero-copy except for **one intentional memcpy** in
-  `scatter` (`buffer[dst] = tile[src]`); a batched `out=` signature removes exactly that
-  copy by letting the codec write into the pool slot itself. The relevant requirement we
-  carry upstream is that the API be **batched** (N chunks → one buffer), not per-chunk —
-  a per-chunk `out=` leaves the loop-overhead shape unchanged. The decode-side
+  decode→slot path is now zero-copy: chunked slots adopt the decoded tile, so the memcpy
+  a per-chunk `out=` would have removed is already gone. What `out=` buys us instead is
+  **whose allocation it is** — today we adopt numcodecs', which is why the buffer arena
+  ([#36](https://github.com/emfdavid/insitubatch/issues/36)) has nothing to recycle and
+  is blocked on this. The relevant requirement we carry upstream is that the API be
+  **batched** (N chunks → one buffer), not per-chunk — a per-chunk `out=` leaves the
+  loop-overhead shape unchanged. The decode-side
   implementation is ours to write once a signature is agreed.
 
 Also relevant but monitor-only: `Store` read-into-buffer proposals help mainly on the

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ running a *synchronous* `__getitem__`. Against cloud Zarr that means no shared
 chunk cache (every worker re-reads the same chunk), no way to drive async
 obstore, and dask thread pools nested inside forked workers. `insitubatch`
 **inverts** it: one async event loop streams stored chunks under a single
-concurrency budget and scatters them into a bounded pool that assembles batches —
-the pool doubles as the cache; torch runs `num_workers=0`.
+concurrency budget into a bounded pool that holds them and assembles batches on
+demand — the pool doubles as the cache; torch runs `num_workers=0`.
 
 The payoff is a **two-regime** story against the worker-process `DataLoader`. On a
 **well-chunked** store it **matches a hand-tuned worker/xbatcher pool** (swept to 32 workers)
@@ -66,8 +66,9 @@ chunk once. Full numbers + methodology:
 
 The engine is the **decoupled fetch scheduler**: reads flatten to *stored chunks*
 under one `max_inflight` budget (no nested inner/outer concurrency caps), decoded
-tiles scatter into a **`ChunkPool`** that is the assembly buffer *and* the cache
-(byte budget + pin/LRU, heap or mmap-on-NVMe). **Read concurrency and
+stored chunks are adopted **by reference** into a **`ChunkPool`** that is the
+residency tier *and* the cache (byte budget + pin/LRU, heap or mmap-on-NVMe); `gather`
+places each one straight into its rectangle of the batch. **Read concurrency and
 residency/shuffle span are independent dials** — the decoupling reaches ~1 GB/s at
 flat, low memory (validated on S3; see below). Built: planner + chunk-aligned
 splits, async obstore reads, the scheduler + pool (with **decode-once caching**,
@@ -129,10 +130,11 @@ the same is enforced in CI.
 
 ### Free-threaded (3.13t)
 
-The engine is free-threading-correct by construction: the `ChunkPool`'s scatter
-does its disjoint copy **before** the lock and publishes readiness **under** it, so
-the lock — not the GIL — is the happens-before edge to the consuming gather. The
-race probe is `test_pool_concurrent_scatter_is_race_free` (64 tiles, 32 threads).
+The engine is free-threading-correct by construction: a delivering thread does its
+write **before** the lock — each tile is its own key, so writers never collide — and
+publishes readiness **under** it, so the lock, not the GIL, is the happens-before edge
+to the consuming gather. The race probe is
+`test_pool_concurrent_scatter_is_race_free` (64 tiles, 32 threads).
 
 Run the suite GIL-free on a free-threaded interpreter:
 
@@ -152,7 +154,7 @@ PYTHON_GIL=0 UV_PROJECT_ENVIRONMENT=.venv-ft uv run --python 3.13t pytest -q
 
 CI mirrors this: a `{3.12, 3.13}` matrix plus a `3.13t` job that asserts the GIL is
 actually off before testing. Throughput is **GIL-independent by design** — fetch
-(obstore/Rust), decode (numcodecs zstd, C), and scatter/gather (vectorized numpy) all
+(obstore/Rust), decode (numcodecs zstd, C), and gather (vectorized numpy) all
 release the GIL — so 3.13t runs at the **same speed** as the GIL build, not faster. The
 free-threading work is **correctness + future-proofing, not a speedup**; *not depending*
 on the GIL is the point (see [DESIGN.md](DESIGN.md)).

--- a/bench/_profile.py
+++ b/bench/_profile.py
@@ -2,10 +2,10 @@
 
 Sampling (not deterministic, unlike yappi/cProfile) so it barely perturbs the
 threading we want to study, and ``--native`` reaches into Rust and C -- the
-obstore/tokio fetch and the numcodecs decode + numpy scatter memcpy -- exactly
-the parts a Python-level profiler cannot see. py-spy samples *all* threads of the
-target, so the named threads (``insitu-sched`` / ``insitu-dec`` / ``insitu-prefetch``)
-show up as distinct stacks.
+obstore/tokio fetch, the numcodecs decode, and the numpy gather -- exactly the parts
+a Python-level profiler cannot see. py-spy samples *all* threads of the target, so the
+decode pool (``insitu-dec``), the producer (``insitu-prefetch``) and zarr's shared loop
+thread (``zarr_io``, where orchestration runs) show up as distinct stacks.
 
 Attach model: py-spy uses ptrace, and here it is a *child* attaching to its
 parent (this process). Under the common ``kernel.yama.ptrace_scope=1`` a child may

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,41 +130,104 @@ per-batch allocation *and* enables `non_blocking` transfer together. See Known
 limitations in
 [DESIGN.md](https://github.com/emfdavid/insitubatch/blob/main/DESIGN.md#known-limitations--defects).
 
-### Event-loop ownership (fsspec backends)
+### One event loop, one decode pool
 
 A genuinely-async fsspec backend (gcsfs, s3fs) binds its aiohttp session to the *first
 event loop that awaits it*, permanently — no constructor knob pins it. For a zarr store
 that first loop is **zarr's** process-wide store-IO loop (`zarr.core.sync._get_loop()`),
 because any zarr sync call (`open_geometries`, `xr.open_zarr`, user code) touches the
 store first. That is the correct owner: the session living on zarr's loop is what keeps
-the store drivable by *any* zarr code — so insitubatch **conforms** (routes its reads
-there) rather than hijacking the session onto its own loop, which would break every other
-zarr-sync consumer in the process. The scheduler keeps its own orchestration loop and
-bridges each fsspec read to zarr's loop (`run_coroutine_threadsafe`); obstore is
-loop-agnostic (Rust runtime) and is awaited inline. Teardown closes the session on its own
-loop (`close_store`), so gcsfs's finalizer — which wrongly targets
-`fsspec.asyn.get_loop()` — becomes a no-op.
+the store drivable by *any* zarr code.
+
+**insitubatch runs its orchestration on that loop too.** There is no second loop, no
+per-read bridge, and no per-pass thread churn: gcsfs and obstore are both a plain inline
+`await`. What made this possible is that
+[`ChunkTransform.decode_chunk`](https://zarr.readthedocs.io/) (zarr 3.3.0) is
+*synchronous*. The async codec pipeline dispatches to the **loop's default executor**, so
+keeping our own decode pool used to mean claiming that slot — which on a loop we share
+retunes zarr's concurrency process-wide, and breaks it when we shut the pool down. Calling
+a sync decode ourselves means we pass our executor explicitly and never touch the default.
 
 ```mermaid
 flowchart TD
-    subgraph proc["insitubatch process (one training run)"]
+    subgraph proc["insitubatch process"]
       OG["any zarr sync call<br/>open_geometries / xr.open_zarr"]
-      SL["Scheduler loop<br/>own loop, new thread per pass<br/>orchestration + decode/scatter pool"]
-      ZL["zarr store-IO loop<br/>zarr.core.sync._get_loop()"]
+      ZL["zarr store-IO loop (zarr_io)<br/>zarr.core.sync._get_loop()<br/><b>scheduler orchestration runs here</b>"]
+      DP["insitu-dec pool<br/>process-wide, N threads<br/>decode (GIL released)"]
       SESS[("gcsfs aiohttp session")]
       OBS["obstore ObjectStore<br/>Rust tokio runtime, loop-agnostic"]
-      FL["fsspec.asyn.get_loop()<br/>NOT where the session lives"]
     end
     OG -->|"first await creates the session here"| ZL
     ZL -->|owns| SESS
-    SL -->|"fsspec read: run_coroutine_threadsafe (bridge)"| ZL
-    SL -->|"obstore read: await inline"| OBS
-    FL -.->|"gcsfs finalizer wrongly targets this;<br/>close_store fixes the mismatch at teardown"| SESS
+    ZL -->|"fsspec read: await inline (no bridge)"| SESS
+    ZL -->|"obstore read: await inline"| OBS
+    ZL -->|"run_in_executor(decode_pool, decode_chunk)"| DP
+    DP -->|"NDBuffer handed back by reference"| ZL
 ```
 
-Collapsing the two loops into one — running the scheduler's orchestration *on* zarr's
-loop for all backends, deleting the bridge and the per-pass thread churn — is planned
-under M-GCS in [DESIGN.md](https://github.com/emfdavid/insitubatch/blob/main/DESIGN.md).
+#### The handoff, per stored tile
+
+`loop.run_in_executor(pool, fn, *args)` submits to the pool and wraps the resulting
+future; the coroutine `await`s it and **suspends**, so the loop is free to service other
+tiles, other in-flight reads, and everyone else's zarr work. The worker resolves the
+future via `call_soon_threadsafe`. What crosses the boundary is a Python object reference
+— no copy, no pickling; it is a thread boundary, not a process one.
+
+```
+insitu-prefetch          zarr_io  (ONE loop, shared with all zarr sync work)   insitu-dec (N)
+     │                       │                                                      │
+     │                  _drive ──► _admit ──► pool.try_admit    [_cv, brief]         │
+     │                  _one, holding one `max_inflight` permit:                     │
+     │                       │                                                      │
+     │                  ① await store.get(key) ──── obstore / gcsfs, inline ──┐      │
+     │                       │   coroutine SUSPENDS, loop runs other tasks    │      │
+     │                       │◄───────────────────────── Buffer ─────────────┘      │
+     │                       │                                                      │
+     │                  ② await run_in_executor(pool, decode_chunk, buf, spec)       │
+     │                       │──── submit ─────────────────────────────────────────►│
+     │                       │   coroutine SUSPENDS                   decode_chunk   │
+     │                       │                                   (GIL RELEASED in    │
+     │                       │                                    numcodecs)         │
+     │                       │◄── call_soon_threadsafe ── NDBuffer ─────────────────│
+     │                       │                                                      │
+     │                  np.moveaxis(tile, ax, 0)   [a VIEW, no copy]                 │
+     │                       │                                                      │
+     │                  ③ deliver:                                                   │
+     │                       │  tiled     → w.deliver(tile) INLINE  [dict + _cv]     │
+     │                       │  assembling→ await run_in_executor(...) ─────────────►│
+     │                       │                              _advance → assemble →    │
+     │                       │                              chunk_transform → persist│
+     │                       │◄────────────────── done ─────────────────────────────│
+     │◄── _cv.notify_all() wakes wait_ready ──┘
+   gather
+```
+
+Delivery is inline on the tiled path because it is a dict write and a counter. It becomes
+an executor hop when the pool **assembles**, because delivering the last tile also runs
+the assembly memcpy, the user `chunk_transform` and the mmap write-back — and none of that
+may sit on a loop shared with the rest of the process.
+
+`max_inflight` is what bounds the executor: a `ThreadPoolExecutor` queue is unbounded, and
+the semaphore is held across ①②③, so in-flight tiles, queued decode work and decoded-tile
+residency are all bounded by that one dial.
+
+#### Sharing a loop means owning nothing
+
+A scheduler tears down **only what it created**. It cancels the tasks it started (never
+`asyncio.all_tasks`, which is the whole loop's set), and it does not stop the loop, close
+it, or shut down the decode pool. Each of those is correct on a private loop and
+destructive on a shared one — cancelling the task set raises `CancelledError` inside
+unrelated zarr reads, stopping the loop hangs every later `zarr.core.sync.sync()` call,
+and shutting the shared pool down makes the next scheduler raise *cannot schedule new
+futures after shutdown*. All three were observed while designing this, are pinned by
+`tests/test_loop_ownership.py`, and are why the acceptance gate for sharing a loop is a
+`close()` test rather than a steady-state one.
+
+Measured: with a consumer-stalled, back-pressured `_drive`, unrelated zarr-sync work
+completes ~5,700 reads during the stall at p50 1.69–1.77 ms, against 1.74–1.80 ms for a
+private per-pass loop — no starvation, no deadlock, and the victim keeps running through
+teardown. Teardown also closes the fsspec session on its own loop (`close_store`), so
+gcsfs's finalizer — which wrongly targets `fsspec.asyn.get_loop()` — becomes a no-op.
 
 ## Sample geometry — the axis-role contract
 
@@ -379,8 +442,9 @@ The pipeline holds two guarantees, and they are **orthogonal** — batch size to
 `order` is the ledger for sample-once: an `(N, 2)` array of `[chunk_id, within]`, one row per
 drawn sample. It is a permutation of every valid anchor, so each sample appears once. The
 **sample-level fancy index is never stored** — `gather` recomputes it per batch from the rows
-(`anchor = chunk_id·spc + within`; `sample = anchor + offset`; scatter `slot.data[within[mask]]`
-per unique read chunk), Python work `O(chunks-in-batch)`, never `O(samples)`.
+(`anchor = chunk_id·spc + within`; `sample = anchor + offset`; then, per unique read chunk,
+one coalesced write per stored tile into its sub-rectangle of the batch), Python work
+`O(chunks-in-batch × tiles-per-chunk)`, never `O(samples)`.
 
 The figure traces one epoch, archive → batch. Colour tracks the *bytes* — a chunk keeps its
 colour from the archive ① through the resident pool ③; the **read plan** ② in between is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,7 +221,15 @@ legible to zarr rather than being a private dict of ndarrays:
 | `ArrayGeometry.tile_placement` | returns a `zarr.core.indexing.ChunkProjection` — `chunk_coords`, `chunk_selection`, `out_selection`, `is_complete_chunk` |
 | the sync decode | `zarr.core.chunk_utils.ChunkTransform.decode_chunk` — so we do not maintain a codec whitelist |
 | `ArrayGeometry` inner grid | conforms to `DimensionGridLike` (proven in `tests/test_zarr_indexing_parity.py`) |
-| a `_Slot` | a **decoded shard** — zarr's word for one addressable unit made of a grid of inner chunks |
+
+A `_Slot` deliberately has **no** zarr counterpart. It is a *residency* unit — the stored
+chunks sharing one sample-axis index — whereas a zarr **shard** is a *storage* unit, one
+addressable object holding a grid of chunks. They have the same shape, which makes the
+analogy tempting and wrong: a slot is never stored or addressed as one object. What this
+codebase calls a *tile* is what its public API calls a **stored chunk** (one zarr chunk,
+or one zarr shard on a sharded array — whatever a single `store.get` returns); that
+duplication is tracked in
+[#40](https://github.com/emfdavid/insitubatch/issues/40), not fixed here.
 
 Two zarr facilities are deliberately *not* adopted. `FusedCodecPipeline.read_sync` takes
 `ByteGetter`s and therefore **owns the IO**, which would surrender the scheduler,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -211,6 +211,25 @@ may sit on a loop shared with the rest of the process.
 the semaphore is held across ①②③, so in-flight tiles, queued decode work and decoded-tile
 residency are all bounded by that one dial.
 
+#### Built on zarr's abstractions
+
+The pool speaks zarr's own vocabulary for "a grid of inner chunks", so the structure stays
+legible to zarr rather than being a private dict of ndarrays:
+
+| ours | zarr |
+|---|---|
+| `ArrayGeometry.tile_placement` | returns a `zarr.core.indexing.ChunkProjection` — `chunk_coords`, `chunk_selection`, `out_selection`, `is_complete_chunk` |
+| the sync decode | `zarr.core.chunk_utils.ChunkTransform.decode_chunk` — so we do not maintain a codec whitelist |
+| `ArrayGeometry` inner grid | conforms to `DimensionGridLike` (proven in `tests/test_zarr_indexing_parity.py`) |
+| a `_Slot` | a **decoded shard** — zarr's word for one addressable unit made of a grid of inner chunks |
+
+Two zarr facilities are deliberately *not* adopted. `FusedCodecPipeline.read_sync` takes
+`ByteGetter`s and therefore **owns the IO**, which would surrender the scheduler,
+`max_inflight` and back-pressure; `decode_chunk` is IO-free, which is why it is the one we
+use. And the process-global `codec_pipeline.path` is never flipped — that retunes the
+substrate under user code — so we build our own `ChunkTransform` from the array's declared
+codecs, which is also what keeps zarr-v2 (`V2Codec(filters, compressor)`) working.
+
 #### Sharing a loop means owning nothing
 
 A scheduler tears down **only what it created**. It cancels the tasks it started (never

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,9 +94,9 @@ flowchart TB
         SKIP -->|"miss"| OBS["obstore get (stored chunk)"]
         OBS --> DEC["decode · GIL released"]
         DEC --> CT["chunk_transform (vectorized)"]
-        CT --> SCAT["scatter tile → outer-chunk slot"]
+        CT --> DLV["deliver: adopt the tile (no copy)"]
     end
-    SCAT --> POOL["ChunkPool — byte budget + pin/LRU<br/>buffer AND cache · heap or mmap NVMe"]
+    DLV --> POOL["ChunkPool — byte budget + pin/LRU<br/>residency AND cache · heap or mmap NVMe"]
     POOL --> GTH["gather + batch_transform"]
     GTH --> PQ["prefetch queue · depth d"]
     PQ --> GPU[("device + device_transform<br/>→ model step")]
@@ -109,9 +109,11 @@ flowchart TB
 
 The unit of work is the **stored chunk** (an `(outer, inner)` tile), and one
 `max_inflight` budget spans every fetch — so read concurrency is one dial, with no
-nested inner/outer caps. Each decoded tile is scattered into its outer chunk's slot
-in the **ChunkPool**, which is the assembly buffer *and* the cache in one: a byte
-budget with pin/unpin + LRU, backed by heap or an mmap'd `.npy` on NVMe. Before
+nested inner/outer caps. Each decoded tile is **adopted by reference** into its outer
+chunk's slot in the **ChunkPool** — the tile *is* the resident buffer, so the fill path
+has no memcpy — and the pool is the residency tier *and* the cache in one: a byte budget
+with pin/unpin + LRU, backed by heap or an mmap'd `.npy` on NVMe. Placement is deferred to
+`gather`, which writes each stored chunk straight into its rectangle of the batch. Before
 fetching, the scheduler asks the pool whether it already holds a chunk — a hit
 (cross-epoch, since the pool persists) skips fetch + decode + transform entirely.
 
@@ -703,7 +705,7 @@ print(ds.bad_chunks)   # the (array, chunk_index, inner_coord) reads that were b
 ```
 
 Granularity is the **stored** chunk (tile), so one corrupt inner tile NaNs only its
-region of the outer chunk, not the whole field. A failure *during scatter* (a genuine
+region of the outer chunk, not the whole field. A failure *during delivery* (a genuine
 bug, not a bad chunk) still poisons — the policy only covers fetch/decode. Dropping
 NaN-containing *samples* is deliberately not automatic (it would break the fixed-shape
 vectorized gather); exclude known-bad chunks at the split/manifest level instead
@@ -795,8 +797,8 @@ object, the `ChunkPool`, parameterized by a byte budget:
 
 | layer | reuse scope | how |
 |---|---|---|
-| read-plan dedup | within a request | a chunk's tiles are fetched once, scattered into one slot |
-| assembly buffer | within an epoch | a small budget (the working set, ~2 blocks) |
+| read-plan dedup | within a request | a chunk's tiles are fetched once, held by one slot |
+| residency | within an epoch | a small budget (the working set, ~2 blocks) |
 | cache | across epochs | a large budget retains drained chunks |
 
 A chunk is **pinned** while the current epoch needs it; once its shuffle-block is
@@ -808,9 +810,9 @@ whose samples scatter across a shuffle block). Raise the budget past the working
 and drained chunks linger, so a still-resident prepped chunk is a cross-epoch hit:
 the same machinery becomes the cache by *"don't evict."*
 
-Backing is **heap or mmap** (`cache_dir` → mmap'd `.npy` on local NVMe): the scatter
-writes straight into the slot either way, so a hit needs no copy out of a separate
-cache. mmap makes the footprint reclaimable kernel page cache, bounded on disk by
+Backing is **heap or mmap** (`cache_dir` → mmap'd `.npy` on local NVMe): a heap slot
+adopts the decoded tile, and the mmap tier writes it straight into its tile-major slice and
+keeps the view — so a hit needs no copy out of a separate cache either way. mmap makes the footprint reclaimable kernel page cache, bounded on disk by
 bytes, so the working set stays bounded. Caching the *prepped* representation is
 strictly stronger than a raw-byte NVMe cache for an ML pipeline. The default budget
 is the working set (read-once); raise `cache_budget_bytes` to cache.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -284,11 +284,11 @@ this section as "obstore wins HTTP", not "fsspec is worse".
 ## Free-threading readiness
 
 insitubatch's throughput is **GIL-independent by design**: the heavy work already runs
-outside the GIL — fetch (obstore/Rust), decode (numcodecs zstd, C), scatter/gather
+outside the GIL — fetch (obstore/Rust), decode (numcodecs zstd, C), gather
 (vectorized numpy) — and scheduling is a single asyncio loop, so there is no GIL-held
 hot path for free-threading to accelerate. (Decode even parallelizes *under* the GIL:
 zstd releases it, so the `decode_threads` sweep scales 1→2 on the GIL build too.) On the
-3.13 free-threaded build the engine is **correct** — the scatter is disjoint and readiness
+3.13 free-threaded build the engine is **correct** — deliveries never collide and readiness
 is published under the lock, so the lock, not the GIL, is the happens-before edge — and it
 runs at the **same speed** as the GIL build.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -146,7 +146,7 @@ there). Tests for an absent framework `importorskip`-skip, so a core-only run is
 
 **Free-threaded (3.13t).** If you touch `ChunkPool`, the scheduler, or anything that
 publishes chunk readiness across threads, run the free-threaded job too — the pool's
-lock-free disjoint scatter is exactly what it exercises. The full recipe (a separate
+lock discipline and its cross-thread readiness signalling are exactly what it exercises. The full recipe (a separate
 `.venv-ft`, and why you must assert the GIL is actually off before trusting the run) is in
 the [README](https://github.com/emfdavid/insitubatch#free-threaded-313t). CI mirrors it.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -131,7 +131,7 @@ uv sync --extra gpu      # CUDA box only: cupy + kvikio zero-copy path
 ## Status
 
 **Alpha — validated on real cloud IO.** Built: planner + chunk-aligned splits, async
-obstore reads, the decoupled fetch **`Scheduler`** + **`ChunkPool`** (assembly buffer
+obstore reads, the decoupled fetch **`Scheduler`** + **`ChunkPool`** (residency tier
 *and* cache — byte budget + pin/LRU, heap or mmap-on-NVMe, with **cross-run
 persistence** via `persist=True`), approximate (shuffle-block) shuffle, chunk/batch
 **transforms** (incl. a fitted `StandardScaler`), **prefetch**, **windowed multi-offset

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -227,9 +227,42 @@ Then branch on what you are running:
 
 ## Advanced: decode threads
 
-`decode_threads` (on `SchedulerConfig`) sizes the pool that runs codec decode and the
-scatter memcpy. It defaults to auto (`min(32, cpu+4)`) and rarely needs changing; on a busy
-box ~8 can beat auto by avoiding oversubscription. It is only reachable when you drive a
-`Scheduler` directly — `InSituDataset` uses the auto default. There is no separate
-inner-fan-out cap: the inner grid is dialed by `max_inflight`, which fetches at stored-chunk
-granularity.
+`decode_threads` (on `SchedulerConfig`) sizes the pool that runs codec decode. It defaults
+to auto (`min(32, cpu+4)`) and rarely needs changing; on a busy box ~8 can beat auto by
+avoiding oversubscription. It is only reachable when you drive a `Scheduler` directly —
+`InSituDataset` uses the auto default. There is no separate inner-fan-out cap: the inner
+grid is dialed by `max_inflight`, which fetches at stored-chunk granularity.
+
+**The decode pool is process-wide.** It is created once and outlives every scheduler, so
+`decode_threads` takes effect on the **first** dataset built in the process; a later,
+different value is ignored and logs a warning. That is deliberate rather than a limitation:
+how many threads can usefully decode at once is a property of the *machine* — cores, memory
+bandwidth — not of the dataset being read, and two datasets in one process should not run
+two pools competing for the same cores. If you want a non-default size, set it on the first
+dataset you create.
+
+## Ragged chunk grids cost more than their arrays
+
+A zarr chunk grid that does not divide the array evenly still stores **full-size chunks at
+the edges**. An ERA5-shaped array of 721 latitudes chunked at 180 occupies five stored
+chunks — 900 rows of storage for 721 rows of data.
+
+The pool holds stored chunks **whole**, padding included, because the buffer unit is the
+stored chunk (one unit, one shape). So resident bytes per chunk are
+`n_tiles × prod(chunk_shape) × itemsize`, which can exceed the logical chunk:
+
+| geometry | logical chunk | actually resident | ratio |
+|---|---|---|---|
+| 720×1440 @ 45×90 (divides evenly) | 63.3 MiB | 63.3 MiB | 1.000× |
+| 2048×2048 @ 256×256 (divides evenly) | 16.0 MiB | 16.0 MiB | 1.000× |
+| **721×1440 @ 180×360** | 3.96 MiB | 4.94 MiB | **1.248×** |
+| **as above, short final outer chunk** | 1.98 MiB | 3.96 MiB | **1.997×** |
+
+The automatic budget accounts for this, and so does `resident_bytes` — the number you are
+told is the number you are using. What it means for you is that **a ragged grid needs a
+proportionally larger `cache_budget_bytes`** if you set one by hand. If your grid divides
+evenly, this section costs you nothing.
+
+Your `chunk_transform` is unaffected: it receives the **logical** chunk, clipped, as a real
+contiguous array. It never sees padding, never masks an edge, and never needs to know the
+chunk grid.

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -79,12 +79,16 @@ data is written, and it sets how cheap concurrency can be.
 Peak memory is the sum of three independently-bounded pieces — none grows with epoch length
 or dataset size:
 
-- **Shuffle window:** `block_chunks × outer_chunk_bytes` — the decoded chunks held resident.
+- **Shuffle window:** `block_chunks × resident_chunk_bytes` — the decoded chunks held resident.
 - **Reads in flight:** `max_inflight × stored_chunk_bytes` — the fetch pipeline.
 - **Batch queue:** `prefetch_depth × batch_bytes` — assembled batches awaiting the consumer.
 
-where an outer chunk is `sample_chunk × ∏inner_shape × itemsize` and a stored chunk is
-`sample_chunk × ∏inner_chunk × itemsize`.
+where a stored chunk is `sample_chunk × ∏inner_chunk × itemsize`, and a resident chunk is
+the **stored chunks that compose it**, held whole:
+`n_stored_chunks × stored_chunk_bytes`. That equals the logical
+`sample_chunk × ∏inner_shape × itemsize` exactly when the chunk grid divides the array
+evenly, and exceeds it when it does not — see [Ragged chunk grids](#ragged-chunk-grids-cost-more-than-their-arrays)
+below.
 
 The point to internalize: **raising concurrency costs *stored-chunk*-sized memory, not
 *outer-chunk*-sized** — but only when the data is inner (spatially) chunked. If each outer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,12 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.26",
-    "zarr>=3.0",
+    # 3.3 for `zarr.core.chunk_utils.ChunkTransform.decode_chunk` -- the *synchronous*
+    # full-chain decode the scheduler dispatches to its own executor. Without it we would
+    # be back to the async codec pipeline, which dispatches to the event loop's default
+    # executor and so cannot be used on a loop we share (see docs/architecture.md).
+    # NB this is also what sets our Python floor: zarr itself requires >=3.12 from 3.2.0.
+    "zarr>=3.3",
     "xarray>=2024.9",
     "obstore>=0.3",
 ]

--- a/src/insitubatch/debug.py
+++ b/src/insitubatch/debug.py
@@ -3,9 +3,9 @@
 ``print_debug_info()`` dumps the versions and interpreter facts that actually change
 insitubatch's behavior: the storage stack (zarr / obstore / numpy), whichever framework
 adapter is installed, and the **free-threading state**. That last one matters more here
-than in most libraries -- the ``ChunkPool``'s lock-free disjoint scatter is exercised very
-differently on a 3.13t build with the GIL genuinely off, and "works for me" reports have
-turned on exactly that difference::
+than in most libraries -- the ``ChunkPool``'s lock discipline and its cross-thread readiness
+signalling are exercised very differently on a 3.13t build with the GIL genuinely off, and
+"works for me" reports have turned on exactly that difference::
 
     python -c "import insitubatch; insitubatch.print_debug_info()"
 

--- a/src/insitubatch/plan.py
+++ b/src/insitubatch/plan.py
@@ -3,9 +3,9 @@
 Expand the outer (sample-axis) chunks a draw order needs into the deduplicated set
 of *stored chunks* (tiles) the scheduler fetches. Python touches O(reads), never
 O(samples) -- the constraint David's S3 benchmark imposed (per-chunk overhead
-bounds throughput; never loop per-sample in Python). The scheduler scatters each
-decoded tile into its outer-chunk slot in the :class:`~insitubatch.pool.ChunkPool`;
-batches gather straight from those slots by ``(chunk_id, within)`` draw rows.
+bounds throughput; never loop per-sample in Python). The scheduler hands each decoded
+tile to the :class:`~insitubatch.pool.ChunkPool`, which holds it by reference; batches
+gather straight from those tiles by ``(chunk_id, within)`` draw rows.
 """
 
 from __future__ import annotations
@@ -24,9 +24,9 @@ def build_stored_chunk_reads(
 ) -> list[StoredChunkRead]:
     """Expand outer chunk ids into deduped stored-chunk reads, in priority order.
 
-    There is no gather map: the scheduler scatters tiles into per-outer-chunk slots
+    There is no gather map: the scheduler delivers tiles into per-outer-chunk slots
     in a :class:`~insitubatch.pool.ChunkPool`, and batches are gathered straight
-    from those assembled slots by ``(chunk_id, within)`` draw rows -- the same
+    from those tiles by ``(chunk_id, within)`` draw rows -- the same
     coordinates the shuffle order already produces. So the result is just *what to
     fetch, in what order*; the scheduler keeps ``max_inflight`` tiles in flight
     across the list.

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -555,7 +555,7 @@ class ChunkPool:
         # its charge is `slot_shape` and this reduces to the same number.
         n_tiles, tile_shape = self._tile_grid(array, chunk_index)
         dtype = out.dtype if self._whole_chunks else src.dtype
-        nbytes = n_tiles * int(np.prod(tile_shape, dtype=np.int64)) * dtype.itemsize
+        nbytes = self._charge(array, chunk_index)
         with self._cv:
             if key in self._slots:
                 # Already resident (in-flight, or a ready cross-epoch hit) -> incref and
@@ -835,6 +835,34 @@ class ChunkPool:
             return 1, self._out_by_path[array].slot_shape(chunk_index)
         src = self._by_path[array]
         return src.n_inner_chunks(chunk_index), src.tile_shape()
+
+    def _charge(self, array: str, chunk_index: int) -> int:
+        """Bytes to charge one slot against the budget: its **peak** residency.
+
+        For a tiled slot that is just its tiles. An assembling slot is charged the larger
+        of the two shapes it takes on, because it holds the **source tiles** for its whole
+        fill and only collapses to the assembled output at completion -- and on a ragged
+        grid the tiles are the bigger of the two (1.248x on ERA5 721x1440 at 180x360).
+        Charging the output alone, as the assembled design did, under-reports the entire
+        fill window.
+
+        The brief overlap at completion (tiles + assembled + the transform's own result) is
+        not charged, for the same reason the in-flight decode transient is not: it is
+        bounded by `max_inflight` and belongs to the fetch, not to residency.
+        """
+        n_tiles, tile_shape = self._tile_grid(array, chunk_index)
+        out = self._out_by_path[array]
+        dtype = out.dtype if self._whole_chunks else self._by_path[array].dtype
+        nbytes = n_tiles * int(np.prod(tile_shape, dtype=np.int64)) * dtype.itemsize
+        if not self._whole_chunks:
+            return nbytes
+        src = self._by_path[array]
+        during_fill = (
+            src.n_inner_chunks(chunk_index)
+            * int(np.prod(src.tile_shape(), dtype=np.int64))
+            * src.dtype.itemsize
+        )
+        return max(nbytes, during_fill)
 
     def _alloc(
         self, array: str, chunk_index: int, shape: tuple[int, ...], dtype: np.dtype

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -479,6 +479,18 @@ class ChunkPool:
             return len(self._positions())
 
     @property
+    def assembles(self) -> bool:
+        """True if publishing a chunk does real work (assembly / transform / write-back).
+
+        The scheduler needs this to decide *where* delivery runs. On the plain tiled path a
+        delivery is a dict write and a counter, so it belongs inline on the loop. When a
+        slot must publish a whole array, ``_advance`` also runs the assembly memcpy, the
+        user ``chunk_transform`` and the mmap write-back -- none of which may sit on an
+        event loop we share with the rest of the process.
+        """
+        return self._whole_chunks
+
+    @property
     def resident_bytes(self) -> int:
         with self._cv:
             return self._bytes

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -69,7 +69,7 @@ from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, replace
 from enum import Enum
 from pathlib import Path
-from typing import TextIO
+from typing import TextIO, cast
 
 import numpy as np
 
@@ -188,12 +188,23 @@ class SlotState(Enum):
 class _Slot:
     """One outer chunk's cache slot plus its lifecycle bookkeeping.
 
-    ``data`` is the cache slot, sized at the transform's *output* geometry. ``scratch`` is
-    a transient *source*-shaped assembly buffer, present only when a reshaping transform
-    means the slot cannot also be the assembly target; tiles scatter into it and the
-    transformed result lands in ``data`` (then ``scratch`` is dropped). With no reshaping
-    transform ``scratch`` is ``None`` and tiles scatter straight into ``data`` -- the slot
-    is buffer and cache in one, no extra copy (the common path).
+    **The buffer unit is the stored chunk.** ``tiles`` maps each inner stored-chunk
+    coordinate to the decoded tile itself: the tile *is* the residency, adopted by
+    reference, so the fill path has no memcpy. ``gather`` places each tile straight into
+    its sub-rectangle of the batch.
+
+    A chunk that needs a whole array collapses to a **one-tile** slot rather than a second
+    representation: ``output_geometry`` already sets post-transform ``chunks`` to the full
+    inner shape, so a transformed chunk is by definition a 1x1 grid, and ``tiles`` holds
+    ``{(0, ...): transformed}``. Same for the mmap tier. So there is exactly one thing
+    ``gather`` can find, and no "assembled or tiled?" dispatch anywhere.
+
+    ``scratch`` is the transient *source*-shaped assembly buffer used only while a
+    transform runs (it needs one contiguous array); it is dropped at publication.
+
+    Tiles are stored **whole, never clipped** -- one buffer unit, one shape. Clipping edge
+    tiles would create two kinds of tile and a ragged shape, which defeats a fixed-shape
+    arena later. The padding is therefore real residency, and is charged as such at admit.
 
     Two counters, because quiescence and completeness are different questions and
     answering both with one number is what made ``fail()`` have to lie:
@@ -209,7 +220,9 @@ class _Slot:
       partial (its fetch was cancelled), never a cache entry.
     """
 
-    data: np.ndarray
+    tiles: dict[tuple[int, ...], np.ndarray]  # inner_coord -> stored tile (the residency)
+    array: str  # zarr path this slot belongs to
+    chunk_index: int  # its outer (sample-axis) chunk
     writers: int  # outstanding tile TASKS -> quiescence
     pending: int  # tiles not yet delivered -> completeness
     nbytes: int  # slot size, charged to the budget (fixed at admit)
@@ -221,6 +234,19 @@ class _Slot:
     def quiescent(self) -> bool:
         """No tile task can still write into this slot."""
         return self.writers == 0
+
+    @property
+    def backing(self) -> np.ndarray | None:
+        """The single array behind a one-tile slot, or ``None`` if it is genuinely tiled.
+
+        Only the paths that publish a whole array (mmap tier, chunk transform) have one,
+        and only they ask -- ``_free`` needs the memmap to close, ``_record_completed``
+        needs its filename. A multi-tile slot is heap-backed by construction, so both are
+        no-ops for it.
+        """
+        if len(self.tiles) != 1:
+            return None
+        return next(iter(self.tiles.values()))
 
 
 @dataclass(slots=True)
@@ -309,6 +335,10 @@ class ChunkPool:
             label: output_geometry(g, self._chunk_transforms) for label, g in geometries.items()
         }
         self._out_by_path = {g.path: self._out_geom[label] for label, g in geometries.items()}
+        # Does a slot hold the STORED tiles, or one whole array? Pool-level, because both
+        # consumers that need a whole array are pool-wide: a chunk_transform (user code must
+        # not be handed a dict of tiles) and the mmap tier (one file per chunk).
+        self._whole_chunks = bool(self._chunk_transforms)
         self._reshapes = {
             p: (
                 out.inner_shape != self._by_path[p].inner_shape
@@ -324,6 +354,7 @@ class ChunkPool:
         self._dir = Path(backing_dir) if backing_dir is not None else None
         if self._dir is not None:
             self._dir.mkdir(parents=True, exist_ok=True)
+            self._whole_chunks = True  # the mmap tier is one .npy per chunk
         # Observability. hits/misses (+ the revive failure breakdown) are per-epoch --
         # reset by unpin_all at each epoch boundary -- so the driver can warn when a
         # configured persist cache served nothing. manifest_entries is load-time (how
@@ -502,10 +533,24 @@ class ChunkPool:
         """
         key = (array, chunk_index)
         src, out = self._by_path[array], self._out_by_path[array]
-        # The cache slot is the OUTPUT geometry (what a reshaping transform produces and what
-        # gather reads); the budget is charged for it. Assembly tiles are SOURCE-shaped, so a
-        # reshaping path also needs a transient source-shaped scratch buffer (not cached).
-        nbytes = int(np.prod(out.slot_shape(chunk_index), dtype=np.int64)) * out.dtype.itemsize
+        # Charge what the slot will actually HOLD, which is the stored tiles.
+        #
+        # A stored chunk decodes at full ``chunk_shape`` and we keep it whole (never
+        # clipped -- see _Slot), so residency is ``n_tiles * chunk_shape``, which EXCEEDS
+        # the assembled ``slot_shape`` wherever the grid does not divide the extent:
+        # measured 1.248x on ERA5 721x1440 @ 180x360, and 1.997x on a short final outer
+        # chunk. Charging ``slot_shape`` here -- as the assembled design did -- would let a
+        # pool told "2048 MiB" resident 2560 MiB while reporting 2048. Grids that divide
+        # exactly (720/45, 2048/256) show no difference at all, which is exactly why this
+        # is easy to get wrong and needs a ragged-grid test.
+        #
+        # A path that needs a whole array republishes as a single tile at completion, so
+        # its charge is `slot_shape` and this reduces to the same number.
+        if self._whole_chunks:
+            nbytes = int(np.prod(out.slot_shape(chunk_index), dtype=np.int64)) * out.dtype.itemsize
+        else:
+            tile_nbytes = int(np.prod(src.chunks, dtype=np.int64)) * src.dtype.itemsize
+            nbytes = src.n_inner_chunks(chunk_index) * tile_nbytes
         with self._cv:
             if key in self._slots:
                 # Already resident (in-flight, or a ready cross-epoch hit) -> incref and
@@ -523,7 +568,9 @@ class ChunkPool:
                 else None
             )
             self._slots[key] = _Slot(
-                data=self._alloc(array, chunk_index, out.slot_shape(chunk_index), out.dtype),
+                tiles={},  # filled by reference as tiles land; no buffer allocated here
+                array=array,
+                chunk_index=chunk_index,
                 writers=0,  # no task has started yet; counted on entry to tile_write
                 pending=src.n_inner_chunks(chunk_index),
                 nbytes=nbytes,
@@ -606,7 +653,13 @@ class ChunkPool:
         # A revived chunk enters the SAME lifecycle at a later state rather than being a
         # second way to be gatherable: no tiles were ever outstanding, nothing is pending.
         self._slots[key] = _Slot(
-            data=data, writers=0, pending=0, nbytes=nbytes, state=SlotState.READY
+            tiles={(0,) * len(self._out_by_path[array].inner_chunks): data},
+            array=array,
+            chunk_index=chunk_index,
+            writers=0,
+            pending=0,
+            nbytes=nbytes,
+            state=SlotState.READY,
         )
         self._bytes += nbytes
         self.max_resident = max(self.max_resident, len(self._positions()))
@@ -799,18 +852,20 @@ class ChunkPool:
     def _deliver(
         self, array: str, chunk_index: int, inner_coord: tuple[int, ...], tile: np.ndarray
     ) -> None:
-        """Copy one decoded tile into its slot (called by :class:`_TileWrite`).
+        """Adopt one decoded tile into its slot (called by :class:`_TileWrite`).
 
-        The memcpy happens *before* the lock (rule 1); the counter moves *under* it
-        (rule 2). Publication is :meth:`_advance`'s business, not this method's.
+        **No copy.** The decoded tile becomes the resident buffer by reference -- this is
+        the memcpy the chunked-slot design deletes. Placement is deferred to ``gather``,
+        which knows the batch rectangle it is filling; ``tile_placement`` therefore moves
+        from the write path to the read path rather than disappearing.
+
+        The dict write happens *before* the lock (rule 1) -- it is this task's own key, and
+        no other writer touches it -- and the counter moves *under* it (rule 2).
+        Publication is :meth:`_advance`'s business, not this method's.
         """
         key = (array, chunk_index)
         slot = self._slots[key]  # allocated by the scheduler before any delivery
-        dst, src = self._by_path[array].tile_placement(chunk_index, inner_coord)
-        # Tiles assemble at the SOURCE shape: into scratch on a reshaping path, else straight
-        # into the slot (which is then both buffer and cache). Disjoint, fixed-shape, lock-free.
-        buffer = slot.data if slot.scratch is None else slot.scratch
-        buffer[dst] = tile[src]  # disjoint, fixed-shape: lock-free (rule 1)
+        slot.tiles[inner_coord] = tile
         with self._cv:
             slot.pending -= 1
 
@@ -850,14 +905,23 @@ class ChunkPool:
                 # abandoned partial), or the slot is already published.
                 return
             slot.state = SlotState.ASSEMBLED
-            buffer = slot.data if slot.scratch is None else slot.scratch
+            needs_whole = self._whole_chunks
 
-        # Sole owner now (quiescent, and ASSEMBLED excludes it from eviction): assemble-stage
-        # transforms on the whole (source-shaped) outer chunk, then land the (possibly
-        # reshaped) result in the output-sized slot.
-        prepped = self._apply_transforms(array, chunk_index, buffer)
+        # Sole owner now (quiescent, and ASSEMBLED excludes it from eviction).
+        #
+        # The common path stops here: the tiles ARE the chunk, nothing to assemble.
+        # Assembly happens only for the two consumers that genuinely need one contiguous
+        # array -- a chunk_transform (user code, which must not be handed a dict of tiles)
+        # and the mmap tier (one file per chunk). Both then publish a **one-tile** slot, so
+        # `gather` still sees exactly one representation.
+        if needs_whole:
+            whole = self._assemble(array, chunk_index, slot)
+            prepped = self._apply_transforms(array, chunk_index, whole)
+            with self._cv:
+                slot.tiles = {
+                    (0,) * len(self._out_by_path[array].inner_chunks): self._persist(slot, prepped)
+                }
         with self._cv:
-            slot.data = self._persist(slot.data, prepped)
             slot.scratch = None  # assembly done -- drop the transient source-shaped buffer
             slot.state = SlotState.READY
             # Record the completed entry *now* (not at eviction/close) so a crash still leaves a
@@ -866,26 +930,44 @@ class ChunkPool:
             self._record_completed(key, slot)
             self._cv.notify_all()
 
-    def _persist(self, current: np.ndarray, prepped: np.ndarray) -> np.ndarray:
-        """Land the prepped (post-transform) array in the slot's (output-sized) backing.
+    def _assemble(self, array: str, chunk_index: int, slot: _Slot) -> np.ndarray:
+        """Stitch a slot's stored tiles into one contiguous source-shaped array.
 
-        No transform (``prepped is current``) is a no-op -- the scatter already wrote the
-        slot. Otherwise heap just holds the new array; mmap writes it back into the slot's
-        file so the cached chunk stays on NVMe. The slot is sized at the transform's *output*
-        geometry (see :func:`output_geometry`), so a reshaping transform lands here exactly
-        like a shape-preserving one -- ``prepped.shape`` matches the slot by construction. A
-        mismatch means ``__call__`` disagreed with its declared ``output_inner``: a bug, raised.
+        Only for the two consumers that need a whole array (see :meth:`_advance`). This is
+        the memcpy the chunked slot removed from the fill path -- reintroduced *once*, at
+        completion, for the paths that cannot avoid it, instead of on every tile delivery.
         """
-        if prepped is current or self._dir is None:
+        geom = self._by_path[array]
+        buffer = slot.scratch
+        if buffer is None:
+            buffer = np.empty(geom.slot_shape(chunk_index), dtype=geom.dtype)
+        for coord, tile in slot.tiles.items():
+            proj = geom.tile_placement(chunk_index, coord)
+            buffer[proj.out_selection] = tile[proj.chunk_selection]
+        return buffer
+
+    def _persist(self, slot: _Slot, prepped: np.ndarray) -> np.ndarray:
+        """Land the assembled (post-transform) chunk in the slot's backing.
+
+        Heap just holds the array. The mmap tier copies it into the slot's ``.npy`` so the
+        cached chunk stays on NVMe, and returns the memmap -- which then becomes the slot's
+        single tile. The backing is sized at the transform's *output* geometry (see
+        :func:`output_geometry`), so a reshaping transform lands here exactly like a
+        shape-preserving one. A shape mismatch means ``__call__`` disagreed with its
+        declared ``output_inner``: a bug, raised.
+        """
+        if self._dir is None:
             return prepped
-        if prepped.shape != current.shape:
+        out = self._out_by_path[slot.array]
+        backing = self._alloc(slot.array, slot.chunk_index, prepped.shape, out.dtype)
+        if prepped.shape != backing.shape:
             raise ValueError(
                 f"chunk_transform produced shape {prepped.shape} but the cache slot is sized "
-                f"{current.shape} from the declared output geometry; a reshaping transform's "
+                f"{backing.shape} from the declared output geometry; a reshaping transform's "
                 "output_inner must agree with what __call__ returns."
             )
-        current[:] = prepped  # write the transformed result into the memmap (casts to slot dtype)
-        return current
+        backing[:] = prepped  # write into the memmap (casts to slot dtype)
+        return backing
 
     def fail(self, array: str, chunk_index: int, error: BaseException) -> None:
         """Poison one chunk so a waiting consumer re-raises instead of hanging.
@@ -1006,7 +1088,22 @@ class ChunkPool:
             out = self._buffers.take(n, out_geom.inner_shape, out_geom.dtype)
             for cid in np.unique(read_cid):
                 mask = read_cid == cid  # rows that read this chunk -> one coalesced index
-                out[mask] = self._slots[(geom.path, int(cid))].data[within[mask]]
+                slot = self._slots[(geom.path, int(cid))]
+                rows = within[mask]
+                # One coalesced write per stored tile. A slot that holds a whole array
+                # (transformed, or revived) is simply a 1-tile grid, so this is the same
+                # single fancy-index the assembled path used to do -- no special case.
+                # A tiled slot's tiles sit on the SOURCE stored-chunk grid; a whole-chunk
+                # slot has one tile on the output grid (`output_geometry` sets post-transform
+                # chunks to the full inner shape, making it a 1x1 grid).
+                tile_geom = out_geom if self._whole_chunks else geom
+                for coord, tile in slot.tiles.items():
+                    proj = tile_geom.tile_placement(int(cid), coord)
+                    # `tile_placement` always builds plain slice tuples; zarr types the
+                    # fields as the wider SelectorTuple, so narrow them back for indexing.
+                    dst = cast("tuple[slice, ...]", proj.out_selection)
+                    src = cast("tuple[slice, ...]", proj.chunk_selection)
+                    out[(mask, *dst[1:])] = tile[(rows, *src[1:])]  # type: ignore[arg-type]
             arrays[var] = out
         offsets = {var: self._geom[var].offset for var in variables}
         return Batch(arrays=arrays, sample_indices=anchor, offsets=offsets)
@@ -1017,9 +1114,10 @@ class ChunkPool:
         ``keep_file`` leaves the ``.npy`` on disk (a persisted cache entry); otherwise the
         file is unlinked (heap/spill teardown or a discarded partial).
         """
-        mmap = getattr(slot.data, "_mmap", None)
+        backing = slot.backing
+        mmap = getattr(backing, "_mmap", None)
         if mmap is not None:
-            fname = getattr(slot.data, "filename", None)
+            fname = getattr(backing, "filename", None)
             mmap.close()
             if fname and not keep_file:
                 with contextlib.suppress(FileNotFoundError):
@@ -1052,7 +1150,7 @@ class ChunkPool:
         """
         if not self._persistent:
             return
-        fname = getattr(slot.data, "filename", None)
+        fname = getattr(slot.backing, "filename", None)
         if fname is None:
             return  # heap backing -- nothing on disk to record
         fname = Path(fname).name

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -223,20 +223,19 @@ class SlotState(Enum):
 
 @dataclass(slots=True)
 class _Slot:
-    """One outer chunk's cache slot plus its lifecycle bookkeeping.
+    """Everything the pool holds for one outer chunk, and the bookkeeping that says when
+    it is complete and when it is safe to take away.
 
-    A slot is **not** a zarr shard, despite having the same shape. A shard is a *storage*
-    unit -- one addressable object holding a grid of chunks; a slot is a *residency* unit,
-    a group of stored chunks sharing a sample-axis index, never stored or addressed as one
-    object. zarr has no name for that grouping, which is why ours is called a chunk. (What
-    this file calls a **tile** is what the public API calls a **stored chunk**: one zarr
-    chunk, or one zarr shard on a sharded array -- whatever a single ``store.get`` returns.
-    Two names for one concept; see #40.)
+    A slot is a unit of **residency**: one array's chunk along the sample axis, held as
+    the stored chunks it is made of. **The buffer unit is the stored chunk** -- ``tiles``
+    maps each inner coordinate to the decoded tile itself (whatever a single ``store.get``
+    returns), adopted by reference, so the tile *is* the resident buffer and the fill path
+    has no memcpy. ``gather`` places each tile straight into its sub-rectangle of the
+    batch.
 
-    **The buffer unit is the stored chunk.** ``tiles`` maps each inner stored-chunk
-    coordinate to the decoded tile itself: the tile *is* the residency, adopted by
-    reference, so the fill path has no memcpy. ``gather`` places each tile straight into
-    its sub-rectangle of the batch.
+    Admission, pinning, the byte budget, eviction and ``wait_ready`` all work at slot
+    granularity, so a chunk is never half-resident even though it arrives one tile at a
+    time.
 
     A chunk that needs a whole array collapses to a **one-tile** slot rather than a second
     representation: ``output_geometry`` already sets post-transform ``chunks`` to the full
@@ -251,8 +250,8 @@ class _Slot:
     tiles would create two kinds of tile and a ragged shape, which defeats a fixed-shape
     arena later. The padding is therefore real residency, and is charged as such at admit.
 
-    Two counters, because quiescence and completeness are different questions and
-    answering both with one number is what made ``fail()`` have to lie:
+    Two counters, because quiescence and completeness are different questions and one
+    number cannot answer both:
 
     * ``writers`` -- tile tasks **currently running**. Incremented when a task enters
       :meth:`ChunkPool.tile_write` and decremented exactly once on every exit path,
@@ -989,8 +988,8 @@ class ChunkPool:
     def _advance(self, array: str, chunk_index: int) -> None:
         """The **only** function that moves a slot's state. Called once per tile release.
 
-        Everything the old code spread across the scatter's tail, ``fail`` and
-        ``unpin_all`` lives here, so there is exactly one lever:
+        Every transition is decided here, from the slot's own counters, so there is
+        exactly one lever:
 
         * still has writers -> nothing to decide yet.
         * quiesced + FAILED -> **drop it**. A poisoned slot must not survive as a

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -218,12 +218,13 @@ class SlotState(Enum):
 class _Slot:
     """One outer chunk's cache slot plus its lifecycle bookkeeping.
 
-    In zarr's vocabulary this is a **decoded shard**: zarr calls one addressable unit made
-    of a grid of inner chunks a *shard*, and that is exactly what a slot is once decoded --
-    ``tiles`` are its inner chunks, keyed by the same stored-chunk coordinates. The word is
-    worth keeping straight for the upstream conversation (``decode(out=)``,
-    zarr-python#3060), where "make ``out`` a chunked in-memory array rather than requiring
-    contiguity" is a proposal for precisely this shape.
+    A slot is **not** a zarr shard, despite having the same shape. A shard is a *storage*
+    unit -- one addressable object holding a grid of chunks; a slot is a *residency* unit,
+    a group of stored chunks sharing a sample-axis index, never stored or addressed as one
+    object. zarr has no name for that grouping, which is why ours is called a chunk. (What
+    this file calls a **tile** is what the public API calls a **stored chunk**: one zarr
+    chunk, or one zarr shard on a sharded array -- whatever a single ``store.get`` returns.
+    Two names for one concept; see #40.)
 
     **The buffer unit is the stored chunk.** ``tiles`` maps each inner stored-chunk
     coordinate to the decoded tile itself: the tile *is* the residency, adopted by

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -218,6 +218,13 @@ class SlotState(Enum):
 class _Slot:
     """One outer chunk's cache slot plus its lifecycle bookkeeping.
 
+    In zarr's vocabulary this is a **decoded shard**: zarr calls one addressable unit made
+    of a grid of inner chunks a *shard*, and that is exactly what a slot is once decoded --
+    ``tiles`` are its inner chunks, keyed by the same stored-chunk coordinates. The word is
+    worth keeping straight for the upstream conversation (``decode(out=)``,
+    zarr-python#3060), where "make ``out`` a chunked in-memory array rather than requiring
+    contiguity" is a proposal for precisely this shape.
+
     **The buffer unit is the stored chunk.** ``tiles`` maps each inner stored-chunk
     coordinate to the decoded tile itself: the tile *is* the residency, adopted by
     reference, so the fill path has no memcpy. ``gather`` places each tile straight into

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -221,6 +221,7 @@ class _Slot:
     """
 
     tiles: dict[tuple[int, ...], np.ndarray]  # inner_coord -> stored tile (the residency)
+    backing: np.ndarray | None  # the whole tile-major .npy memmap, when persisting
     array: str  # zarr path this slot belongs to
     chunk_index: int  # its outer (sample-axis) chunk
     writers: int  # outstanding tile TASKS -> quiescence
@@ -234,19 +235,6 @@ class _Slot:
     def quiescent(self) -> bool:
         """No tile task can still write into this slot."""
         return self.writers == 0
-
-    @property
-    def backing(self) -> np.ndarray | None:
-        """The single array behind a one-tile slot, or ``None`` if it is genuinely tiled.
-
-        Only the paths that publish a whole array (mmap tier, chunk transform) have one,
-        and only they ask -- ``_free`` needs the memmap to close, ``_record_completed``
-        needs its filename. A multi-tile slot is heap-backed by construction, so both are
-        no-ops for it.
-        """
-        if len(self.tiles) != 1:
-            return None
-        return next(iter(self.tiles.values()))
 
 
 @dataclass(slots=True)
@@ -308,7 +296,14 @@ class ChunkPool:
     """
 
     _MANIFEST_NAME = "insitu_cache.jsonl"
-    _MANIFEST_FORMAT = 2
+    _MANIFEST_FORMAT = 3
+    """Bumped to 3: a persisted chunk is now stored **tile-major**.
+
+    A ``.npy`` holds ``(n_tiles, *tile_shape)`` -- each stored tile contiguous, in
+    :meth:`ArrayGeometry.inner_index` order -- rather than one assembled
+    ``slot_shape`` array. File count per chunk is unchanged. A version-2 cache is
+    structurally unreadable under the new layout, so the header check rejects the whole
+    log and refetches rather than misreading it as data."""
 
     def __init__(
         self,
@@ -335,9 +330,10 @@ class ChunkPool:
             label: output_geometry(g, self._chunk_transforms) for label, g in geometries.items()
         }
         self._out_by_path = {g.path: self._out_geom[label] for label, g in geometries.items()}
-        # Does a slot hold the STORED tiles, or one whole array? Pool-level, because both
-        # consumers that need a whole array are pool-wide: a chunk_transform (user code must
-        # not be handed a dict of tiles) and the mmap tier (one file per chunk).
+        # Does a slot hold the STORED tiles, or one whole array? Only a chunk_transform
+        # forces the latter: user code must be handed a real array, never a dict of tiles.
+        # The mmap tier does NOT force it -- a persisted chunk stores its tiles tile-major
+        # (see `_tile_grid`), so the cache round-trips tiles rather than assembling them.
         self._whole_chunks = bool(self._chunk_transforms)
         self._reshapes = {
             p: (
@@ -354,7 +350,6 @@ class ChunkPool:
         self._dir = Path(backing_dir) if backing_dir is not None else None
         if self._dir is not None:
             self._dir.mkdir(parents=True, exist_ok=True)
-            self._whole_chunks = True  # the mmap tier is one .npy per chunk
         # Observability. hits/misses (+ the revive failure breakdown) are per-epoch --
         # reset by unpin_all at each epoch boundary -- so the driver can warn when a
         # configured persist cache served nothing. manifest_entries is load-time (how
@@ -558,11 +553,9 @@ class ChunkPool:
         #
         # A path that needs a whole array republishes as a single tile at completion, so
         # its charge is `slot_shape` and this reduces to the same number.
-        if self._whole_chunks:
-            nbytes = int(np.prod(out.slot_shape(chunk_index), dtype=np.int64)) * out.dtype.itemsize
-        else:
-            tile_nbytes = int(np.prod(src.chunks, dtype=np.int64)) * src.dtype.itemsize
-            nbytes = src.n_inner_chunks(chunk_index) * tile_nbytes
+        n_tiles, tile_shape = self._tile_grid(array, chunk_index)
+        dtype = out.dtype if self._whole_chunks else src.dtype
+        nbytes = n_tiles * int(np.prod(tile_shape, dtype=np.int64)) * dtype.itemsize
         with self._cv:
             if key in self._slots:
                 # Already resident (in-flight, or a ready cross-epoch hit) -> incref and
@@ -579,8 +572,17 @@ class ChunkPool:
                 if self._reshapes[array]
                 else None
             )
+            # Persisting without a transform: back the slot with one tile-major .npy now,
+            # so a delivered tile is written straight to its slice and the slot's tile is a
+            # view of the file. That is the write we already owed -- not an extra copy.
+            backing = (
+                self._alloc(array, chunk_index, (n_tiles, *tile_shape), dtype)
+                if self._dir is not None and not self._whole_chunks
+                else None
+            )
             self._slots[key] = _Slot(
                 tiles={},  # filled by reference as tiles land; no buffer allocated here
+                backing=backing,
                 array=array,
                 chunk_index=chunk_index,
                 writers=0,  # no task has started yet; counted on entry to tile_write
@@ -645,15 +647,18 @@ class ChunkPool:
             logger.debug("cache: persisted %s unreadable (%s); refetching", key, exc)
             self._persisted.pop(key, None)
             return False
-        if geom is None or data.shape != geom.slot_shape(chunk_index) or data.dtype != geom.dtype:
+        n_tiles, tile_shape = self._tile_grid(array, chunk_index)
+        want_shape = (n_tiles, *tile_shape)
+        want_dtype = geom.dtype if geom is not None else None
+        if geom is None or data.shape != want_shape or data.dtype != want_dtype:
             self.revive_mismatch += 1
             logger.debug(
                 "cache: persisted %s shape/dtype %s/%s != current %s/%s; refetching",
                 key,
                 data.shape,
                 data.dtype,
-                None if geom is None else geom.slot_shape(chunk_index),
-                None if geom is None else geom.dtype,
+                None if geom is None else want_shape,
+                want_dtype,
             )
             del data  # drop the mmap ref; structural fingerprint mismatch -> a miss
             self._persisted.pop(key, None)
@@ -664,8 +669,19 @@ class ChunkPool:
             return False
         # A revived chunk enters the SAME lifecycle at a later state rather than being a
         # second way to be gatherable: no tiles were ever outstanding, nothing is pending.
+        # Tiles come back as zero-copy VIEWS of the one mapping, in the tile-major order
+        # `inner_index` defined when it was written -- so a revived chunk is tiled exactly
+        # like a freshly fetched one. That is what keeps `gather` on a single path: there
+        # is no "revived is assembled, fresh is tiled" split to dispatch on.
+        src_geom = self._by_path[array]
+        coords = (
+            [(0,) * len(self._out_by_path[array].inner_chunks)]
+            if self._whole_chunks
+            else sorted(src_geom.inner_coords(), key=src_geom.inner_index)
+        )
         self._slots[key] = _Slot(
-            tiles={(0,) * len(self._out_by_path[array].inner_chunks): data},
+            tiles={c: data[i] for i, c in enumerate(coords)},
+            backing=data,
             array=array,
             chunk_index=chunk_index,
             writers=0,
@@ -806,6 +822,20 @@ class ChunkPool:
         keep = self._persistent and slot.state is SlotState.READY
         self._free(slot, keep_file=keep)
 
+    def _tile_grid(self, array: str, chunk_index: int) -> tuple[int, tuple[int, ...]]:
+        """``(n_tiles, tile_shape)`` for one slot -- the single rule for its residency.
+
+        Without a transform a slot holds the array's **stored** tiles, sample-first and
+        whole (padding included). With one it holds a single tile: ``output_geometry`` sets
+        post-transform ``chunks`` to the full inner shape, so a transformed chunk is a 1x1
+        grid by construction. Both the budget charge and the persisted ``.npy`` layout are
+        derived from this, so they cannot drift apart.
+        """
+        if self._whole_chunks:
+            return 1, self._out_by_path[array].slot_shape(chunk_index)
+        src = self._by_path[array]
+        return src.n_inner_chunks(chunk_index), src.tile_shape()
+
     def _alloc(
         self, array: str, chunk_index: int, shape: tuple[int, ...], dtype: np.dtype
     ) -> np.ndarray:
@@ -877,7 +907,15 @@ class ChunkPool:
         """
         key = (array, chunk_index)
         slot = self._slots[key]  # allocated by the scheduler before any delivery
-        slot.tiles[inner_coord] = tile
+        if slot.backing is None:
+            slot.tiles[inner_coord] = tile  # heap: adopt by reference, no copy
+        else:
+            # Persisting: write the tile into its tile-major slice and keep the VIEW. The
+            # copy is the file write the mmap tier already owed -- not an extra one -- and
+            # the slot then reads from the same mapping a later run will revive.
+            idx = self._by_path[array].inner_index(inner_coord)
+            slot.backing[idx] = tile
+            slot.tiles[inner_coord] = slot.backing[idx]
         with self._cv:
             slot.pending -= 1
 
@@ -971,7 +1009,11 @@ class ChunkPool:
         if self._dir is None:
             return prepped
         out = self._out_by_path[slot.array]
-        backing = self._alloc(slot.array, slot.chunk_index, prepped.shape, out.dtype)
+        # A transformed chunk is a one-tile grid, so its file is (1, *slot_shape) -- the
+        # same tile-major layout the untransformed path writes, with n_tiles == 1.
+        backing = self._alloc(slot.array, slot.chunk_index, (1, *prepped.shape), out.dtype)
+        slot.backing = backing
+        backing = backing[0]
         if prepped.shape != backing.shape:
             raise ValueError(
                 f"chunk_transform produced shape {prepped.shape} but the cache slot is sized "
@@ -1126,10 +1168,9 @@ class ChunkPool:
         ``keep_file`` leaves the ``.npy`` on disk (a persisted cache entry); otherwise the
         file is unlinked (heap/spill teardown or a discarded partial).
         """
-        backing = slot.backing
-        mmap = getattr(backing, "_mmap", None)
+        mmap = getattr(slot.backing, "_mmap", None)
         if mmap is not None:
-            fname = getattr(backing, "filename", None)
+            fname = getattr(slot.backing, "filename", None)
             mmap.close()
             if fname and not keep_file:
                 with contextlib.suppress(FileNotFoundError):

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -1,11 +1,17 @@
-"""ChunkPool: the batch-assembly buffer *and* the cache -- one machinery.
+"""ChunkPool: the residency tier *and* the cache -- one machinery.
 
-The scheduler fetches at *stored chunk* (tile) granularity and scatters each
-decoded tile into its outer chunk's pre-allocated array. The pool owns those
-arrays -- the "slots" -- across their whole life: admit (size to the assembled
-chunk, evicting unpinned-LRU for room) -> scatter tiles (disjoint writes from the
-decode pool) -> mark ready (when the last tile lands) -> gather batches (coalesced,
-on the consumer thread) -> unpin (when a shuffle-block is fully drained).
+The scheduler fetches at *stored chunk* (tile) granularity and hands each decoded
+tile to the pool, which **adopts it by reference**: the tile *is* the resident
+buffer, so the fill path has no memcpy and placement is deferred to ``gather``. A
+slot is therefore a grid of stored chunks, not one assembled array. The pool owns
+them across their whole life: admit (charge the tiles it will hold, evicting
+unpinned-LRU for room) -> deliver tiles (from the decode pool) -> mark ready (when
+the last tile lands) -> gather batches (one coalesced write per stored chunk, on
+the consumer thread) -> unpin (when a shuffle-block is fully drained).
+
+A slot that must publish a *whole* array -- only a ``chunk_transform``, which must
+be handed a real array rather than a dict of tiles -- assembles at completion and
+republishes as a **one-tile** slot, so ``gather`` still sees one representation.
 
 Buffer and cache differ only in budget + backing, so they are the same code:
 
@@ -14,9 +20,10 @@ Buffer and cache differ only in budget + backing, so they are the same code:
   pressure evicts them in LRU order. A small budget is read-once (unpinned chunks
   evicted promptly); a large budget retains drained chunks so a still-resident
   prepped chunk is a hit next epoch -- decode-once reuse.
-* a **backing**: heap (``np.empty``) or mmap'd ``.npy`` on NVMe (``open_memmap``),
-  the scatter writing straight into the slot either way; mmap keeps the working set
-  as reclaimable page cache rather than anon heap.
+* a **backing**: heap (the adopted tile itself) or an mmap'd ``.npy`` on NVMe
+  (``open_memmap``), which stores a chunk's tiles **tile-major** -- each contiguous,
+  written straight into its slice, with the slot keeping the view. mmap keeps the
+  working set as reclaimable page cache rather than anon heap.
 
 With ``persist=True`` (requires a ``backing_dir``) the mmap tier becomes a **cross-run
 cache**: slot files survive ``close`` (only budget eviction removes them), an append-only
@@ -36,20 +43,20 @@ See [docs/architecture.md] for where this sits in the pipeline.
 
 Thread-safety / free-threading (the load-bearing invariant)
 -----------------------------------------------------------
-Scatter runs on many decode-pool threads at once -- including two tiles of the
+Delivery runs on many decode-pool threads at once -- including two tiles of the
 *same* outer chunk concurrently (inner-grid parallelism). We never lock the data
-copy; we lock only the Python-level bookkeeping. Two rules make this correct
+write; we lock only the Python-level bookkeeping. Two rules make this correct
 under both the GIL build *and* free-threaded 3.13t (where the GIL is no longer an
 incidental barrier):
 
-1. **Disjoint, fixed-shape writes are lock-free.** Tiles cover disjoint regions
-   of a slot whose shape never changes, so the memcpy ``slot[dst] = tile`` races
-   nothing.
-2. **Readiness is published *through the lock*, after the copy.** Each scatter
-   does its memcpy, *then* takes the lock to decrement the completion counter.
-   The consumer observes ``ready`` under the same lock. That lock release ->
+1. **Deliveries do not collide.** Each tile is its own key in ``slot.tiles``
+   (its ``inner_coord``), and on the mmap tier its own disjoint, fixed-shape slice
+   of the backing. No two writers touch the same bytes, so the write races nothing.
+2. **Readiness is published *through the lock*, after the write.** Each delivery
+   lands its tile, *then* takes the lock to decrement the completion counter.
+   The consumer observes readiness under the same lock. That lock release ->
    acquire pair is the happens-before edge guaranteeing the consumer sees every
-   completed copy -- we do not lean on the GIL for it.
+   completed write -- we do not lean on the GIL for it.
 
 So the GIL build is just the serialized (slower) case; free threading is upside.
 """
@@ -381,8 +388,9 @@ class ChunkPool:
             for p, out in self._out_by_path.items()
         }
         # backing: heap (np.empty) or mmap'd .npy under backing_dir (point at NVMe).
-        # The scatter writes straight into the slot either way; mmap keeps the working
-        # set as reclaimable page cache rather than anon heap. Default heap: scattering
+        # A heap slot adopts the tile; the mmap tier writes it into its tile-major slice
+        # and keeps the view. mmap keeps the working set as reclaimable page cache rather
+        # than anon heap. Default heap: writing
         # into mmap is NVMe write traffic even when never reused, so reach for it to
         # spill a working set past RAM or for cross-epoch reuse, not for plain streaming.
         self._dir = Path(backing_dir) if backing_dir is not None else None
@@ -855,7 +863,7 @@ class ChunkPool:
         self._bytes -= slot.nbytes
         # In persist mode a *ready* eviction is a cache demotion, not a deletion: keep the
         # .npy on disk so a later epoch/run can revive it. It was already recorded in the log at
-        # completion (see scatter -> _record_completed), so eviction touches only the backing.
+        # completion (see _advance -> _record_completed), so eviction touches only the backing.
         # A not-ready partial is garbage either way -> unlink it.
         keep = self._persistent and slot.state is SlotState.READY
         self._free(slot, keep_file=keep)
@@ -981,7 +989,7 @@ class ChunkPool:
     def _advance(self, array: str, chunk_index: int) -> None:
         """The **only** function that moves a slot's state. Called once per tile release.
 
-        Everything the old code spread across ``scatter``'s tail, ``fail`` and
+        Everything the old code spread across the scatter's tail, ``fail`` and
         ``unpin_all`` lives here, so there is exactly one lever:
 
         * still has writers -> nothing to decide yet.

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -120,6 +120,36 @@ def output_geometry(geom: ArrayGeometry, transforms: Sequence[ChunkTransform]) -
     return rebuild(inner, dt)
 
 
+def slot_charge_bytes(
+    src: ArrayGeometry, out: ArrayGeometry, chunk_index: int = 0, *, assembles: bool
+) -> int:
+    """Peak bytes one cache slot occupies. **The single rule for sizing and charging.**
+
+    A slot holds the array's stored tiles, kept **whole** -- a chunk grid that does not
+    divide the array evenly still stores full-size edge chunks (721 rows chunked at 180
+    occupy 900), and we do not clip them. So residency is ``n_tiles * tile_shape``, which
+    can exceed the assembled logical chunk.
+
+    When the pool assembles (a ``chunk_transform`` is configured) the slot holds the source
+    tiles for its whole fill and only collapses to the assembled output at completion, so
+    the charge is the larger of the two. A transform that *shrinks* the data makes the
+    tiles the binding term; one that grows it makes the output the binding term.
+
+    :func:`InSituDataset` sizes its automatic budget with this too. They must not drift:
+    sizing from the output shape while charging the tiles under-provisions the budget and
+    the pool starves mid-epoch, which is a hang-shaped failure rather than a slow one.
+    """
+    tiles = (
+        src.n_inner_chunks(chunk_index)
+        * int(np.prod(src.tile_shape(), dtype=np.int64))
+        * src.dtype.itemsize
+    )
+    if not assembles:
+        return tiles
+    assembled = int(np.prod(out.slot_shape(chunk_index), dtype=np.int64)) * out.dtype.itemsize
+    return max(tiles, assembled)
+
+
 def _transform_token(fn: ChunkTransform) -> str:
     """A stable identity for one chunk_transform, for the cross-run cache fingerprint.
 
@@ -850,19 +880,12 @@ class ChunkPool:
         not charged, for the same reason the in-flight decode transient is not: it is
         bounded by `max_inflight` and belongs to the fetch, not to residency.
         """
-        n_tiles, tile_shape = self._tile_grid(array, chunk_index)
-        out = self._out_by_path[array]
-        dtype = out.dtype if self._whole_chunks else self._by_path[array].dtype
-        nbytes = n_tiles * int(np.prod(tile_shape, dtype=np.int64)) * dtype.itemsize
-        if not self._whole_chunks:
-            return nbytes
-        src = self._by_path[array]
-        during_fill = (
-            src.n_inner_chunks(chunk_index)
-            * int(np.prod(src.tile_shape(), dtype=np.int64))
-            * src.dtype.itemsize
+        return slot_charge_bytes(
+            self._by_path[array],
+            self._out_by_path[array],
+            chunk_index,
+            assembles=self._whole_chunks,
         )
-        return max(nbytes, during_fill)
 
     def _alloc(
         self, array: str, chunk_index: int, shape: tuple[int, ...], dtype: np.dtype

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -55,56 +55,71 @@ import asyncio
 import contextlib
 import os
 import threading
-from collections.abc import Callable, Coroutine, Sequence
+from collections.abc import Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Any, TypeVar
+from typing import Any
 
 import numpy as np
 import zarr.api.asynchronous as za
 from zarr.abc.store import Store
 from zarr.core.array_spec import ArraySpec
 from zarr.core.buffer import default_buffer_prototype
+from zarr.core.chunk_utils import ChunkTransform
+from zarr.core.sync import _get_loop
 
 from .plan import build_stored_chunk_reads
 from .pool import ChunkPool
 from .types import ArrayGeometry, StoredChunkRead
 
-_T = TypeVar("_T")
-
 STARVATION_POLL_S = 0.25
+
+_DECODE_POOL: ThreadPoolExecutor | None = None
+_DECODE_POOL_LOCK = threading.Lock()
+
+
+def decode_pool(workers: int | None = None) -> ThreadPoolExecutor:
+    """The process-wide decode pool. Created once, never shut down.
+
+    Process-lived on purpose. A per-scheduler pool was rebuilt on every pass (churn), and
+    -- once orchestration moved onto zarr's loop -- shutting one down was actively unsafe:
+    the pool had to be installed as the loop's *default executor* for ``decode_threads`` to
+    mean anything, so closing it left zarr's own ``run_in_executor(None, ...)`` raising
+    ``cannot schedule new futures after shutdown`` for the rest of the process.
+
+    We no longer touch the loop's default executor at all (see :meth:`Scheduler._one`), and
+    this pool outlives every scheduler, so neither failure is reachable.
+
+    ``workers`` sizes it on **first** use only; later callers get the existing pool. Sizing
+    is process-wide because the pool is -- a second dataset does not get a second pool.
+    """
+    global _DECODE_POOL
+    with _DECODE_POOL_LOCK:
+        if _DECODE_POOL is None:
+            n = workers or min(32, (os.cpu_count() or 4) + 4)
+            _DECODE_POOL = ThreadPoolExecutor(max_workers=n, thread_name_prefix="insitu-dec")
+        return _DECODE_POOL
+
+
+def reset_decode_pool() -> None:
+    """Drop the process-wide decode pool so the next use rebuilds it. **Tests only.**
+
+    Not a user-facing knob: production code never wants this (the whole point is that the
+    pool outlives schedulers). Tests need it to size the pool per case, to run a
+    free-threaded arm, and to avoid leaking one case's pool into the next.
+    """
+    global _DECODE_POOL
+    with _DECODE_POOL_LOCK:
+        pool, _DECODE_POOL = _DECODE_POOL, None
+    if pool is not None:
+        pool.shutdown(wait=True, cancel_futures=True)
+
+
 """How often a parked admission re-checks for a *provably* terminal starvation.
 
 Detection latency only: the test is structural (nothing in flight, and a consumer
 blocked in ``wait_ready``), never "we have waited a while", so a slow consumer is
 never mistaken for a deadlock however long it takes."""
-
-
-def _fsspec_io_loop(store: Store) -> asyncio.AbstractEventLoop | None:
-    """The event loop an fsspec-backed store's IO must run on, if not the caller's.
-
-    A genuinely-async fsspec backend (gcsfs, s3fs) binds its aiohttp session to
-    whichever event loop *first awaits* one of its coroutines, and can never be used
-    from another loop ("Future attached to a different loop"). Neither zarr's
-    ``FsspecStore`` nor gcsfs exposes a knob to pin that loop -- the ``loop=``
-    constructor arg does not bind the session -- and zarr's ``FsspecStore.get``
-    awaits ``fs._cat_file`` on the *calling* loop with no routing of its own.
-
-    zarr drives all of *its* store IO on one process-wide background loop
-    (``zarr.core.sync._get_loop()``); because insitu reads a zarr store opened through
-    zarr (``open_geometries``/``open_array``), the session is created there. So the
-    correct, self-consistent choice is to route insitu's fsspec reads to that same
-    loop: the session lives there, and driving every read there keeps one loop for the
-    store even if nothing opened it first. ``None`` for stores needing no routing --
-    obstore's ``ObjectStore`` bridges its Rust runtime to whatever loop awaits it
-    (no ``.fs``), so the scheduler awaits it inline.
-    """
-    fs = getattr(store, "fs", None)
-    if fs is None or not getattr(fs, "asynchronous", False):
-        return None
-    from zarr.core.sync import _get_loop
-
-    return _get_loop()
 
 
 @dataclass(slots=True)
@@ -132,19 +147,44 @@ class _ArrayCtx:
     """Per-variable handles for the stored-chunk fetch+decode path.
 
     Cached once per array: the store + key encoder address a stored chunk, the
-    codec pipeline + spec decode its bytes (this reconstructs exactly what
+    codec transform + spec decode its bytes (this reconstructs exactly what
     ``arr.getitem`` would stitch, for single-inner and spatially-chunked arrays).
+
+    ``codec`` is a **synchronous** :class:`~zarr.core.chunk_utils.ChunkTransform`, not the
+    array's async ``codec_pipeline`` -- see :func:`_sync_transform` for why that matters.
     """
 
     path: str
-    store: object
+    store: Store
     encode: Callable[[tuple[int, ...]], str]
-    codec: object
+    codec: ChunkTransform
     spec: ArraySpec
     chunk_shape: tuple[int, ...]
     fill_value: object
     dtype: np.dtype
     sample_axis: int  # physical axis to move to the front on decode (0 = no-op)
+
+
+def _sync_transform(meta: Any) -> ChunkTransform:
+    """A **synchronous** full-chain decoder for one array's codecs.
+
+    ``ChunkTransform.decode_chunk`` is pure compute with no IO, so we can call it inside
+    an executor task we dispatch ourselves -- which is what lets us keep our own decode
+    pool without claiming the loop's single default-executor slot. The async
+    ``codec_pipeline.decode`` cannot: it dispatches to the loop default on our behalf.
+
+    Format-agnostic, and v2 is not optional -- **WeatherBench2 ARCO is zarr-v2**, whose
+    pipeline is a single ``V2Codec(filters, compressor)`` rather than v3's
+    ``(BytesCodec, ZstdCodec, ...)``. A v3-only path would silently miss our main weather
+    benchmark. Verified byte-identical to the async pipeline on v3 zstd / uncompressed /
+    gzip and on v2.
+    """
+    codecs = getattr(meta, "codecs", None)
+    if codecs is None:  # zarr-v2: the compressor hangs off V2Codec, not a codec chain
+        from zarr.codecs._v2 import V2Codec
+
+        codecs = (V2Codec(filters=meta.filters, compressor=meta.compressor),)
+    return ChunkTransform(codecs=tuple(codecs))
 
 
 def _bad_fill(ctx: _ArrayCtx) -> object:
@@ -195,12 +235,13 @@ class Scheduler:
         self.inflight_peak = 0
         self._inflight_now = 0
 
-        workers = self._config.decode_threads or min(32, (os.cpu_count() or 4) + 4)
-        self._decode_pool = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="insitu-dec")
-        self._loop = asyncio.new_event_loop()
-        # Set once reads begin: the foreign loop an fsspec store pins its IO to (gcsfs/
-        # s3fs), or None for a loop-agnostic store (obstore). See _fsspec_io_loop / _io.
-        self._foreign_loop: asyncio.AbstractEventLoop | None = None
+        self._decode_pool = decode_pool(self._config.decode_threads)
+        # ONE loop for the whole process: zarr's. An async fsspec backend binds its aiohttp
+        # session to whichever loop first awaits it, and because we read a store opened
+        # through zarr that loop is zarr's -- so being on it is what deletes the bridge
+        # (gcsfs and obstore now take the same inline `await`). obstore is loop-agnostic
+        # and does not care. We are a guest on it: see `close` and `_shutdown`.
+        self._loop = _get_loop()
         self._inflight: asyncio.Semaphore | None = None
         self._capacity: asyncio.Event | None = None  # set on unpin -> wakes a parked admit
         self._open_lock: asyncio.Lock | None = None
@@ -210,47 +251,50 @@ class Scheduler:
         # it cancels unrelated zarr-sync work mid-flight. Mutated only on the loop thread
         # (create_task and the done-callback both run there), so it needs no lock.
         self._tasks: set[asyncio.Task] = set()
-        # Whether this scheduler stood the loop up. A borrowed loop must never be stopped
-        # or closed by us -- doing so leaves zarr's process-global loop dead for the rest
-        # of the process.
-        self._owns_loop = True
-        self._thread: threading.Thread | None = threading.Thread(
-            target=self._run_loop, daemon=True, name="insitu-sched"
-        )
-        self._thread.start()
-        self._ready.wait()
+        self._loop.call_soon_threadsafe(self._setup)
+        self._ready.wait(timeout=10)
 
     # -- loop lifecycle -----------------------------------------------------
 
-    def _run_loop(self) -> None:
-        asyncio.set_event_loop(self._loop)
-        self._loop.set_default_executor(self._decode_pool)  # decode + scatter -> our pool
+    def _setup(self) -> None:
+        """Create our asyncio primitives **on** the loop. Runs there, once, at construction.
+
+        Deliberately does NOT call ``set_default_executor``: a borrowed loop has exactly one
+        default-executor slot, and claiming it retunes zarr's own concurrency process-wide
+        (then breaks it when we shut our pool down). We pass :attr:`_decode_pool` explicitly
+        instead -- which is possible only because decode is now a *synchronous* call we
+        dispatch ourselves (:meth:`_one`), rather than an async pipeline that dispatches to
+        the loop default on our behalf.
+        """
         self._inflight = asyncio.Semaphore(self._config.max_inflight)
         self._capacity = asyncio.Event()
         self._open_lock = asyncio.Lock()
-        self._loop.call_soon(self._ready.set)
-        self._loop.run_forever()
+        self._ready.set()
 
     def close(self) -> None:
-        """Cancel any in-flight driver, then stop the loop and decode pool.
+        """Cancel this scheduler's in-flight driver. Nothing else.
 
-        Graceful: a consumer may close mid-epoch (early ``break``) while ``_drive``
-        is still streaming. We cancel outstanding tasks and let them unwind *before*
-        stopping the loop, so no coroutine is orphaned (which would surface as
-        ``GeneratorExit`` / "never awaited" warnings on GC).
+        Graceful: a consumer may close mid-epoch (early ``break``) while ``_drive`` is
+        still streaming, so we cancel our outstanding tasks and let them unwind.
+
+        **A scheduler owns no shared resource, so it tears down no shared resource.** The
+        loop is zarr's and lives for the process; the decode pool is process-wide and
+        outlives every scheduler; the chunk pool is caller-owned and persists across epochs
+        as the cache. Closing any of them here would break unrelated work elsewhere in the
+        process -- which is not hypothetical: stopping the loop hangs every later
+        ``zarr.core.sync.sync()`` call, and shutting the decode pool down makes the next
+        scheduler raise ``cannot schedule new futures after shutdown``. Both were observed.
         """
         with contextlib.suppress(Exception):  # loop may already be down
             fut = asyncio.run_coroutine_threadsafe(self._shutdown(), self._loop)
             fut.result(timeout=5)  # resolves while the loop is still running
-        if self._owns_loop:
-            self._loop.call_soon_threadsafe(self._loop.stop)  # ...then stop it
-            if self._thread is not None:
-                self._thread.join(timeout=5)
-                if not self._thread.is_alive():  # exited run_forever -> safe to close
-                    self._loop.close()  # release the self-pipe; don't leave it for __del__
-        self._decode_pool.shutdown(wait=False, cancel_futures=True)
-        # NB: the *chunk* pool is caller-owned (persists across epochs as the cache) -- the
-        # dataset closes it, not us.
+        # NB: we do NOT shut the decode pool down. It is process-wide and outlives every
+        # scheduler (see `decode_pool`); shutting it here would make the *next* scheduler
+        # raise "cannot schedule new futures after shutdown" -- which is precisely the
+        # shared-resource teardown bug this design exists to avoid, and the suite catches
+        # it immediately. Tests that need a fresh pool call `reset_decode_pool()`.
+        # The *chunk* pool is likewise caller-owned (it persists across epochs as the
+        # cache) -- the dataset closes it, not us.
 
     async def _shutdown(self) -> None:
         """Cancel + drain **our** in-flight tasks. Never the loop's other work.
@@ -432,18 +476,6 @@ class Scheduler:
             f"cache_budget_bytes, or lower batch_size / block_chunks.{concurrent}"
         )
 
-    async def _io(self, coro: Coroutine[Any, Any, _T]) -> _T:
-        """Await a store coroutine on the loop that store's IO belongs to.
-
-        obstore is loop-agnostic -> await inline on our loop. An fsspec store's IO must
-        run on its own loop (see :func:`_fsspec_io_loop`); schedule it there and bridge
-        the result back to ours, without blocking either loop -- so read concurrency is
-        preserved across the boundary.
-        """
-        if self._foreign_loop is None:
-            return await coro
-        return await asyncio.wrap_future(asyncio.run_coroutine_threadsafe(coro, self._foreign_loop))
-
     async def _ensure_arrays(self) -> None:
         if self._arrays:
             return
@@ -451,16 +483,13 @@ class Scheduler:
         async with self._open_lock:
             if self._arrays:
                 return
-            # Resolve the store's IO loop once, before the first store touch (open reads
-            # metadata) -- an fsspec store crashes if that touch runs on our loop.
-            self._foreign_loop = _fsspec_io_loop(self._store)
             store = self._store
             # Open each distinct array once, keyed by its zarr path: several windowed
             # views (same path, different offset) share one open + one decode path.
             for geom in self._geometries.values():
                 if geom.path in self._arrays:
                     continue
-                aa = await self._io(za.open_array(store=store, path=geom.path, mode="r"))
+                aa = await za.open_array(store=store, path=geom.path, mode="r")
                 # Format-agnostic: zarr-v2 metadata exposes `dtype`/`encode_chunk_key`
                 # where v3 has `data_type`/`chunk_key_encoding.encode_chunk_key` -- so the
                 # engine reads public v2 stores (WeatherBench2 ARCO) as well as v3.
@@ -477,7 +506,7 @@ class Scheduler:
                     path=aa.store_path.path,
                     store=aa.store_path.store,
                     encode=meta.encode_chunk_key,
-                    codec=aa.codec_pipeline,
+                    codec=_sync_transform(meta),
                     spec=spec,
                     chunk_shape=tuple(aa.metadata.chunks),
                     fill_value=aa.metadata.fill_value,
@@ -516,7 +545,13 @@ class Scheduler:
                         self.bad_chunks.append(read)
                         tile = np.full(ctx.chunk_shape, _bad_fill(ctx), dtype=ctx.dtype)
                     try:
-                        await self._loop.run_in_executor(None, w.deliver, tile)
+                        # Delivery used to be a second executor hop, because it was a
+                        # memcpy into the assembled slot. Under chunked slots it is a dict
+                        # assignment and a counter, so the hop is deleted rather than
+                        # fused -- and the decoded tile stops living in this frame across
+                        # it, which is what made tile residency scale with `max_inflight`
+                        # (an IO dial) instead of with the pool doing the work.
+                        w.deliver(tile)
                     except Exception as exc:  # noqa: BLE001 - a delivery failure is a real bug
                         w.fail(exc)
             finally:
@@ -529,11 +564,17 @@ class Scheduler:
         ax = ctx.sample_axis
         phys = read.inner_coord[:ax] + (read.chunk_index,) + read.inner_coord[ax:]
         key = ctx.path + "/" + ctx.encode(phys)
-        buf = await self._io(ctx.store.get(key, prototype=self._proto))  # type: ignore[attr-defined]
+        # One path for every backend. We are on zarr's loop, which is the loop an async
+        # fsspec session is bound to, so gcsfs and obstore are both a plain inline await.
+        buf = await ctx.store.get(key, prototype=self._proto)
         if buf is None:  # absent chunk == all fill_value (zarr's getitem semantics)
             tile = np.full(ctx.chunk_shape, ctx.fill_value, dtype=ctx.dtype)
         else:
-            [decoded] = list(await ctx.codec.decode([(buf, ctx.spec)]))  # type: ignore[attr-defined]
+            # Decode on OUR pool, named explicitly -- never `None`, which would mean the
+            # loop's default executor and would make us a guest that retunes its host.
+            decoded = await self._loop.run_in_executor(
+                self._decode_pool, ctx.codec.decode_chunk, buf, ctx.spec
+            )
             tile = decoded.as_numpy_array()
         # Seam 2: the decoded tile is in physical order; move the sample axis to the front
         # so it matches the sample-first slot the pool scatters into (no-op when ax == 0).

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -205,7 +205,18 @@ class Scheduler:
         self._capacity: asyncio.Event | None = None  # set on unpin -> wakes a parked admit
         self._open_lock: asyncio.Lock | None = None
         self._ready = threading.Event()
-        self._thread = threading.Thread(target=self._run_loop, daemon=True, name="insitu-sched")
+        # OUR tasks, and only ours. `asyncio.all_tasks(loop)` is the *whole loop's* task
+        # set: correct while the loop is private, destructive the moment it is shared --
+        # it cancels unrelated zarr-sync work mid-flight. Mutated only on the loop thread
+        # (create_task and the done-callback both run there), so it needs no lock.
+        self._tasks: set[asyncio.Task] = set()
+        # Whether this scheduler stood the loop up. A borrowed loop must never be stopped
+        # or closed by us -- doing so leaves zarr's process-global loop dead for the rest
+        # of the process.
+        self._owns_loop = True
+        self._thread: threading.Thread | None = threading.Thread(
+            target=self._run_loop, daemon=True, name="insitu-sched"
+        )
         self._thread.start()
         self._ready.wait()
 
@@ -231,22 +242,33 @@ class Scheduler:
         with contextlib.suppress(Exception):  # loop may already be down
             fut = asyncio.run_coroutine_threadsafe(self._shutdown(), self._loop)
             fut.result(timeout=5)  # resolves while the loop is still running
-        self._loop.call_soon_threadsafe(self._loop.stop)  # ...then stop it
-        self._thread.join(timeout=5)
-        if not self._thread.is_alive():  # loop has exited run_forever -> safe to close
-            self._loop.close()  # release the self-pipe now; don't leave it for __del__
+        if self._owns_loop:
+            self._loop.call_soon_threadsafe(self._loop.stop)  # ...then stop it
+            if self._thread is not None:
+                self._thread.join(timeout=5)
+                if not self._thread.is_alive():  # exited run_forever -> safe to close
+                    self._loop.close()  # release the self-pipe; don't leave it for __del__
         self._decode_pool.shutdown(wait=False, cancel_futures=True)
-        # NB: the pool is caller-owned (persists across epochs as the cache) -- the
+        # NB: the *chunk* pool is caller-owned (persists across epochs as the cache) -- the
         # dataset closes it, not us.
 
     async def _shutdown(self) -> None:
-        # Cancel + drain in-flight tasks, but do NOT stop the loop here: stopping
-        # inside the awaited coroutine would race the delivery of this future's
-        # result back to close(), which then blocks until its timeout.
-        tasks = [t for t in asyncio.all_tasks(self._loop) if t is not asyncio.current_task()]
-        for task in tasks:
+        """Cancel + drain **our** in-flight tasks. Never the loop's other work.
+
+        Do NOT stop the loop here: stopping inside the awaited coroutine would race the
+        delivery of this future's result back to :meth:`close`, which then blocks until
+        its timeout.
+
+        This deliberately does not use ``asyncio.all_tasks(self._loop)``. That is the
+        whole loop's task set, and on a shared loop it cancels unrelated zarr-sync work
+        -- observed as a ``CancelledError`` raised inside an innocent ``zarr`` read in a
+        different thread. We cancel exactly what we created (:attr:`_tasks`).
+        """
+        current = asyncio.current_task()
+        mine = [t for t in self._tasks if t is not current and not t.done()]
+        for task in mine:
             task.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
+        await asyncio.gather(*mine, return_exceptions=True)
 
     def __enter__(self) -> Scheduler:
         return self
@@ -309,6 +331,9 @@ class Scheduler:
         # a not-ready (in-flight) slot is eviction-protected until its fetch completes.
         decided: dict[tuple[str, int], bool] = {}
         tasks: list[asyncio.Task] = []
+        me = asyncio.current_task()
+        if me is not None:
+            self._tasks.add(me)  # so _shutdown can cancel the driver itself
         try:
             for read in reads:
                 key = (read.array, read.chunk_index)
@@ -320,12 +345,18 @@ class Scheduler:
                     decided[key] = hit
                 if hit:
                     continue  # cross-epoch hit: prepped chunk already resident, no fetch
-                tasks.append(asyncio.create_task(self._one(read)))
+                task = asyncio.create_task(self._one(read))
+                self._tasks.add(task)
+                task.add_done_callback(self._tasks.discard)
+                tasks.append(task)
             await asyncio.gather(*tasks)
         except BaseException:
             for task in tasks:
                 task.cancel()
             raise
+        finally:
+            if me is not None:
+                self._tasks.discard(me)
 
     async def _admit(self, array: str, chunk_index: int) -> None:
         """Admit a miss chunk against the byte budget, awaiting an unpin if full.

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -1,8 +1,9 @@
 """Scheduler: the fetch driver.
 
-One asyncio event loop streams *stored-chunk* (tile) reads under a single
-``max_inflight`` budget, decodes each tile off the loop (numcodecs C, GIL
-released), and scatters it into its outer chunk's slot in a :class:`ChunkPool`.
+Orchestration runs on **zarr's** process-global event loop, streaming *stored-chunk*
+(tile) reads under a single ``max_inflight`` budget, decoding each tile off the loop
+(``ChunkTransform.decode_chunk``, numcodecs C, GIL released) on a process-wide decode
+pool, and handing it to a :class:`ChunkPool` that **adopts it by reference**.
 
 The point is that the two things you tune are independent: **read concurrency** is
 dialed by ``max_inflight`` alone, while **residency / shuffle span** is governed by
@@ -14,7 +15,8 @@ stitch the inner grid under a second cap is what couples them). See
 Two bounded resources, deliberately distinct:
 
 * **in-flight** (``max_inflight``, an ``asyncio.Semaphore``) -- tiles in flight; a
-  slot is held from fetch-start to scatter-done, spanning fetch + decode + scatter.
+  slot is held from fetch-start to delivery, spanning fetch + decode + deliver. It is
+  also what bounds the decode pool's queue, which is otherwise unbounded.
 * **residency** (the pool's byte budget) -- admission (``pool.try_admit``) evicts
   ready-and-unreferenced LRU to make room and *references* (refcounted pin) the chunk,
   so it stays resident from in-flight fetch through to the consumer's release; when the
@@ -459,7 +461,7 @@ class Scheduler:
 
         * ``try_admit`` just failed -- the budget is full of in-flight or referenced
           slots, so no eviction can make room.
-        * nothing is in flight -- no scatter is pending, so no slot can become ready
+        * nothing is in flight -- no delivery is pending, so no slot can become ready
           and satisfy a waiter on its own.
         * a consumer is blocked in ``wait_ready`` -- and a blocked consumer never
           reaches its next ``unpin_block``, so the one thing that could free budget
@@ -610,5 +612,5 @@ class Scheduler:
             )
             tile = decoded.as_numpy_array()
         # Seam 2: the decoded tile is in physical order; move the sample axis to the front
-        # so it matches the sample-first slot the pool scatters into (no-op when ax == 0).
+        # so it matches the sample-first grid the pool and gather address (no-op when ax == 0).
         return np.moveaxis(tile, ax, 0) if ax else tile

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 import os
 import threading
 from collections.abc import Callable, Sequence
@@ -74,7 +75,10 @@ from .types import ArrayGeometry, StoredChunkRead
 
 STARVATION_POLL_S = 0.25
 
+logger = logging.getLogger(__name__)
+
 _DECODE_POOL: ThreadPoolExecutor | None = None
+_DECODE_POOL_WORKERS = 0
 _DECODE_POOL_LOCK = threading.Lock()
 
 
@@ -90,14 +94,29 @@ def decode_pool(workers: int | None = None) -> ThreadPoolExecutor:
     We no longer touch the loop's default executor at all (see :meth:`Scheduler._one`), and
     this pool outlives every scheduler, so neither failure is reachable.
 
-    ``workers`` sizes it on **first** use only; later callers get the existing pool. Sizing
-    is process-wide because the pool is -- a second dataset does not get a second pool.
+    ``workers`` sizes it on **first** use only; later callers get the existing pool and are
+    warned if they asked for a different size. That is the right shape rather than a
+    limitation: how many threads can usefully decode at once is a property of the
+    *machine* -- core count, memory bandwidth -- not of the dataset being read. Two
+    datasets in one process do not want two pools competing for the same cores, and the
+    second one's number is not more correct than the first's.
     """
-    global _DECODE_POOL
+    global _DECODE_POOL, _DECODE_POOL_WORKERS
     with _DECODE_POOL_LOCK:
         if _DECODE_POOL is None:
-            n = workers or min(32, (os.cpu_count() or 4) + 4)
-            _DECODE_POOL = ThreadPoolExecutor(max_workers=n, thread_name_prefix="insitu-dec")
+            _DECODE_POOL_WORKERS = workers or min(32, (os.cpu_count() or 4) + 4)
+            _DECODE_POOL = ThreadPoolExecutor(
+                max_workers=_DECODE_POOL_WORKERS, thread_name_prefix="insitu-dec"
+            )
+        elif workers and workers != _DECODE_POOL_WORKERS:
+            logger.warning(
+                "decode_threads=%d ignored: the decode pool is process-wide and was already "
+                "built with %d threads. Thread count is a property of the machine, not of a "
+                "dataset, so the first value wins. Set decode_threads on the first dataset "
+                "created in this process.",
+                workers,
+                _DECODE_POOL_WORKERS,
+            )
         return _DECODE_POOL
 
 
@@ -108,9 +127,9 @@ def reset_decode_pool() -> None:
     pool outlives schedulers). Tests need it to size the pool per case, to run a
     free-threaded arm, and to avoid leaking one case's pool into the next.
     """
-    global _DECODE_POOL
+    global _DECODE_POOL, _DECODE_POOL_WORKERS
     with _DECODE_POOL_LOCK:
-        pool, _DECODE_POOL = _DECODE_POOL, None
+        pool, _DECODE_POOL, _DECODE_POOL_WORKERS = _DECODE_POOL, None, 0
     if pool is not None:
         pool.shutdown(wait=True, cancel_futures=True)
 
@@ -130,8 +149,13 @@ class SchedulerConfig:
     bounded separately by the pool's byte budget (admission evicts unpinned-LRU)."""
 
     decode_threads: int = 0
-    """Size of the decode/scatter pool (GIL-releasing codec decode + the disjoint
-    scatter memcpy run here). ``0`` = auto = ``min(32, cpu+4)``."""
+    """Size of the decode pool (the GIL-releasing codec decode runs here). ``0`` = auto =
+    ``min(32, cpu+4)``.
+
+    The pool is **process-wide** (see :func:`decode_pool`), so this sizes it once, on the
+    first dataset built in the process; a later, different value is ignored with a warning.
+    Thread count is a property of the machine rather than of the data, so one number per
+    process is the honest shape."""
 
     on_bad_chunk: str = "raise"
     """What to do when a stored chunk fails to fetch/decode (truncated/corrupt --

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -569,13 +569,22 @@ class Scheduler:
                         self.bad_chunks.append(read)
                         tile = np.full(ctx.chunk_shape, _bad_fill(ctx), dtype=ctx.dtype)
                     try:
-                        # Delivery used to be a second executor hop, because it was a
-                        # memcpy into the assembled slot. Under chunked slots it is a dict
-                        # assignment and a counter, so the hop is deleted rather than
-                        # fused -- and the decoded tile stops living in this frame across
-                        # it, which is what made tile residency scale with `max_inflight`
-                        # (an IO dial) instead of with the pool doing the work.
-                        w.deliver(tile)
+                        # Delivery used to be a second executor hop, because it was a memcpy
+                        # into the assembled slot. On the tiled path it is now a dict
+                        # assignment and a counter, so the hop is deleted rather than fused
+                        # -- and the decoded tile stops living in this frame across it,
+                        # which is what made tile residency scale with `max_inflight` (an IO
+                        # dial) instead of with the pool doing the work.
+                        #
+                        # It stays a hop when the pool assembles, because delivering the
+                        # LAST tile then also runs the assembly memcpy, the user
+                        # `chunk_transform` and the mmap write-back (`ChunkPool._advance`).
+                        # This loop is zarr's, shared with the whole process: running user
+                        # code on it would stall every other zarr caller.
+                        if self.pool.assembles:
+                            await self._loop.run_in_executor(self._decode_pool, w.deliver, tile)
+                        else:
+                            w.deliver(tile)
                     except Exception as exc:  # noqa: BLE001 - a delivery failure is a real bug
                         w.fail(exc)
             finally:

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -17,9 +17,10 @@ dataset directly (``frameworks.to_jax`` per batch); TF wraps it
 (``frameworks.as_tf_dataset``).
 
 The engine is the fetch scheduler: one event loop streams stored-chunk reads under
-a single ``max_inflight`` budget and scatters decoded tiles into a
-:class:`ChunkPool`. This producer walks the shuffle order, waits on each block's
-assembled chunks, gathers coalesced batches, and unpins the block (making it
+a single ``max_inflight`` budget and delivers decoded tiles into a
+:class:`ChunkPool`, which holds them by reference. This producer walks the shuffle
+order, waits on each block's chunks, gathers coalesced batches, and unpins the block
+(making it
 LRU-evictable / retainable for reuse). Read concurrency (``max_inflight``) and the
 residency budget are independent dials. See [docs/architecture.md] for the pipeline.
 """

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -36,7 +36,7 @@ import numpy as np
 from zarr.abc.store import Store
 
 from .buffers import HostAllocator
-from .pool import ChunkPool, output_geometry
+from .pool import ChunkPool, output_geometry, slot_charge_bytes
 from .scheduler import Scheduler, SchedulerConfig
 from .shuffle import block_shuffled_order, sequential_order
 from .split import SplitManifest, valid_anchor_range
@@ -216,8 +216,13 @@ class InSituDataset:
         out_geoms = list(self._out_geometries.values())
         geoms = list(self.geometries.values())
 
+        assembles = bool(self.chunk_transforms)
+
         def bytes_per_chunk(g: ArrayGeometry, o: ArrayGeometry) -> int:
-            return int(g.sample_chunk_size * int(np.prod(o.inner_shape)) * o.dtype.itemsize)
+            # Exactly what ChunkPool will charge -- see `slot_charge_bytes`. Sizing from the
+            # output shape while the pool charges stored tiles under-provisions the budget,
+            # and the pool then starves mid-epoch instead of merely running lean.
+            return slot_charge_bytes(g, o, assembles=assembles)
 
         if uniform_spc:
             # Uniform chunk size: every variable's chunk aligns to the reference grid, so a

--- a/src/insitubatch/types.py
+++ b/src/insitubatch/types.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field, replace
 from enum import StrEnum
 
 import numpy as np
+from zarr.core.indexing import ChunkProjection
 
 
 class SplitName(StrEnum):
@@ -153,22 +154,35 @@ class ArrayGeometry:
         """
         return (len(self.samples_in_chunk(chunk_index)), *self.inner_shape)
 
-    def tile_placement(
-        self, chunk_index: int, inner_coord: tuple[int, ...]
-    ) -> tuple[tuple[slice, ...], tuple[slice, ...]]:
-        """``(dst, src)`` slices for scattering one decoded tile into its slot.
+    def tile_placement(self, chunk_index: int, inner_coord: tuple[int, ...]) -> ChunkProjection:
+        """Where one stored tile lands inside its outer chunk, as zarr's own projection.
 
-        ``dst`` indexes the outer-chunk slot; ``src`` clips the full chunk-shaped
-        decoded tile to the (possibly partial) edge region -- both axis 0 (short
-        final outer chunk) and the inner edges. After the copy the tile is free.
+        Returns a :class:`zarr.core.indexing.ChunkProjection` -- the vocabulary zarr uses
+        for exactly this ("a mapping of items from chunk to output array"), rather than a
+        private ``(dst, src)`` pair. ``out_selection`` indexes the assembled outer chunk;
+        ``chunk_selection`` clips the full chunk-shaped decoded tile to the (possibly
+        partial) edge region, on axis 0 (short final outer chunk) and the inner edges
+        alike. ``is_complete_chunk`` says the tile is used whole -- i.e. it is not an edge
+        tile -- which is what tells a reader whether the stored chunk carries padding.
+
+        Both selections are **sample-first**, matching the slot and the sample-first tile
+        the scheduler delivers (it moves the sample axis to the front on decode), not the
+        array's physical axis order.
         """
         n0 = len(self.samples_in_chunk(chunk_index))
-        dst = [slice(0, n0)]
+        out = [slice(0, n0)]
         for i, c, s in zip(inner_coord, self.inner_chunks, self.inner_shape, strict=True):
             start = i * c
-            dst.append(slice(start, min(start + c, s)))
-        src = tuple(slice(0, sl.stop - sl.start) for sl in dst)
-        return tuple(dst), src
+            out.append(slice(start, min(start + c, s)))
+        chunk = tuple(slice(0, sl.stop - sl.start) for sl in out)
+        full = (self.sample_chunk_size, *self.inner_chunks)
+        complete = all(sl.stop == n for sl, n in zip(chunk, full, strict=True))
+        return ChunkProjection(
+            chunk_coords=(chunk_index, *inner_coord),
+            chunk_selection=chunk,
+            out_selection=tuple(out),
+            is_complete_chunk=complete,
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/insitubatch/types.py
+++ b/src/insitubatch/types.py
@@ -146,6 +146,18 @@ class ArrayGeometry:
             n *= len(r)
         return n
 
+    def inner_index(self, inner_coord: tuple[int, ...]) -> int:
+        """Row-major position of one inner stored-chunk coord in :meth:`inner_coords`.
+
+        The inverse of iterating ``inner_coords()``. It is what gives the persisted cache a
+        **stable tile order**: a chunk's ``.npy`` stores its tiles tile-major at this index,
+        so a revived file maps back to coordinates without recording them.
+        """
+        idx = 0
+        for i, r in zip(inner_coord, self.inner_grid(), strict=True):
+            idx = idx * len(r) + i
+        return idx
+
     def slot_shape(self, chunk_index: int) -> tuple[int, ...]:
         """Shape of the assembled outer chunk: ``(n_samples_in_chunk, *inner_shape)``.
 
@@ -153,6 +165,15 @@ class ArrayGeometry:
         exactly (no over-allocation, no out-of-range scatter).
         """
         return (len(self.samples_in_chunk(chunk_index)), *self.inner_shape)
+
+    def tile_shape(self) -> tuple[int, ...]:
+        """One stored chunk's shape, **sample-first** -- the shape a decoded tile arrives in.
+
+        The scheduler moves the sample axis to the front on decode, so this is
+        ``(sample_chunk_size, *inner_chunks)`` rather than the array's physical chunk order.
+        Full size always: an edge chunk is stored whole and its padding is kept.
+        """
+        return (self.sample_chunk_size, *self.inner_chunks)
 
     def tile_placement(self, chunk_index: int, inner_coord: tuple[int, ...]) -> ChunkProjection:
         """Where one stored tile lands inside its outer chunk, as zarr's own projection.

--- a/src/insitubatch/types.py
+++ b/src/insitubatch/types.py
@@ -248,9 +248,18 @@ class StoredChunkRead:
 class DecodedChunk:
     """A decoded, in-memory chunk, keyed by its read.
 
-    ``data`` has shape ``(n_samples_in_chunk, *inner_shape)``. The buffer holds a
-    bounded number of these; memory overhead is O(in-flight chunks), independent
-    of batch size.
+    ``data`` has shape ``(n_samples_in_chunk, *inner_shape)`` -- the **logical** chunk, and
+    a real contiguous array, never a view over stored tiles.
+
+    In particular it carries **no stored-chunk padding**. A zarr chunk grid that does not
+    divide the array evenly still stores full-size chunks at the edges (721 rows chunked at
+    180 occupy 900), and the pool holds those tiles whole. Assembly clips every tile to its
+    in-bounds region before a transform sees it, so a transform never has to know the chunk
+    grid, mask an edge, or handle padding values. ``n_samples_in_chunk`` is likewise the
+    real count, so a short final chunk arrives short rather than padded.
+
+    The buffer holds a bounded number of these; memory overhead is O(in-flight chunks),
+    independent of batch size.
     """
 
     read: ChunkRead

--- a/tests/test_chunked_slots.py
+++ b/tests/test_chunked_slots.py
@@ -112,3 +112,37 @@ def test_a_transformed_chunk_is_a_one_tile_slot(tmp_path):
         rows = np.array([[0, 0]], dtype=np.int64)
         got = pool.gather(rows, ["v"], geom.sample_chunk_size).arrays["v"]
     np.testing.assert_allclose(got[0], src[0] / 2.0, rtol=1e-6)
+
+
+def test_user_code_never_runs_on_the_shared_event_loop(tmp_path):
+    """A ``chunk_transform`` must not execute on zarr's process-global loop.
+
+    Publishing an assembled chunk runs the assembly memcpy, the user transform and the
+    mmap write-back. The scheduler now shares zarr's loop with the whole process, so doing
+    any of that on the loop thread stalls every other zarr caller -- the exact shared-fate
+    failure the loop consolidation is meant to avoid. Regression: an earlier draft
+    delivered inline unconditionally and ran user code on ``zarr_io``.
+    """
+    import threading
+
+    ran_on: list[str] = []
+
+    class Spy:
+        def __call__(self, chunk):
+            ran_on.append(threading.current_thread().name)
+            return chunk
+
+    url, _ = _store(tmp_path, (2, 8, 8), (1, 4, 4), name="thread.zarr")
+    geoms = open_geometries(obstore_store(url))
+    geom = geoms["v"]
+    pool = ChunkPool(geoms, chunk_transforms=[Spy()])
+    with Scheduler(obstore_store(url), geoms, pool, SchedulerConfig()) as sched:
+        sched.start(range(geom.n_chunks), geom.sample_chunk_size)
+        for cid in range(geom.n_chunks):
+            sched.pool.wait_ready("v", cid, sched.owner)
+
+    assert ran_on, "the transform never ran"
+    assert all(t.startswith("insitu-dec") for t in ran_on), (
+        f"chunk_transform ran on {sorted(set(ran_on))}; it must run on the decode pool, "
+        "never on the shared event loop"
+    )

--- a/tests/test_chunked_slots.py
+++ b/tests/test_chunked_slots.py
@@ -263,3 +263,60 @@ def test_a_version_2_cache_is_rejected_not_misread(tmp_path):
     reset = ChunkPool(geoms, backing_dir=cache, persist=True, reset_stale_cache=True)
     assert reset.manifest_entries == 0
     assert not reset.pin_if_ready("v", 0, reset.new_owner()), "a reset cache must not revive"
+
+
+def test_a_transform_never_sees_stored_chunk_padding(tmp_path):
+    """User code gets the logical chunk: no edge padding, no fill values, no masking.
+
+    721 rows chunked at 180 occupy 900 rows of storage. The pool holds those tiles whole,
+    so the padding is real -- but assembly clips every tile before the transform runs, and
+    `DecodedChunk.data` documents that guarantee.
+    """
+    seen: list[tuple] = []
+
+    class Spy:
+        def __call__(self, chunk):
+            seen.append((chunk.data.shape, float(np.nanmin(chunk.data)), chunk.data.base))
+            return chunk
+
+    url, _ = _store(tmp_path, (2, 721, 360), (1, 180, 360), name="pad.zarr")
+    geoms = open_geometries(obstore_store(url))
+    geom = geoms["v"]
+    assert geom.inner_grid()[0].stop * 180 > geom.inner_shape[0], "grid must overhang the array"
+
+    pool = ChunkPool(geoms, chunk_transforms=[Spy()])
+    with Scheduler(obstore_store(url), geoms, pool, SchedulerConfig()) as sched:
+        sched.start(range(geom.n_chunks), geom.sample_chunk_size)
+        for cid in range(geom.n_chunks):
+            sched.pool.wait_ready("v", cid, sched.owner)
+
+    assert seen, "the transform never ran"
+    for shape, _mn, base in seen:
+        assert shape == geom.slot_shape(0), f"transform saw {shape}, not the logical chunk"
+        assert base is None, "the transform must get a real array, not a view over tiles"
+
+
+def test_an_assembling_slot_is_charged_its_fill_time_residency(tmp_path):
+    """A transform pool holds SOURCE tiles for its whole fill, then collapses to one.
+
+    On a ragged grid the tiles are the larger shape, so charging only the assembled output
+    under-reports the entire fill window -- 1.248x on this geometry.
+    """
+    url, _ = _store(tmp_path, (2, 721, 1440), (1, 180, 360), name="charge.zarr")
+    geoms = open_geometries(obstore_store(url))
+    geom = geoms["v"]
+
+    tiles = geom.n_inner_chunks(0) * int(np.prod(geom.tile_shape())) * geom.dtype.itemsize
+    assembled = int(np.prod(geom.slot_shape(0))) * geom.dtype.itemsize
+    assert tiles > assembled
+
+    class Scale:
+        def __call__(self, chunk):
+            return chunk
+
+    for transforms in ([], [Scale()]):
+        pool = ChunkPool(geoms, chunk_transforms=transforms)
+        pool.try_admit("v", 0, pool.new_owner())
+        assert pool.resident_bytes == tiles, (
+            f"charged {pool.resident_bytes} but holds {tiles} bytes of tiles during fill"
+        )

--- a/tests/test_chunked_slots.py
+++ b/tests/test_chunked_slots.py
@@ -1,0 +1,114 @@
+"""The pool's buffer unit is the stored chunk: residency, edges, and the budget.
+
+A slot adopts decoded tiles by reference instead of copying them into one assembled
+array. Two consequences need pinning, because neither is visible on a grid that divides
+evenly -- and every probe store we had divided evenly (720/45, 1440/90, 2048/256):
+
+* a stored chunk is decoded **whole**, padding included, and we keep it whole, so
+  residency is ``n_tiles * chunk_shape`` and can EXCEED the assembled ``slot_shape``;
+* the budget must charge that, or a pool told N bytes quietly resides more.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import zarr
+
+from insitubatch import ensure_local_dir, obstore_store, open_geometries
+from insitubatch.pool import ChunkPool
+from insitubatch.scheduler import Scheduler, SchedulerConfig
+from insitubatch.transforms import StandardScaler
+
+
+def _store(tmp_path, shape, chunks, name="ragged.zarr"):
+    url = f"file://{tmp_path}/{name}"
+    ensure_local_dir(url)
+    g = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
+    a = g.create_array("v", shape=shape, chunks=chunks, dtype="f4")
+    a[:] = np.random.default_rng(0).standard_normal(shape).astype("f4")
+    return url, np.asarray(a[:])
+
+
+def test_ragged_grid_charges_the_padding_it_actually_holds(tmp_path):
+    """721 rows chunked at 180 stores 900 rows. The budget must say so.
+
+    Charging ``slot_shape`` would report 3.96 MiB while holding 4.94 MiB -- a pool told
+    "2048 MiB" would resident ~2560. The ratio here is the ERA5 one, 1.248x.
+    """
+    url, _ = _store(tmp_path, (2, 721, 1440), (1, 180, 360))
+    geoms = open_geometries(obstore_store(url))
+    geom = geoms["v"]
+    assert geom.n_inner_chunks(0) == 5 * 4, "grid must be ragged for this test to mean anything"
+
+    pool = ChunkPool(geoms)
+    pool.try_admit("v", 0, pool.new_owner())
+
+    assembled = int(np.prod(geom.slot_shape(0))) * geom.dtype.itemsize
+    held = geom.n_inner_chunks(0) * int(np.prod(geom.chunks)) * geom.dtype.itemsize
+    assert held > assembled, "a ragged grid stores more than the array covers"
+    assert pool.resident_bytes == held
+    assert pool.resident_bytes != assembled
+    assert held / assembled == pytest.approx(1.248, abs=0.005)
+
+
+def test_short_final_chunk_charges_the_full_tiles(tmp_path):
+    """A short final OUTER chunk compounds it: tiles are spc-deep regardless."""
+    url, _ = _store(tmp_path, (10, 8, 8), (4, 8, 8), name="short.zarr")
+    geoms = open_geometries(obstore_store(url))
+    geom = geoms["v"]
+    last = geom.n_chunks - 1
+    assert len(geom.samples_in_chunk(last)) == 2, "final chunk must be short"
+
+    pool = ChunkPool(geoms)
+    pool.try_admit("v", last, pool.new_owner())
+    assembled = int(np.prod(geom.slot_shape(last))) * geom.dtype.itemsize
+    held = geom.n_inner_chunks(last) * int(np.prod(geom.chunks)) * geom.dtype.itemsize
+    assert pool.resident_bytes == held == 2 * assembled
+
+
+def test_tiles_are_adopted_not_copied(tmp_path):
+    """The decoded tile IS the resident buffer -- the fill path has no memcpy left."""
+    url, _ = _store(tmp_path, (1, 8, 8), (1, 4, 4), name="adopt.zarr")
+    geoms = open_geometries(obstore_store(url))
+    pool = ChunkPool(geoms)
+    pool.try_admit("v", 0, pool.new_owner())
+    tile = np.arange(16, dtype="f4").reshape(1, 4, 4)
+    pool.deliver_tile("v", 0, (0, 0), tile)
+    assert pool._slots[("v", 0)].tiles[(0, 0)] is tile, "the pool copied instead of adopting"
+
+
+@pytest.mark.parametrize("chunks", [(1, 180, 360), (1, 721, 1440)])
+def test_ragged_gather_matches_the_array(tmp_path, chunks):
+    """End to end: edge tiles carry padding, and none of it reaches the batch."""
+    url, src = _store(tmp_path, (3, 721, 1440), chunks, name=f"g{chunks[1]}.zarr")
+    geoms = open_geometries(obstore_store(url))
+    geom = geoms["v"]
+    with Scheduler(obstore_store(url), geoms, ChunkPool(geoms), SchedulerConfig()) as sched:
+        sched.start(range(geom.n_chunks), geom.sample_chunk_size)
+        got = []
+        for cid in range(geom.n_chunks):
+            sched.pool.wait_ready("v", cid, sched.owner)
+            rows = np.array([[cid, 0]], dtype=np.int64)
+            got.append(sched.pool.gather(rows, ["v"], geom.sample_chunk_size).arrays["v"])
+    np.testing.assert_array_equal(np.concatenate(got), src)
+
+
+def test_a_transformed_chunk_is_a_one_tile_slot(tmp_path):
+    """A transform needs a whole array, so its slot republishes as a single tile.
+
+    That is what keeps `gather` on one path: it never asks "assembled or tiled?", because
+    a whole-array slot is just a 1x1 grid.
+    """
+    url, src = _store(tmp_path, (2, 8, 8), (1, 4, 4), name="tx.zarr")
+    geoms = open_geometries(obstore_store(url))
+    geom = geoms["v"]
+    pool = ChunkPool(geoms, chunk_transforms=[StandardScaler(mean={"v": 0.0}, std={"v": 2.0})])
+    with Scheduler(obstore_store(url), geoms, pool, SchedulerConfig()) as sched:
+        sched.start(range(geom.n_chunks), geom.sample_chunk_size)
+        sched.pool.wait_ready("v", 0, sched.owner)
+        slot = pool._slots[("v", 0)]
+        assert len(slot.tiles) == 1, "a transformed chunk must publish as one tile"
+        rows = np.array([[0, 0]], dtype=np.int64)
+        got = pool.gather(rows, ["v"], geom.sample_chunk_size).arrays["v"]
+    np.testing.assert_allclose(got[0], src[0] / 2.0, rtol=1e-6)

--- a/tests/test_chunked_slots.py
+++ b/tests/test_chunked_slots.py
@@ -146,3 +146,120 @@ def test_user_code_never_runs_on_the_shared_event_loop(tmp_path):
         f"chunk_transform ran on {sorted(set(ran_on))}; it must run on the decode pool, "
         "never on the shared event loop"
     )
+
+
+# -- persistence: tile-major on disk, one path in memory -----------------------------
+
+
+def _fill(url, geoms, **poolkw):
+    """Drive one full pass so every chunk is fetched, assembled and persisted."""
+    geom = geoms["v"]
+    pool = ChunkPool(geoms, **poolkw)
+    with Scheduler(obstore_store(url), geoms, pool, SchedulerConfig()) as sched:
+        sched.start(range(geom.n_chunks), geom.sample_chunk_size)
+        for cid in range(geom.n_chunks):
+            sched.pool.wait_ready("v", cid, sched.owner)
+    return pool
+
+
+def test_cache_dir_no_longer_assembles(tmp_path):
+    """Persisting is not a reason to assemble -- only a chunk_transform is."""
+    url, _ = _store(tmp_path, (2, 8, 8), (1, 4, 4), name="p1.zarr")
+    geoms = open_geometries(obstore_store(url))
+    assert ChunkPool(geoms, backing_dir=tmp_path / "c1", persist=True).assembles is False
+    assert ChunkPool(geoms).assembles is False
+
+
+def test_persisted_chunk_is_stored_tile_major(tmp_path):
+    """One .npy per chunk, shaped (n_tiles, *tile_shape), each tile contiguous."""
+    url, src = _store(tmp_path, (2, 8, 8), (1, 4, 4), name="p2.zarr")
+    geoms = open_geometries(obstore_store(url))
+    geom = geoms["v"]
+    cache = tmp_path / "c2"
+    _fill(url, geoms, backing_dir=cache, persist=True)
+
+    files = sorted(cache.glob("*.npy"))
+    assert len(files) == geom.n_chunks, "file count per chunk must not change"
+    on_disk = np.lib.format.open_memmap(files[0], mode="r")
+    assert on_disk.shape == (geom.n_inner_chunks(0), *geom.tile_shape())
+    # every tile is contiguous in the file, in inner_index order
+    for coord in geom.inner_coords():
+        proj = geom.tile_placement(0, coord)
+        np.testing.assert_array_equal(
+            on_disk[geom.inner_index(coord)][proj.chunk_selection], src[0:1][proj.out_selection]
+        )
+
+
+def test_revived_tiles_are_zero_copy_views_of_one_mapping(tmp_path):
+    """A cross-run hit maps the file and slices it -- it does not read it into memory."""
+    url, src = _store(tmp_path, (2, 8, 8), (1, 4, 4), name="p3.zarr")
+    geoms = open_geometries(obstore_store(url))
+    geom = geoms["v"]
+    cache = tmp_path / "c3"
+    _fill(url, geoms, backing_dir=cache, persist=True)
+
+    revived = ChunkPool(geoms, backing_dir=cache, persist=True)
+    # A cross-run hit is revived by `pin_if_ready` -- the driver's "can I skip the fetch?"
+    # question -- not by `try_admit`, which is the miss path that allocates for a fetch.
+    assert revived.pin_if_ready("v", 0, revived.new_owner())
+    slot = revived._slots[("v", 0)]
+    assert slot.state.name == "READY", "a persisted chunk must revive ready, not refetch"
+    assert len(slot.tiles) == geom.n_inner_chunks(0), "revive must come back TILED, not assembled"
+    for tile in slot.tiles.values():
+        assert tile.base is slot.backing, "revived tiles must be views of the one mapping"
+
+
+def test_persist_round_trips_the_data(tmp_path):
+    """The real gate: a cross-run cache hit gathers byte-identical to a cold read."""
+    url, src = _store(tmp_path, (4, 721, 180), (1, 180, 90), name="p4.zarr")
+    geoms = open_geometries(obstore_store(url))
+    geom = geoms["v"]
+    assert geom.n_inner_chunks(0) == 5 * 2, "ragged, so edge padding is exercised"
+    cache = tmp_path / "c4"
+
+    def read(pool):
+        out = []
+        for cid in range(geom.n_chunks):
+            rows = np.array([[cid, 0]], dtype=np.int64)
+            out.append(pool.gather(rows, ["v"], geom.sample_chunk_size).arrays["v"])
+        return np.concatenate(out)
+
+    cold = _fill(url, geoms, backing_dir=cache, persist=True)
+    np.testing.assert_array_equal(read(cold), src)
+
+    warm = ChunkPool(geoms, backing_dir=cache, persist=True)
+    owner = warm.new_owner()
+    for cid in range(geom.n_chunks):
+        assert warm.pin_if_ready("v", cid, owner), "every chunk should revive from disk"
+    np.testing.assert_array_equal(read(warm), src)
+    assert warm.misses == 0, "a fully persisted cache should serve every chunk"
+
+
+def test_a_version_2_cache_is_rejected_not_misread(tmp_path):
+    """The layout changed, so an old cache must be reset -- never reinterpreted.
+
+    A v2 ``.npy`` holds one assembled ``slot_shape`` array; read as tile-major it would be
+    plausible-looking garbage. The manifest version is what stops that.
+    """
+    import json
+
+    url, _ = _store(tmp_path, (2, 8, 8), (1, 4, 4), name="p5.zarr")
+    geoms = open_geometries(obstore_store(url))
+    cache = tmp_path / "c5"
+    _fill(url, geoms, backing_dir=cache, persist=True)
+
+    log = next(cache.glob("*.log"), None) or next(cache.glob("*.jsonl"), None)
+    assert log is not None, f"no cache log found in {sorted(cache.iterdir())}"
+    lines = log.read_text().splitlines()
+    header = json.loads(lines[0])
+    header["format_version"] = 2  # pretend the cache predates the tile-major layout
+    log.write_text("\n".join([json.dumps(header), *lines[1:]]) + "\n")
+
+    # Loud by design: a stale cache is a user decision, not something to silently discard.
+    with pytest.raises(ValueError, match="stale .log format changed"):
+        ChunkPool(geoms, backing_dir=cache, persist=True)
+
+    # ...and with consent it resets and refetches rather than reinterpreting v2 bytes.
+    reset = ChunkPool(geoms, backing_dir=cache, persist=True, reset_stale_cache=True)
+    assert reset.manifest_entries == 0
+    assert not reset.pin_if_ready("v", 0, reset.new_owner()), "a reset cache must not revive"

--- a/tests/test_fsspec_store.py
+++ b/tests/test_fsspec_store.py
@@ -39,21 +39,24 @@ def test_fsspec_store_round_trips_an_epoch(write_zarr) -> None:
     np.testing.assert_array_equal(got, srcs["t2m"])
 
 
-def test_fsspec_store_io_routes_to_zarr_loop(tmp_path) -> None:
-    # Regression for the cross-loop crash: a genuinely-async fsspec store (gcsfs, or
-    # the local async wrapper here) binds its session to the loop that first awaits it
-    # -- zarr's -- so the scheduler must drive its IO there, not on its own loop. An
-    # obstore store is loop-agnostic and needs no routing. (The round-trip above already
-    # exercises the routed read end to end; this pins the selection directly.)
+def test_scheduler_drives_both_backends_on_zarr_loop(write_zarr) -> None:
+    # Regression for the cross-loop crash, restated for the consolidated design. A
+    # genuinely-async fsspec store (gcsfs, or the local async wrapper here) binds its
+    # session to the loop that first awaits it -- zarr's -- which used to force a
+    # per-read bridge off our own loop. The scheduler now *runs on* that loop, so both
+    # backends are a plain inline await and there is no routing decision left to make.
+    # This pins the property the bridge used to provide: same loop, either backend.
     from zarr.core.sync import _get_loop
 
-    from insitubatch import obstore_store
-    from insitubatch.scheduler import _fsspec_io_loop
+    from insitubatch import obstore_store, open_geometries
+    from insitubatch.pool import ChunkPool
+    from insitubatch.scheduler import Scheduler, SchedulerConfig
 
-    fss = fsspec_store(f"file://{tmp_path}")  # async fsspec wrapper -> route to zarr's loop
-    assert _fsspec_io_loop(fss) is _get_loop()
-    obs = obstore_store(f"file://{tmp_path}")  # loop-agnostic -> await inline
-    assert _fsspec_io_loop(obs) is None
+    url, _ = write_zarr(n=8, spc=2)
+    for store in (fsspec_store(url), obstore_store(url)):
+        geoms = open_geometries(store)
+        with Scheduler(store, geoms, ChunkPool(geoms), SchedulerConfig()) as sched:
+            assert sched._loop is _get_loop()
 
 
 def test_fsspec_store_writes_local_zarr(tmp_path) -> None:

--- a/tests/test_loop_ownership.py
+++ b/tests/test_loop_ownership.py
@@ -1,0 +1,141 @@
+"""Teardown ownership: what a scheduler may cancel, and whose loop it may stop.
+
+These are the regressions behind the #30 shared-loop decision. Every failure they
+cover lives in ``close()``, not in steady state -- a back-pressured ``_drive`` on a
+shared loop does *not* starve other work, but a naive teardown destroys it:
+
+1. ``asyncio.all_tasks(loop)`` is the **whole loop's** task set, so cancelling it
+   kills unrelated ``zarr`` sync work mid-flight (observed as ``CancelledError``
+   raised inside an innocent read on another thread).
+2. ``loop.stop()`` / ``loop.close()`` on a borrowed loop leaves zarr's
+   process-global loop dead for the rest of the process.
+
+Both are silent and intermittent in the wild, so they are pinned here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import numpy as np
+import pytest
+import zarr
+
+from insitubatch import ensure_local_dir, obstore_store, open_geometries
+from insitubatch.pool import ChunkPool
+from insitubatch.scheduler import Scheduler, SchedulerConfig
+
+
+@pytest.fixture
+def store_url(tmp_path):
+    url = f"file://{tmp_path}/own.zarr"
+    ensure_local_dir(url)
+    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
+    arr = group.create_array("v", shape=(4, 6, 6), chunks=(1, 6, 6), dtype="f4")
+    arr[:] = np.random.default_rng(0).standard_normal((4, 6, 6)).astype("f4")
+    return url
+
+
+def _sched(url) -> Scheduler:
+    geoms = open_geometries(obstore_store(url))
+    return Scheduler(url, geoms, ChunkPool(geoms), SchedulerConfig(max_inflight=2))
+
+
+def test_shutdown_cancels_only_our_tasks(store_url):
+    """A foreign task on our loop survives ``close()``; ours are cancelled."""
+    sched = _sched(store_url)
+    started = threading.Event()
+    foreign_cancelled = threading.Event()
+    foreign_finished = threading.Event()
+
+    async def foreign() -> None:
+        # Stands in for unrelated zarr-sync work sharing the loop.
+        started.set()
+        try:
+            await asyncio.sleep(0.5)
+        except asyncio.CancelledError:
+            foreign_cancelled.set()
+            raise
+        foreign_finished.set()
+
+    fut = asyncio.run_coroutine_threadsafe(foreign(), sched._loop)
+    assert started.wait(timeout=5)
+    # Cancel + drain OUR tasks only. (close() would also stop the loop, which would
+    # orphan the foreign task for reasons unrelated to what this test pins.)
+    done = asyncio.run_coroutine_threadsafe(sched._shutdown(), sched._loop)
+    done.result(timeout=5)
+
+    assert not foreign_cancelled.is_set(), "shutdown cancelled a task it did not create"
+    fut.result(timeout=5)
+    assert foreign_finished.is_set()
+    sched.close()
+
+
+def test_shutdown_cancels_what_we_registered(store_url):
+    """The flip side of the pair: anything in ``_tasks`` IS cancelled.
+
+    Together with the test above this pins the whole contract -- in ``_tasks`` means
+    ours and gets cancelled, absent from it means someone else's and is left alone --
+    without racing a real driver to completion.
+    """
+    sched = _sched(store_url)
+    running = threading.Event()
+
+    async def ours() -> None:
+        running.set()
+        await asyncio.sleep(30)
+
+    async def register() -> asyncio.Task:
+        task = asyncio.create_task(ours())
+        sched._tasks.add(task)
+        task.add_done_callback(sched._tasks.discard)
+        return task
+
+    task = asyncio.run_coroutine_threadsafe(register(), sched._loop).result(timeout=5)
+    assert running.wait(timeout=5)
+    asyncio.run_coroutine_threadsafe(sched._shutdown(), sched._loop).result(timeout=5)
+
+    assert task.cancelled(), "shutdown left one of our own tasks running"
+    sched.close()
+
+
+def test_parked_driver_is_registered_and_cancelled(store_url):
+    """A real driver, parked on a full budget, is tracked and torn down by close().
+
+    Budget holds one chunk while four are requested and nothing consumes, so ``_admit``
+    parks -- the state ``close()`` actually has to unwind mid-epoch.
+    """
+    geoms = open_geometries(obstore_store(store_url))
+    geom = next(iter(geoms.values()))
+    one_chunk = int(np.prod(geom.slot_shape(0))) * geom.dtype.itemsize
+    pool = ChunkPool(geoms, budget_bytes=one_chunk)
+    sched = Scheduler(store_url, geoms, pool, SchedulerConfig(max_inflight=2))
+
+    sched.start(np.arange(geom.n_chunks), geom.sample_chunk_size)
+    for _ in range(500):  # wait for the driver to park, not for a wall-clock guess
+        if sched._tasks:
+            break
+        threading.Event().wait(0.01)
+    assert sched._tasks, "driver never registered itself for shutdown"
+
+    sched.close()
+    assert not [t for t in sched._tasks if not t.done()], "close() left our tasks running"
+
+
+def test_borrowed_loop_is_not_stopped_or_closed(store_url):
+    """With ``_owns_loop`` false, ``close()`` leaves the loop running and usable."""
+    sched = _sched(store_url)
+    sched._owns_loop = False  # pretend the loop was handed to us (the #30 shape)
+    loop = sched._loop
+
+    sched.close()
+
+    assert not loop.is_closed(), "close() closed a loop it does not own"
+    assert loop.is_running(), "close() stopped a loop it does not own"
+    # ...and it still runs work afterwards, which is the property that actually matters.
+    assert asyncio.run_coroutine_threadsafe(asyncio.sleep(0, result=7), loop).result(timeout=5) == 7
+
+    # tidy up the loop this test is now responsible for
+    sched._owns_loop = True
+    sched.close()

--- a/tests/test_loop_ownership.py
+++ b/tests/test_loop_ownership.py
@@ -21,6 +21,7 @@ import threading
 import numpy as np
 import pytest
 import zarr
+from zarr.core.sync import _get_loop
 
 from insitubatch import ensure_local_dir, obstore_store, open_geometries
 from insitubatch.pool import ChunkPool
@@ -124,10 +125,17 @@ def test_parked_driver_is_registered_and_cancelled(store_url):
 
 
 def test_borrowed_loop_is_not_stopped_or_closed(store_url):
-    """With ``_owns_loop`` false, ``close()`` leaves the loop running and usable."""
+    """``close()`` leaves zarr's loop running and usable -- it is not ours to close.
+
+    Note there is nothing to "tidy up" afterwards: the loop belongs to zarr and lives for
+    the process. An earlier draft of this test "cleaned up" by closing the loop itself,
+    which stopped zarr's process-global loop and hung every subsequent test in the session
+    on ``zarr.core.sync.sync()``. That is exactly the failure mode this contract exists to
+    prevent, and it is one line away at all times.
+    """
     sched = _sched(store_url)
-    sched._owns_loop = False  # pretend the loop was handed to us (the #30 shape)
     loop = sched._loop
+    assert loop is _get_loop(), "the scheduler must run on zarr's loop, not one of its own"
 
     sched.close()
 
@@ -135,7 +143,3 @@ def test_borrowed_loop_is_not_stopped_or_closed(store_url):
     assert loop.is_running(), "close() stopped a loop it does not own"
     # ...and it still runs work afterwards, which is the property that actually matters.
     assert asyncio.run_coroutine_threadsafe(asyncio.sleep(0, result=7), loop).result(timeout=5) == 7
-
-    # tidy up the loop this test is now responsible for
-    sched._owns_loop = True
-    sched.close()

--- a/tests/test_loop_ownership.py
+++ b/tests/test_loop_ownership.py
@@ -143,3 +143,50 @@ def test_borrowed_loop_is_not_stopped_or_closed(store_url):
     assert loop.is_running(), "close() stopped a loop it does not own"
     # ...and it still runs work afterwards, which is the property that actually matters.
     assert asyncio.run_coroutine_threadsafe(asyncio.sleep(0, result=7), loop).result(timeout=5) == 7
+
+
+def test_decode_pool_is_process_wide_and_warns_on_a_second_size(caplog):
+    """One pool per process, sized once; a later different request warns and is ignored.
+
+    Thread count is a property of the machine, not of a dataset, so the first value wins
+    rather than the last. Silently ignoring it would be worse than either.
+    """
+    from insitubatch.scheduler import decode_pool, reset_decode_pool
+
+    reset_decode_pool()
+    try:
+        first = decode_pool(3)
+        assert first._max_workers == 3
+
+        with caplog.at_level("WARNING"):
+            again = decode_pool(3)  # same size -> no warning
+        assert again is first
+        assert not caplog.records
+
+        with caplog.at_level("WARNING"):
+            other = decode_pool(9)  # different size -> warn, keep the first pool
+        assert other is first, "a second request must not build a second pool"
+        assert first._max_workers == 3, "the live pool must not be resized underneath users"
+        assert any("decode_threads=9 ignored" in r.getMessage() for r in caplog.records)
+    finally:
+        reset_decode_pool()
+
+
+def test_reset_decode_pool_rebuilds(store_url):
+    """The test seam actually works -- otherwise every test above shares one pool."""
+    from insitubatch.scheduler import decode_pool, reset_decode_pool
+
+    reset_decode_pool()
+    try:
+        a = decode_pool(2)
+        reset_decode_pool()
+        b = decode_pool(4)
+        assert b is not a and b._max_workers == 4
+        # ...and a scheduler built after the reset still works end to end.
+        sched = _sched(store_url)
+        geom = next(iter(sched._geometries.values()))
+        sched.start(np.arange(geom.n_chunks), geom.sample_chunk_size)
+        sched.pool.wait_ready("v", 0, sched.owner)
+        sched.close()
+    finally:
+        reset_decode_pool()

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -173,8 +173,9 @@ def test_pool_concurrent_scatter_is_race_free() -> None:
         pool.try_admit("v", 0, owner)
 
         def scatter(ic, pool=pool, geom=geom, ref=ref) -> None:  # default-bind per round
-            dst, _src = geom.tile_placement(0, ic)
-            pool.deliver_tile("v", 0, ic, ref[dst].copy())  # full chunk-shaped tile
+            proj = geom.tile_placement(0, ic)
+            # full chunk-shaped tile: the pool adopts it by reference, so hand it its own
+            pool.deliver_tile("v", 0, ic, ref[proj.out_selection].copy())
 
         with ThreadPoolExecutor(max_workers=32) as ex:
             list(ex.map(scatter, coords))

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -91,20 +91,23 @@ def test_scheduler_inflight_saturates_to_budget(tiled_store):
         assert sched.inflight_peak == 4
 
 
-def test_scheduler_close_closes_the_loop(tiled_store):
-    """close() must close the loop, not leave it for GC.
+def test_scheduler_close_leaves_the_borrowed_loop_alive(tiled_store):
+    """close() must leave zarr's loop running and usable -- it is not ours to close.
 
-    An unclosed event loop is re-closed by ``BaseEventLoop.__del__`` during garbage
-    collection, which raises ``ValueError: Invalid file descriptor: -1`` on the
-    already-gone self-pipe socket -- a noisy unraisable first seen under
-    free-threaded 3.13t (where finalizer timing exposes the latent leak).
+    This test used to assert the opposite. Orchestration now runs on zarr's
+    process-global loop (``zarr.core.sync._get_loop()``), so closing it would leave every
+    other zarr sync call in the process dead. The leak the old contract guarded against
+    -- an unclosed loop re-closed by ``BaseEventLoop.__del__``, raising ``ValueError:
+    Invalid file descriptor: -1`` on the gone self-pipe -- cannot happen to a loop we
+    never created and zarr keeps alive for the process lifetime.
     """
     url, _ = tiled_store
     geoms = open_geometries(obstore_store(url), variables=["single_inner"])
     sched = _make(url, geoms)
     sched.start(range(geoms["single_inner"].n_chunks), geoms["single_inner"].sample_chunk_size)
     sched.close()
-    assert sched._loop.is_closed()
+    assert not sched._loop.is_closed(), "close() closed a loop it does not own"
+    assert sched._loop.is_running(), "close() stopped a loop it does not own"
 
 
 def test_scheduler_windowed_views_decode_once_and_lead(tiled_store):

--- a/uv.lock
+++ b/uv.lock
@@ -1428,7 +1428,7 @@ requires-dist = [
     { name = "virtualizarr", marker = "extra == 'virtual'", specifier = ">=1.2" },
     { name = "xarray", specifier = ">=2024.9" },
     { name = "xbatcher", marker = "extra == 'bench'", specifier = ">=0.3" },
-    { name = "zarr", specifier = ">=3.0" },
+    { name = "zarr", specifier = ">=3.3" },
     { name = "zarr", marker = "extra == 'astronomy'", specifier = ">=3.3" },
 ]
 provides-extras = ["torch", "jax", "tf", "gpu", "virtual", "cache", "bench", "docs", "icechunk", "gcsfs", "arraylake", "astronomy"]


### PR DESCRIPTION
## Summary

Closes #30. Two changes that had to land together, because both rewrite `Scheduler._one`:
sequencing them separately meant writing the concurrency core twice with a guaranteed
conflict.

**1. Orchestration runs on zarr's event loop.** There is no second loop, no per-read
bridge, and no per-pass thread churn — gcsfs and obstore are both a plain inline `await`.
Deleted: `_io`, `_foreign_loop`, `_fsspec_io_loop`, `_run_loop`, the `insitu-sched` thread,
and the per-pass `ThreadPoolExecutor` (three of four execution contexts were rebuilt every
epoch).

What made this possible is that `zarr.core.chunk_utils.ChunkTransform.decode_chunk` (zarr
3.3.0) is **synchronous**. The async codec pipeline dispatches to the *loop's default
executor*, so keeping our own decode pool meant claiming that slot — which on a borrowed
loop retunes zarr's concurrency process-wide and then breaks it on close. Calling a sync
decode ourselves means we pass our executor explicitly and never touch the default.

**2. The pool's buffer unit is the stored chunk.** A slot was one assembled ndarray that
every decoded tile was memcpy'd into; it is now the decoded tiles themselves, adopted by
reference, with placement deferred to `gather`. Stored chunks are kept **whole** — one
buffer unit, one shape.

`gather` has no dispatch at all: a transformed chunk republishes as a *one-tile* slot
(`output_geometry` already sets post-transform `chunks` to the full inner shape), and a
persisted chunk is stored tile-major so a revived chunk is tiled exactly like a fresh one.
There is never an "assembled or tiled?" branch.

`DESIGN.md`'s **scatter-assemble** was a documented design decision, so per `CLAUDE.md`
this went to #30 for discussion before code. That decision is now recorded as superseded
rather than quietly removed.

### Built on zarr's abstractions, not a private dict of ndarrays

A deliberate goal, not incidental: the chunked pool speaks zarr's own vocabulary for
"a grid of inner chunks", so the structure stays legible to zarr and to the `decode(out=)`
conversation upstream.

| ours | zarr | status |
|---|---|---|
| `ArrayGeometry.tile_placement` | `zarr.core.indexing.ChunkProjection` | **adopted** — it now *returns* one (`chunk_coords`, `chunk_selection`, `out_selection`, `is_complete_chunk`) instead of a private `(dst, src)` pair |
| our own sync codec whitelist | `zarr.core.chunk_utils.ChunkTransform.decode_chunk` | **adopted** — so the whitelist is **work we no longer have to do**; the design note had costed it, with GZip and zarr-v2 `V2Codec` traps |
| `ArrayGeometry` inner grid | `DimensionGridLike` | **already conformant** — proven by the pre-existing `tests/test_zarr_indexing_parity.py`, unchanged here |

`decode_and_scatter_chunk` is *not* used, and that is the point: it is the decode+scatter
fusion the design note wanted hand-rolled, and a chunked slot removes the scatter entirely,
so there is nothing left to fuse.

**Where we deliberately do not map.** A `_Slot` is not a zarr *shard*, despite the
identical shape: a shard is a **storage** unit (one addressable object holding a grid of
chunks), a slot is a **residency** unit (the stored chunks sharing a sample-axis index,
never stored or addressed as one object). An earlier draft of this PR called it a "decoded
shard"; that was wrong and is corrected. Separately, what this codebase calls a *tile* is
what its own public API calls a **stored chunk** — two names for one concept. Both the
duplication and the broader question of aligning our "chunk" (a group, for which zarr has
no word) are split out to
**[#40](https://github.com/emfdavid/insitubatch/issues/40)**, deliberately out of scope:
a rename that wide would hide the functional changes in this diff.

Two zarr facilities deliberately **not** adopted:

- **`FusedCodecPipeline.read_sync` takes `ByteGetter`s — it owns the IO.** Adopting it
  surrenders our scheduler, `max_inflight` and back-pressure. `decode_chunk` is IO-free,
  which is why it is the one we want.
- **The process-global `codec_pipeline.path` is not flipped.** Same objection as `mallopt`:
  it retunes the substrate under user code. We construct our own `ChunkTransform` from the
  array's declared codecs instead.

### Sold as simplicity, not throughput

**Wall clock is a null.** 4 vCPU (L3 33 MiB) and 16 vCPU / 62 GB, local zarr on NVMe,
`file://` via obstore, zarr 3.3.0, `batch_size=16`, `block_chunks=8`, `max_inflight=32`,
`decode_threads=8`, 3 epochs, medians of 3 interleaved A/B/A/B reps, fingerprint-verified
per arm. `main` is the control, measured in the same session:

| store | inner chunk | arm | wall (4 vCPU) | wall (16 vCPU) |
|---|---|---|---|---|
| `arco_many` (256×720×1440, spc 16) | 45×90 | warm | 1.006× | 1.004× |
| `ragged` (250×721×1440, spc 16) | 180×360 | warm | 0.997× | 1.007× |
| `tiled512` (512×2048×2048, spc 1) | 256×256 | cold | 1.040× | 1.116× |

The memcpy this deletes is 7.7–10.1% of process CPU on an inner-tiled store and never
surfaces at wall level, because it was not the bottleneck. **No throughput claim is made.**

The gather cost is **not** intrinsic — a controlled sweep varying only the inner tile grid
(same array, same config, warm so decode contention is zero):

| tiles/chunk | 1 | 4 | 16 | 256 |
|---|---|---|---|---|
| inner chunk | 720×1440 | 180×1440 | 180×360 | 45×90 |
| gather, 4 vCPU | 0.94× | 0.83× | 1.04× | 1.84× |
| gather, 16 vCPU | 1.02× | 0.94× | 0.97× | 2.20× |

Chunked `gather` is *faster* at coarse grids and loses only at the fine end, which restates
the chunking guidance already in `docs/tuning.md` rather than indicting the design.

### #30's acceptance gate

> a stress test that a consumer-stalled, back-pressured `_drive` sharing zarr's
> process-global loop cannot starve or deadlock other zarr-sync work.

**Passes.** Consumer stalled 2 s/batch with `prefetch_depth=1` so `_drive` parks in
`_admit`; a second thread hammers an unrelated zarr array through the plain sync API.
3 reps each, `main` as the control in the same session:

| arm | victim reads during stall | p50 | p95 | errors |
|---|---|---|---|---|
| this branch (shared loop) | 5670 / 5815 / 5617 | 1.69–1.77 ms | 1.90–1.98 ms | none |
| `main` (private per-pass loop) | 5590 / 5525 / 5687 | 1.74–1.80 ms | 1.95–2.00 ms | none |

**But the gate as written asked the wrong question.** Back-pressure never starved anything
— `_admit` parks on a real `await`, so it yields the loop. Every actual failure was in
`close()`, and all three were found only by testing teardown:

1. `_shutdown` cancelled **every** task on the loop (`asyncio.all_tasks` is the whole loop's
   set) → `CancelledError` inside unrelated zarr reads.
2. `close()` stopped and closed a loop it did not own → `Cannot close a running event loop`,
   and zarr's global loop dead for the rest of the process.
3. Shutting down the now-process-wide decode pool → the next scheduler raises
   *cannot schedule new futures after shutdown*.

They are **races** (the same arm produced them 2/3, 3/3 or 0/3 across runs), which is why
they are pinned by `tests/test_loop_ownership.py` rather than left to review. A scheduler
now cancels only the tasks it created and tears down nothing shared.

### Verified against real GCS

The bridge existed for gcsfs, so `file://` alone would not have proved this. Fingerprints
(SHA-256 over every batch byte + `sample_indices`) are **identical to `main`** on both
backends and both zarr formats:

| store | format | obstore | gcsfs |
|---|---|---|---|
| `gs://insitubatch-bench-insitubatch/adv_sweep_synth128_c64_i128.zarr` | v3 | `adb1de656eef444b` | `adb1de656eef444b` |
| `gs://weatherbench2/.../1959-2022-6h-128x64_equiangular_conservative.zarr` | **v2** | `05cc29eee047e0e1` | `05cc29eee047e0e1` |

WeatherBench2 ARCO is zarr-v2, whose pipeline is a single `V2Codec(filters, compressor)`
rather than v3's codec chain — a v3-only sync-decode path would have silently missed our
main weather benchmark. Also verified byte-identical locally on a ragged grid and on
`sample_axis=1`.

## For reviewers

**Behavior is meant to be unchanged** except for the two items under "User-visible changes"
below. Most valuable second look, in order:

1. **`Scheduler.close` / `_shutdown`** — the whole contract is "own nothing, tear down
   nothing shared". Worth checking the paths that release from the *loop* thread
   (`tile_write`'s `finally`, on failure and cancellation) genuinely cannot reach
   `_advance`'s assembly branch: they leave either `pending > 0` or state `FAILED`.
2. **`ChunkPool._advance` and `pool.assembles`.** Delivery is inline on the tiled path (a
   dict write and a counter) but an executor hop when the pool assembles, because
   delivering the *last* tile also runs the assembly memcpy, the user `chunk_transform` and
   the mmap write-back. An earlier draft delivered inline unconditionally and ran user code
   on `zarr_io` — pinned now by
   `test_user_code_never_runs_on_the_shared_event_loop`.
3. **`slot_charge_bytes` is shared by the pool and the auto-sizer, deliberately.** Sizing
   from the output shape while charging stored tiles under-provisions the budget and the
   pool starves mid-epoch — a hang-shaped failure, not a slow one. It caught me: raising
   the charge without raising the sizer broke 5 tests.
4. **`gather` uses the source grid, not `out_geom`.** `output_geometry` always sets `chunks`
   to the full inner shape, so `out_geom` describes a 1-tile grid — right for an assembling
   slot, wrong for a tiled one.

Two notes on scope. The starvation numbers are `file://` on NVMe, 4 vCPU, a single dataset,
and the tiled path; they do not cover a remote store where the loop also carries network
waits. And `decode_pool()` sizes on first use, so the warning is the only signal a second
dataset's `decode_threads` was ignored.

## User-visible changes

- **Breaking: the persisted cache format is bumped to 3.** A chunk's `.npy` now holds
  `(n_tiles, *tile_shape)` tile-major instead of one assembled array (file count per chunk
  unchanged). An existing `cache_dir` raises the usual stale-cache error and is rebuilt with
  `reset_stale_cache=True`. A version-2 file read as tile-major would be plausible-looking
  garbage, so it is refused rather than reinterpreted.
- **`decode_threads` is process-wide**, sized by the first dataset built in the process; a
  later different value is ignored with a warning. Thread count is a property of the machine,
  not of a dataset, and two datasets should not run two pools competing for the same cores.
- **A ragged chunk grid is charged for the padding it holds** (1.248× on ERA5 721×1440 at
  180×360; 1.997× on a short final outer chunk). The automatic budget accounts for it; a
  hand-set `cache_budget_bytes` on a ragged grid needs to be proportionally larger. Grids
  that divide evenly are unaffected. A `chunk_transform` still receives the **logical**
  clipped chunk and never sees padding.

## Independent verification (examples + benchmarks, post-review)

The unit suite is green, but it does not run the examples — CI only lints and typechecks
them — and it does not touch a real object store or a GPU. So the examples and benchmarks
were run directly against `main` as a control, looking for what the tests could miss.

**Setup.** Two boxes: **g2-standard-16** (16 vCPU, 62 GB, NVIDIA L4 — the box the tables
above were measured on) and an **8 vCPU / 31 GB** box. Local zarr on NVMe, `file://` via
obstore, zarr 3.3.0, torch 2.12.0+cu130, identical resolved envs on both arms. Control is
`main` @ `6282195`, measured in the same session on the same stores. Probe stores rebuilt
with `bench.make_dataset` (`arco_sq` 180×360, `arco_many` 45×90, `ragged` 721×1440 @ 180×360
with a short final outer chunk, `tiled` 2048×2048 @ 256×256 spc=1).

### Correctness: byte-identical to `main` everywhere

The failure mode this refactor can produce is *plausible wrong data* — a tile placed at the
wrong offset, an edge tile clipped wrong, a revived cache entry read with the wrong layout.
Shapes, dtypes, throughput and "it ran" all pass through that, so every arm is SHA-256 over
every delivered byte plus `sample_indices`, sorted into sample order so the digest is
shuffle-independent.

**17 arms, run on both boxes, 34/34 digests identical to `main`:** the four geometry
quadrants on the plain path; the windowed multi-geometry shape the Earth2Studio adapter
drives (two variables at one anchor + `shift()`, `sample_range`, shuffled 3-way split);
`chunk_transform` on three stores; two-epoch runs (cross-epoch reuse and unpinning);
and `cache_dir` cold/warm/transform pairs. Cold and warm digests match within each arm, so
the tile-major persist round-trips; and `arco_sq` and `arco_many` — same data, different
inner chunking — produce the same digest, so the chunk grid does not leak into delivered
bytes.

**Real GCS, both backends.** The deleted fsspec bridge is invisible to `file://`. On
WeatherBench2 ARCO (`gs://weatherbench2/.../1959-2022-6h-128x64_equiangular_conservative.zarr`,
**zarr-v2**, so the `V2Codec` path rather than a v3 codec chain), obstore and gcsfs × shuffled
and unshuffled all give `91df010e652bc478` on both arms.

**Examples, including paths CI never executes.** `advection` on torch, JAX, TF and **CUDA**:
persistence RMSE **0.884** in every run on both arms and both boxes — that number is
model-free, a property of the delivered val data, and is the only signal that has ever caught
a loader defect here. `microscopy` (`sample_axis=2`, per-variable chunking) on CPU and CUDA:
Otsu IoU **0.386** across all nine runs. Model skill varies run to run (0.46–0.63 on a
4-epoch CNN, on both arms) and is training noise, not loader signal. `transforms` (including
the reshaping `Coarsen`, which exercises the one-tile collapse) and `fit_scaler` produce
output identical to `main`. The bench smoke grid runs clean across all five engines.

**The two user-visible claims above, checked directly.** A version-2 `cache_dir` written by
`main` is *refused* by this branch with the documented stale-cache error naming
`reset_stale_cache=True`, not reinterpreted; passing that flag rebuilds it to the correct
digest. The ragged residency multiplier computes to **1.248×** on 721×1440 @ 180×360,
matching the figure quoted above. `slot_charge_bytes` is confirmed to be the single function
used by both the auto-sizer (`source.py:226`) and the pool's own charge (`pool.py:899`) —
the coupling reviewer note 3 flags. And under-sizing is not hang-shaped in practice:
`cache_budget_bytes` is a floor (`max(user, working_set)`, `source.py:273`), and genuine
exhaustion raises `Scheduler._starvation`'s diagnostic rather than hanging.

### The wall-clock table is load-bearing on `compute_ms` — please state it

The warm wall-clock nulls above reproduce, but **only at a stated consumer load**, and the
same stores on the same box give a very different ratio at zero consumer compute. Warm
medians on `arco_many` (45×90, 256 tiles/chunk — the worst quadrant), 16 vCPU,
`batch_size=16 block_chunks=8 max_inflight=32`, 4 epochs, median of the warm epochs, one
process per rep, `main` interleaved as the control:

| per-batch consumer work | branch | `main` | ratio |
|---|---|---|---|
| none | 0.870 s | 0.315 s | **2.76×** |
| 60 ms `time.sleep` (the harness's own proxy, `bench/engines.py:63`) | 1.03 s | 0.994 s | **1.04×** |
| 60 ms single-threaded numpy | 0.929 s | 0.947 s | **0.98×** |
| 60 ms multi-threaded numpy (BLAS takes all 16 cores) | 1.949 s | 1.113 s | 1.75× |

`gather` runs on the producer thread (`source.py:454`, inside `produce()`) behind a
`prefetch_depth` queue, so its cost overlaps consumer compute and disappears from wall clock
as soon as the consumer leaves the loader either cores or the GIL. The last row is core
starvation from a 16-thread BLAS consumer, not a gather defect — the same workload pinned to
one thread is at parity.

So the `1.004×` reported above is right for a GPU-shaped consumer and wrong to read as the
loader's own throughput: **the warm ceiling on a 256-tile grid is ~2.8× lower** (and 1.88×
on 8 vCPU). That is the same effect the gather sweep already discloses at 1.84–2.20×, and it
only reaches wall clock when the loader is the bottleneck. It costs one line to say which
quantity the table reports; without it the table invites exactly the wrong reading.

The mainstream grids are a wash rather than a regression: `arco_sq` (16 tiles/chunk) and
`ragged` (20) came out 1.18–1.19× slower at zero consumer compute on 16 vCPU and 0.85×
*faster* on 8 vCPU, and the spc=1 `tiled` store — where each chunk is gathered once — is
**0.82×, i.e. faster**, on the branch.

## Author attestation

- [ ] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

**Left unchecked deliberately — this was drafted by Claude, and that box is the human
author's to tick.**

## Checklist

- [x] Tests added or updated — `tests/test_loop_ownership.py` (6) and
      `tests/test_chunked_slots.py` (14) are new; the loop-ownership tests all fail on `main`,
      as do 4 of the chunked-slot tests, for the documented reasons
- [x] `uv run ruff check src tests bench examples`, `uv run mypy src bench examples` and
      `uv run pytest -q` are green locally (318 passed, 21 skipped)
- [x] Docstrings and API docs for any new or changed public surface — `decode_pool`,
      `reset_decode_pool`, `slot_charge_bytes`, `ChunkPool.assembles`,
      `ArrayGeometry.tile_shape` / `inner_index`, and `DecodedChunk` (which now states
      outright that user code never sees stored-chunk padding)
- [x] User-facing behavior documented in `docs/*.md` — `docs/architecture.md` (one loop, the
      handoff diagram, teardown ownership), `docs/tuning.md` (process-wide `decode_threads`,
      ragged-grid residency), `DESIGN.md` (scatter-assemble superseded, M-GCS closed)
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] No load-bearing invariant is broken — `Batch` is still numpy, the hot path is still
      O(chunks) (`gather` is O(chunks × tiles-per-chunk), never per-sample), parallelism is
      still in the event loop, no dask, no reshard, no `xr.DataArray`
- [x] Touches `ChunkPool`, the scheduler, and cross-thread readiness → free-threaded run
      passes: 3.13t with `PYTHON_GIL=0` (asserted `sys._is_gil_enabled() is False`),
      99 passed / 2 skipped across pool, lifecycle, chunked-slots, loop-ownership, scheduler,
      residency, prefetch, pinned and window
- [x] Performance claim? **None made** — the change is argued on simplicity, and the numbers
      above exist to show wall clock is a null. Setup and a `main` control are given for every
      table regardless.

