### PR TITLE
feat: describe() -- what a configuration will cost, before it costs it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+- **`InSituDataset.describe()` / `.print_summary()` — what this configuration will cost,
+  before it costs it.** The layout facts that decide whether a run is fast or twice as slow
+  were only discoverable by running it: a 360-byte gather run (1.8-2.2x on the placement
+  path), a chunk grid that does not divide the array so residency is 1.25x what the logical
+  chunk size predicts, `block_chunks` silently widened to fit a batch, a budget sized for one
+  iteration when you meant to `zip(ds.train, ds.val)`. Each of those cost someone an hour to
+  find out, and none of them needs a byte read to know. The report answers from geometry and
+  configuration alone — it opens no store and runs no pass, which is the whole point, because
+  a report that had to touch the store would be useless in exactly the situation you want it.
+  It is on demand: construction stays quiet, because layout advice on every dataset you build
+  teaches people to skim our logs.
+
+  The working-set formula the report prints is now the same function the engine sizes its
+  automatic budget with (`summary.working_set_bytes`) rather than a second copy — a report
+  that predicted a different number from the one the loader uses would be worse than none.
+  The memory block ends in an ESTIMATED row: accounted x 1.25 for glibc's retention of freed
+  slot buffers, re-measured on the chunked-slot pool (#36; it was ~1.85x before that work).
+  Runtime observability — queue depths, per-stage timing, cache hits, peak residency — is a
+  different surface with a different cost model and is tracked separately (#45).
+
 - **The pool's buffer unit is now the stored chunk, and the scheduler runs on zarr's loop.**
   Two changes that had to land together, because both rewrite `Scheduler._one`. A slot used
   to be one assembled ndarray that every decoded tile was memcpy'd into; it is now the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,11 @@ Contributor-facing rules (scope limits, dev setup, AI policy) live in
   `uv run pytest -q`. Docs: `uv run --extra docs mkdocs build --strict` (CI runs it, so a
   broken link fails the build). Pages under `docs/` **cannot** relatively link root files
   (`DESIGN.md`, `GOVERNANCE.md`) — use the GitHub URL, as the existing pages do.
+- **One framework per env.** torch/JAX/TF cannot share a process (Keras 3 pulls JAX in when
+  installed), so a `.venv` carrying several **segfaults mid-suite** — the documented failure
+  mode (README, "One framework per environment"), not a regression. If yours has them all:
+  `pytest -q --ignore=tests/test_tf.py`, then `pytest -q tests/test_tf.py`. CI gives each
+  framework its own job and so never hits it.
 - Pre-commit (ruff + mypy): `uv run pre-commit install` once; runs on every commit.
 - Build: `uv build`. Sync env: `uv sync` (extras: `--extra torch`, `--extra gpu`).
 - Python ≥ 3.12, src layout (`src/insitubatch/`), build backend `uv_build`.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ from insitubatch import InSituDataset, obstore_store, open_geometries, split_by_
 # The engine reads a zarr Store; build one per backend. obstore_store covers
 # file://, s3://, gs://, az://. (fsspec_store reaches GCS Rapid/requester-pays;
 # arraylake_store opens an Icechunk session — same InSituDataset below.)
-store = obstore_store("file:///data/era5.zarr")  # or "s3://bucket/era5.zarr"
+store = obstore_store("gs://insitubatch-bench-insitubatch/era5_c16.zarr", skip_signature=True)
 geoms = open_geometries(store)  # {var: ArrayGeometry} from zarr metadata
 # contiguous chunk blocks by default (no time-series leakage);
 # pass contiguous=False for exchangeable samples (independent scenes)
@@ -200,6 +200,55 @@ for epoch in range(n_epochs):
     for batch in ds.val:  # deterministic; shares the pool with train
         ...
 ```
+
+That store is one of the public benchmark stores, readable by anyone
+(`gs://insitubatch-bench-insitubatch/era5_c{1,2,4,8,16,32}.zarr` — the same
+`era5_c*` chunk-size family the [benchmarks](https://emfdavid.github.io/insitubatch/benchmarks/)
+sweep, full-resolution `721×1440` ERA5-shaped `t2m`, differing only in samples per chunk).
+
+### What it will cost, before it costs it
+
+`ds.print_summary()` answers from **geometry and configuration alone** — it opens no store,
+fetches nothing, and runs no pass. That is what makes it usable in the situation it exists
+for: finding out that a configuration needs 5 GiB, or that concurrency and memory are welded
+together by the chunk layout, *before* waiting an hour to discover it.
+
+```console
+>>> ds.print_summary()
+insitubatch dataset
+
+variables
+  t2m
+    6000x721x1440 float32   chunks 16x721x1440   sample axis 0
+    375 chunks of 16 sample(s)   field 721x1440 in 1 stored chunk(s) of 721x1440
+    stored chunk 63.4 MiB   resident per chunk 63.4 MiB   gather run 4.0 MiB
+
+configuration (resolved)
+  batch_size 32   block_chunks 16   max_inflight 32   prefetch_depth 2
+  shuffle on (seed 0, quality 0.96)   window no   shuffle pool 256 samples for a 32-sample batch
+  splits (chunks)  train 300  val 38  test 37
+  cache backing heap
+
+memory, accounted, for 1 concurrent iteration(s)
+  residency       1.98 GiB   budget (automatic: the working-set floor)
+  in flight       1.98 GiB   max_inflight x stored chunk
+  batch queue    380.2 MiB   (prefetch_depth + 1) x batch
+  accounted       4.33 GiB   sum of the rows above
+  ESTIMATED       5.41 GiB   accounted x 1.25 -- plan for this
+  ...
+
+notes
+  [t2m] one stored chunk per outer chunk at 63.4 MiB: concurrency and memory are coupled here,
+      so each of max_inflight=32 slots costs a whole chunk. Inner-chunk the field to separate
+      them.
+```
+
+The **notes** section is the part that earns the call. Here it caught the *fat, single-inner*
+regime: because the whole `721×1440` field is one stored chunk, every one of the 32 reads in
+flight costs a full 63.4 MiB — so `max_inflight` and memory are welded together, and the fix
+is at write time (inner-chunk the field), not in the loader config. `describe()` returns the
+same report as data if you would rather assert on it in CI than read it, and
+`describe(iterations=N)` sizes the budget for `N` passes sharing the pool.
 
 Hand off to a framework — **zero-copy on CPU via DLPack for torch and JAX**; TF takes one
 CPU copy (its experimental DLPack is unreliable — see `frameworks.to_tf`). The ecosystems

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,6 +25,21 @@ only when called, so importing `insitubatch` never pulls a framework in.
         - print_debug_info
         - debug_info
 
+## The static report
+
+The entry points are the two `InSituDataset` methods above — `describe()` for the dict,
+`print_summary()` for the rendering. These are the shapes `describe()` returns.
+
+::: insitubatch.summary
+    options:
+      show_root_heading: false
+      members:
+        - DatasetReport
+        - VariableReport
+        - ConfigReport
+        - MemoryReport
+        - Note
+
 ## Framework adapters
 
 ::: insitubatch.frameworks

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -52,7 +52,7 @@ will not show up in a small test — it shows up as a lost benchmark six months 
 
 **Parallelism lives in the async event loop, not in worker processes.** The torch surface
 runs `num_workers=0, batch_size=None`. *Why:* worker processes cannot share a chunk cache,
-cannot drive async obstore, and nest thread pools inside forks.
+reach no further than one sample when fanning out reads, and nest thread pools inside forks.
 
 **`chunk_transform`s must be vectorized numpy that releases the GIL.** A pure-Python
 per-element transform is a bug, not a slow path — it serializes the decode pool and kills IO

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -83,6 +83,15 @@ or dataset size:
 - **Reads in flight:** `max_inflight × stored_chunk_bytes` — the fetch pipeline.
 - **Batch queue:** `prefetch_depth × batch_bytes` — assembled batches awaiting the consumer.
 
+`InSituDataset.print_summary()` evaluates all of this for *your* geometry and configuration,
+before any read happens — including the ragged multiplier below, the run length `gather` will
+get, and an estimated peak. Reach for it rather than doing the arithmetic by hand:
+
+```python
+ds = InSituDataset(store, manifest, batch_size=32, block_chunks=16)
+ds.print_summary()              # ds.print_summary(iterations=2) if you will zip two views
+```
+
 where a stored chunk is `sample_chunk × ∏inner_chunk × itemsize`, and a resident chunk is
 the **stored chunks that compose it**, held whole:
 `n_stored_chunks × stored_chunk_bytes`. That equals the logical
@@ -108,7 +117,7 @@ decoded once and reused by both. But each iteration holds its **own** references
 it is working on, so residency is the sum, not the maximum:
 
 ```
-cache_budget_bytes  >=  n_concurrent_iterations x (block_chunks x outer_chunk_bytes)
+cache_budget_bytes  >=  n_concurrent_iterations x (block_chunks x resident_chunk_bytes)
 ```
 
 **The auto-sized default is deliberately computed for one iteration, and stays that way.**
@@ -181,8 +190,9 @@ deterministic — so a scoring pass has no shuffle quality to protect.
    many reads in flight stay cheap, large enough that per-request overhead doesn't dominate.
 2. **Start with the defaults** (`max_inflight=32`, `block_chunks=16`). 32 reads in flight
    saturates in-region S3 in most cases.
-3. **Size `block_chunks` to your RAM budget** (`block_chunks × outer_chunk_bytes` ≤ what you
-   have). Which direction to push it from there is the branch below.
+3. **Size `block_chunks` to your RAM budget** (`block_chunks × resident_chunk_bytes` ≤ what
+   you have — on a ragged grid that is *more* than the outer chunk's logical size). Which
+   direction to push it from there is the branch below.
 4. **Tune `max_inflight`** by the metric your operating point cares about — raise it until
    decoded MB/s stops climbing, *and* check TTFB, because past the IO-bound region only TTFB
    keeps responding. From the repo you can measure the knee directly:

--- a/src/insitubatch/__init__.py
+++ b/src/insitubatch/__init__.py
@@ -33,6 +33,7 @@ from .store import (
     obstore_store,
     open_geometries,
 )
+from .summary import DatasetReport
 from .transforms import (
     BatchTransform,
     ChunkTransform,
@@ -55,6 +56,7 @@ __all__ = [
     "ChunkPool",
     "ChunkRead",
     "ChunkTransform",
+    "DatasetReport",
     "DecodedChunk",
     "InSituDataset",
     "Scheduler",

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -32,16 +32,18 @@ import logging
 import queue
 import threading
 from collections.abc import Callable, Iterator, Sequence
+from typing import TextIO
 
 import numpy as np
 from zarr.abc.store import Store
 
 from .buffers import HostAllocator
-from .pool import ChunkPool, output_geometry, slot_charge_bytes
+from .pool import ChunkPool, output_geometry
 from .scheduler import Scheduler, SchedulerConfig
 from .shuffle import block_shuffled_order, sequential_order
 from .split import SplitManifest, valid_anchor_range
 from .store import close_store, open_geometries
+from .summary import DatasetReport, describe, print_summary, working_set_bytes
 from .types import ArrayGeometry, Batch, DecodedChunk, SplitName, StoredChunkRead
 
 logger = logging.getLogger(__name__)
@@ -163,6 +165,7 @@ class InSituDataset:
         # forever. Capped at the array's chunk count: no batch can span more blocks than
         # there are chunks.
         min_block_chunks = min(-(-batch_size // self._ref_spc), manifest.n_chunks)
+        self._block_chunks_requested = block_chunks  # reported by describe()
         self.block_chunks = max(block_chunks, min_block_chunks)
         if self.block_chunks != block_chunks:
             logger.info(
@@ -185,6 +188,7 @@ class InSituDataset:
         }
         self._epoch = 0
         self._persist = persist
+        self._cache_dir = cache_dir
         self.resident_peak = 0  # peak resident outer chunks (observability)
         self.cache_hits = 0  # chunks served without a fetch this epoch (cross-epoch/run)
         self.cache_misses = 0  # chunks fetched + decoded this epoch
@@ -204,65 +208,19 @@ class InSituDataset:
         # `self.block_chunks` (widened above) guarantees, and what the scheduler's
         # release bookkeeping assumes.
         #
-        # Windows widen the floor. A windowed read (any nonzero offset) crosses a chunk
-        # boundary, so an anchor chunk's read-union spans up to 2 + ceil(span/spc)
-        # chunks per variable (span = max offset - min offset); with every offset 0 the
-        # factor is 1 -- the plain 2 * block_chunks working set.
-        offsets = [g.offset for g in self.geometries.values()]
-        span = max(offsets) - min(offsets)
-        windowed = any(o != 0 for o in offsets)
-        uniform_spc = len({g.sample_chunk_size for g in self.geometries.values()}) == 1
-        # Size from the OUTPUT geometry: the pool caches post-transform chunks, so a regrid
-        # that grows (or shrinks) the data changes the resident footprint the budget must hold.
-        out_geoms = list(self._out_geometries.values())
-        geoms = list(self.geometries.values())
-
-        assembles = bool(self.chunk_transforms)
-
-        def bytes_per_chunk(g: ArrayGeometry, o: ArrayGeometry) -> int:
-            # Exactly what ChunkPool will charge -- see `slot_charge_bytes`. Sizing from the
-            # output shape while the pool charges stored tiles under-provisions the budget,
-            # and the pool then starves mid-epoch instead of merely running lean.
-            return slot_charge_bytes(g, o, assembles=assembles)
-
-        if uniform_spc:
-            # Uniform chunk size: every variable's chunk aligns to the reference grid, so a
-            # block reads exactly its own chunks. (Unchanged formula.)
-            spc0 = geoms[0].sample_chunk_size
-            window_factor = 2 + (-(-span // spc0)) if windowed else 1  # 2 + ceil(span/spc)
-            per_chunk_all_vars = sum(
-                bytes_per_chunk(g, o) for g, o in zip(geoms, out_geoms, strict=True)
-            )
-            working_set = 2 * self.block_chunks * window_factor * per_chunk_all_vars
-            if windowed and self.shuffle:
-                # Shuffle permutes chunk order, so a windowed read can spill into chunks
-                # owned by any other block: a chunk admitted early may be needed late. Until
-                # bounded residency (re-fetch the spill) lands, hold the whole split resident
-                # -- decode-once, the accepted memory cost of windows (spill to NVMe via
-                # cache_dir on large splits). Only `.train` shuffles (eval views are
-                # sequential and spill only locally), so size to the train split.
-                n_train_chunks = len(self.manifest.chunks[SplitName.TRAIN.value])
-                working_set = max(working_set, n_train_chunks * per_chunk_all_vars)
-        else:
-            # Non-uniform chunk size: a variable maps the reference anchor grid onto its own
-            # chunks, so a block touches a variable-specific chunk count. A 2-block read-ahead
-            # window of `2*block_chunks*ref_spc` anchor samples (plus the offset span) covers,
-            # per variable, ceil(window/spc)+1 of its chunks (the +1 for boundary misalignment).
-            def var_bytes(g: ArrayGeometry, o: ArrayGeometry, samples: int) -> int:
-                n_chunks = -(-(samples + span) // g.sample_chunk_size) + 1
-                return n_chunks * bytes_per_chunk(g, o)
-
-            pairs = list(zip(geoms, out_geoms, strict=True))
-            window_samples = 2 * self.block_chunks * self._ref_spc
-            working_set = sum(var_bytes(g, o, window_samples) for g, o in pairs)
-            if self.shuffle:
-                # Under shuffle a variable chunk can be needed by scattered blocks (a coarse
-                # chunk straddling reference-block boundaries) -- like a window spill -- so
-                # hold the train split resident per variable (decode-once). A tighter bound is
-                # future work; different-axis-chunking is today a modest-sized microscopy case.
-                train_samples = len(self.manifest.chunks[SplitName.TRAIN.value]) * self._ref_spc
-                train_ws = sum(var_bytes(g, o, train_samples) for g, o in pairs)
-                working_set = max(working_set, train_ws)
+        # One formula, shared with `describe()`: see summary.working_set_bytes for how
+        # windows and shuffle widen that floor, and why it charges slot_charge_bytes rather
+        # than the assembled shape. A report that predicted a different number from the one
+        # the engine uses would be worse than no report.
+        working_set = working_set_bytes(
+            [self.geometries[label] for label in self.variables],
+            [self._out_geometries[label] for label in self.variables],
+            manifest,
+            block_chunks=self.block_chunks,
+            ref_spc=self._ref_spc,
+            shuffle=self.shuffle,
+            assembles=bool(self.chunk_transforms),
+        )
         # Sized for ONE iteration, deliberately. Every active iteration shares this pool and
         # holds its own references, so N concurrent iterations need ~N x this -- but the engine
         # cannot know N, and guessing high would cost memory in the single-iteration case that
@@ -295,6 +253,20 @@ class InSituDataset:
     def set_epoch(self, epoch: int) -> None:
         """Call from the training loop so each epoch reshuffles deterministically."""
         self._epoch = epoch
+
+    def describe(self, *, iterations: int = 1) -> DatasetReport:
+        """What this dataset will do, from geometry and configuration -- no store access.
+
+        ``iterations`` is how many passes will share the pool at once (``zip(ds.train,
+        ds.val)`` is two), since each holds its own chunk references and the automatic
+        budget covers one. See :meth:`print_summary` for the formatted view, and
+        :mod:`insitubatch.summary` for what each number means.
+        """
+        return describe(self, iterations=iterations)
+
+    def print_summary(self, *, iterations: int = 1, file: TextIO | None = None) -> None:
+        """Print :meth:`describe` for a human. On demand -- construction stays quiet."""
+        print_summary(self.describe(iterations=iterations), file=file)
 
     # -- the splits, as iterables (one dataset, one shared pool) -------------
 

--- a/src/insitubatch/summary.py
+++ b/src/insitubatch/summary.py
@@ -1,0 +1,543 @@
+"""What will this dataset actually do? -- a static report, before anything runs.
+
+``InSituDataset.describe()`` answers from **geometry and configuration only**: it opens no
+store, fetches nothing, and runs no pass. That is the point. The facts it reports -- a
+360-byte gather run, a 2x ragged residency multiplier, a budget sized for one iteration
+when you meant to run two -- are exactly the ones you want *before* waiting an hour to
+discover them, and a report that had to touch the store would be unusable in the situation
+it exists for.
+
+It is deliberately on demand. Construction stays quiet (bar the two warnings that already
+fire), because layout advice on every dataset you build teaches people to skim our logs.
+
+Runtime facts -- queue depths, per-stage timing, cache hits, peak residency -- are a
+different surface with a different cost model, and live in #45.
+
+:func:`working_set_bytes` is shared with :class:`~insitubatch.source.InSituDataset`, which
+sizes its automatic budget with it. One formula, called twice: a report that predicted a
+different number from the one the engine uses would be worse than no report.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, TextIO, TypedDict
+
+import numpy as np
+
+from .pool import slot_charge_bytes
+from .shuffle import shuffle_quality
+from .split import SplitManifest
+from .types import ArrayGeometry, SplitName
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, keeps summary importable from source
+    from .source import InSituDataset
+
+# The measured cliff sits between ~1.4 KiB and ~360 B of contiguous gather run (#43): at
+# 1440 B chunked gather is at parity or faster, at 360 B it costs 1.84-2.20x. 1 KiB is
+# inside that band, so it flags the losing side without crying wolf at the parity point.
+MIN_GATHER_RUN_BYTES = 1024
+
+# Peak RssAnon divided by the accounted total, measured on the chunked-slot pool (#36,
+# re-measured 2026-09-01 after #41: 1.22-1.27x over four runs, MALLOC_ARENA_MAX 32 and 64).
+# One geometry, so it is a rule of thumb for the estimated row -- not a per-dataset model.
+ALLOCATOR_RETENTION = 1.25
+
+
+class VariableReport(TypedDict):
+    """One variable's geometry, and the per-chunk bytes derived from it."""
+
+    label: str
+    path: str
+    dtype: str
+    shape: tuple[int, ...]
+    chunks: tuple[int, ...]
+    sample_axis: int
+    sample_chunk_size: int
+    n_samples: int
+    n_chunks: int
+    offset: int
+    inner_shape: tuple[int, ...]
+    inner_chunks: tuple[int, ...]
+    stored_chunks_per_chunk: int
+    stored_chunk_bytes: int
+    logical_chunk_bytes: int
+    slot_bytes: int
+    ragged_multiplier: float
+    gather_run_bytes: int
+    output_inner_shape: tuple[int, ...]
+    output_dtype: str
+
+
+class MemoryReport(TypedDict):
+    """The accounted pieces of the memory model, evaluated for this configuration."""
+
+    iterations: int
+    residency_bytes: int
+    inflight_bytes: int
+    queue_bytes: int
+    scratch_bytes: int
+    accounted_bytes: int
+    estimated_peak_bytes: int
+    budget_is_automatic: bool
+    working_set_bytes: int
+
+
+class ConfigReport(TypedDict):
+    """What the dataset resolved to -- derived values, not the arguments passed in."""
+
+    batch_size: int
+    block_chunks: int
+    block_chunks_requested: int
+    max_inflight: int
+    prefetch_depth: int
+    shuffle: bool
+    seed: int
+    cache_budget_bytes: int
+    cache_dir: str | None
+    persist: bool
+    chunk_transforms: tuple[str, ...]
+    batch_transforms: tuple[str, ...]
+    assembles: bool
+    windowed: bool
+    offsets: dict[str, int]
+    samples_per_chunk: int
+    n_chunks: dict[str, int]
+    split_chunks: dict[str, int]
+    shuffle_quality: float | None
+
+
+class Note(TypedDict):
+    """One finding. ``severity`` separates "this will hurt" from "worth knowing"."""
+
+    code: str
+    severity: Literal["warn", "note"]
+    subject: str
+    message: str
+
+
+class DatasetReport(TypedDict):
+    """The whole static picture. Returned by :meth:`InSituDataset.describe`."""
+
+    variables: dict[str, VariableReport]
+    config: ConfigReport
+    memory: MemoryReport
+    notes: list[Note]
+
+
+def gather_run_bytes(geom: ArrayGeometry) -> int:
+    """Bytes written per contiguous run when ``gather`` places a stored chunk.
+
+    A stored chunk is contiguous in itself, but it lands in a *sub-rectangle* of the batch,
+    so a run breaks at the first axis where the chunk is narrower than the array. Walking
+    inward from the last axis, the run extends while the chunk spans the full extent; the
+    first axis that does not span ends it. When every inner axis spans (one stored chunk per
+    outer chunk), the whole tile is one run.
+
+    This is the quantity behind the short-run warning: it is set by the innermost extent,
+    which is why full-width slabs ``(1, k, W)`` beat square tiles of the same byte size.
+    """
+    inner_shape, inner_chunks = geom.inner_shape, geom.inner_chunks
+    run = geom.dtype.itemsize
+    for extent, chunk in zip(reversed(inner_shape), reversed(inner_chunks), strict=True):
+        run *= int(chunk)
+        if chunk != extent:
+            break
+    return run
+
+
+def working_set_bytes(
+    geoms: list[ArrayGeometry],
+    out_geoms: list[ArrayGeometry],
+    manifest: SplitManifest,
+    *,
+    block_chunks: int,
+    ref_spc: int,
+    shuffle: bool,
+    assembles: bool,
+) -> int:
+    """The residency floor: what must be co-resident for one iteration to make progress.
+
+    The current block plus one read-ahead block, every variable, because a batch draws
+    across a whole block. Windows widen it (a windowed read crosses chunk boundaries), and
+    shuffle plus windows widen it to the whole split, because a shuffled windowed read can
+    spill into a chunk owned by any other block.
+
+    Charged with :func:`~insitubatch.pool.slot_charge_bytes`, which is what the pool will
+    actually charge -- sizing from the assembled shape while the pool charges stored tiles
+    under-provisions the budget, and the pool then starves mid-epoch, which is a hang-shaped
+    failure rather than a slow one.
+
+    Sized from the **output** geometry: the pool caches post-transform chunks, so a regrid
+    that grows (or shrinks) the data changes the footprint the budget must hold.
+    """
+    offsets = [g.offset for g in geoms]
+    span = max(offsets) - min(offsets)
+    windowed = any(o != 0 for o in offsets)
+    uniform_spc = len({g.sample_chunk_size for g in geoms}) == 1
+
+    def bytes_per_chunk(g: ArrayGeometry, o: ArrayGeometry) -> int:
+        return slot_charge_bytes(g, o, assembles=assembles)
+
+    pairs = list(zip(geoms, out_geoms, strict=True))
+    if uniform_spc:
+        # Every variable's chunk aligns to the reference grid, so a block reads exactly its
+        # own chunks. A windowed read straddles at most one boundary, so an anchor chunk's
+        # read-union spans 2 + ceil(span/spc) chunks per variable; with every offset 0 the
+        # factor is 1 -- the plain 2 * block_chunks working set.
+        spc0 = geoms[0].sample_chunk_size
+        window_factor = 2 + (-(-span // spc0)) if windowed else 1
+        per_chunk_all_vars = sum(bytes_per_chunk(g, o) for g, o in pairs)
+        working_set = 2 * block_chunks * window_factor * per_chunk_all_vars
+        if windowed and shuffle:
+            # Shuffle permutes chunk order, so a windowed read can spill into chunks owned by
+            # any other block: a chunk admitted early may be needed late. Until bounded
+            # residency (re-fetch the spill) lands, hold the whole split resident -- decode-
+            # once, the accepted memory cost of windows (spill to NVMe via cache_dir on large
+            # splits). Only `.train` shuffles (eval views are sequential and spill only
+            # locally), so size to the train split.
+            n_train_chunks = len(manifest.chunks[SplitName.TRAIN.value])
+            working_set = max(working_set, n_train_chunks * per_chunk_all_vars)
+        return working_set
+
+    # Non-uniform chunk size: a variable maps the reference anchor grid onto its own chunks,
+    # so a block touches a variable-specific chunk count. A 2-block read-ahead window of
+    # 2*block_chunks*ref_spc anchor samples (plus the offset span) covers, per variable,
+    # ceil(window/spc)+1 of its chunks (the +1 for boundary misalignment).
+    def var_bytes(g: ArrayGeometry, o: ArrayGeometry, samples: int) -> int:
+        n_chunks = -(-(samples + span) // g.sample_chunk_size) + 1
+        return n_chunks * bytes_per_chunk(g, o)
+
+    window_samples = 2 * block_chunks * ref_spc
+    working_set = sum(var_bytes(g, o, window_samples) for g, o in pairs)
+    if shuffle:
+        # Under shuffle a variable chunk can be needed by scattered blocks (a coarse chunk
+        # straddling reference-block boundaries) -- like a window spill -- so hold the train
+        # split resident per variable (decode-once). A tighter bound is future work;
+        # different-axis-chunking is today a modest-sized microscopy case.
+        train_samples = len(manifest.chunks[SplitName.TRAIN.value]) * ref_spc
+        working_set = max(working_set, sum(var_bytes(g, o, train_samples) for g, o in pairs))
+    return working_set
+
+
+def _variable_report(
+    label: str, src: ArrayGeometry, out: ArrayGeometry, *, assembles: bool
+) -> VariableReport:
+    stored = int(np.prod(src.tile_shape(), dtype=np.int64)) * src.dtype.itemsize
+    logical = int(np.prod(out.slot_shape(0), dtype=np.int64)) * out.dtype.itemsize
+    slot = slot_charge_bytes(src, out, assembles=assembles)
+    return VariableReport(
+        label=label,
+        path=src.path,
+        dtype=str(src.dtype),
+        shape=src.shape,
+        chunks=src.chunks,
+        sample_axis=src.sample_axis,
+        sample_chunk_size=src.sample_chunk_size,
+        n_samples=src.n_samples,
+        n_chunks=src.n_chunks,
+        offset=src.offset,
+        inner_shape=src.inner_shape,
+        inner_chunks=src.inner_chunks,
+        stored_chunks_per_chunk=src.n_inner_chunks(0),
+        stored_chunk_bytes=stored,
+        logical_chunk_bytes=logical,
+        slot_bytes=slot,
+        ragged_multiplier=(slot / logical) if logical else 1.0,
+        gather_run_bytes=gather_run_bytes(src),
+        output_inner_shape=out.inner_shape,
+        output_dtype=str(out.dtype),
+    )
+
+
+def _notes(variables: dict[str, VariableReport], cfg: ConfigReport) -> list[Note]:
+    """Say when a layout is a problem, and why. This is the point of the report.
+
+    Per-variable findings come first: they name the thing you can change. Only findings
+    live here -- the two facts that hold for every dataset (the budget covers one
+    iteration, glibc retains freed slots) are footnotes on the memory block, because a
+    "note" that always fires is not a finding and teaches people to skip the section.
+    """
+    notes: list[Note] = []
+    globals_: list[Note] = []
+
+    for label, v in variables.items():
+        if v["gather_run_bytes"] < MIN_GATHER_RUN_BYTES:
+            notes.append(
+                Note(
+                    code="short-gather-run",
+                    severity="warn",
+                    subject=label,
+                    message=(
+                        f"{_bytes(v['gather_run_bytes'])} contiguous run per gather write "
+                        f"(inner chunks {v['inner_chunks']} of {v['inner_shape']}). Below "
+                        f"~{_bytes(MIN_GATHER_RUN_BYTES)}, gather costs 1.8-2.2x. The run is "
+                        "set by the INNERMOST extent, so full-width slabs (1, k, W) give long "
+                        "runs "
+                        "and fewer decode tasks; square tiles lose on both."
+                    ),
+                )
+            )
+        if v["ragged_multiplier"] > 1.001:
+            notes.append(
+                Note(
+                    code="ragged-grid",
+                    severity="note",
+                    subject=label,
+                    message=(
+                        f"residency is {v['ragged_multiplier']:.3f}x the logical chunk: the "
+                        f"chunk grid {v['inner_chunks']} does not divide {v['inner_shape']}, "
+                        "and stored chunks are kept whole (padding included) rather than "
+                        "clipped. The budget charges the padded size; this is real memory."
+                    ),
+                )
+            )
+        if v["stored_chunks_per_chunk"] == 1:
+            notes.append(
+                Note(
+                    code="single-inner-fat-chunk",
+                    severity="note",
+                    subject=label,
+                    message=(
+                        f"one stored chunk per outer chunk at "
+                        f"{_bytes(v['stored_chunk_bytes'])}: concurrency and memory are "
+                        f"coupled here, so each of max_inflight={cfg['max_inflight']} slots "
+                        "costs a whole chunk. Inner-chunk the field to separate them."
+                    ),
+                )
+            )
+
+    if cfg["block_chunks"] != cfg["block_chunks_requested"]:
+        globals_.append(
+            Note(
+                code="block-chunks-widened",
+                severity="note",
+                subject="config",
+                message=(
+                    f"block_chunks widened {cfg['block_chunks_requested']} -> "
+                    f"{cfg['block_chunks']} so a {cfg['batch_size']}-sample batch fits one "
+                    f"shuffle block at {cfg['samples_per_chunk']} samples/chunk. Below that, "
+                    "a batch spans more blocks than the budget holds and the loader stalls."
+                ),
+            )
+        )
+
+    return notes + globals_
+
+
+def describe(ds: InSituDataset, *, iterations: int = 1) -> DatasetReport:
+    """The static report. ``iterations`` is how many passes will share the pool at once."""
+    if iterations < 1:
+        raise ValueError(f"iterations must be >= 1, got {iterations}")
+
+    assembles = bool(ds.chunk_transforms)
+    variables = {
+        label: _variable_report(
+            label, ds.geometries[label], ds._out_geometries[label], assembles=assembles
+        )
+        for label in ds.variables
+    }
+
+    order = ds._draw_order(SplitName.TRAIN, ds.shuffle)
+    quality = shuffle_quality(order, ds._ref_spc) if len(order) > 1 else None
+
+    cfg = ConfigReport(
+        batch_size=ds.batch_size,
+        block_chunks=ds.block_chunks,
+        block_chunks_requested=ds._block_chunks_requested,
+        max_inflight=ds.scheduler_config.max_inflight,
+        prefetch_depth=ds.prefetch_depth,
+        shuffle=ds.shuffle,
+        seed=ds.seed,
+        cache_budget_bytes=ds.cache_budget_bytes,
+        cache_dir=str(ds._cache_dir) if ds._cache_dir is not None else None,
+        persist=ds._persist,
+        chunk_transforms=tuple(_name(t) for t in ds.chunk_transforms),
+        batch_transforms=tuple(_name(t) for t in ds.batch_transforms),
+        assembles=assembles,
+        windowed=any(g.offset != 0 for g in ds.geometries.values()),
+        offsets={label: g.offset for label, g in ds.geometries.items()},
+        samples_per_chunk=ds._ref_spc,
+        n_chunks={label: v["n_chunks"] for label, v in variables.items()},
+        split_chunks={name: len(ids) for name, ids in ds.manifest.chunks.items()},
+        shuffle_quality=quality,
+    )
+
+    geoms = [ds.geometries[label] for label in ds.variables]
+    out_geoms = [ds._out_geometries[label] for label in ds.variables]
+    floor = working_set_bytes(
+        geoms,
+        out_geoms,
+        ds.manifest,
+        block_chunks=ds.block_chunks,
+        ref_spc=ds._ref_spc,
+        shuffle=ds.shuffle,
+        assembles=assembles,
+    )
+    inflight = cfg["max_inflight"] * max(v["stored_chunk_bytes"] for v in variables.values())
+    batch_bytes = sum(
+        int(np.prod(ds._out_geometries[label].inner_shape, dtype=np.int64))
+        * ds._out_geometries[label].dtype.itemsize
+        * ds.batch_size
+        for label in ds.variables
+    )
+    queue = (ds.prefetch_depth + 1) * batch_bytes
+    scratch = (
+        sum(v["stored_chunk_bytes"] * v["stored_chunks_per_chunk"] for v in variables.values())
+        if assembles
+        else 0
+    )
+    residency = ds.cache_budget_bytes * iterations
+    mem = MemoryReport(
+        iterations=iterations,
+        residency_bytes=residency,
+        inflight_bytes=inflight,
+        queue_bytes=queue,
+        scratch_bytes=scratch,
+        accounted_bytes=residency + inflight + queue + scratch,
+        estimated_peak_bytes=int((residency + inflight + queue + scratch) * ALLOCATOR_RETENTION),
+        budget_is_automatic=ds.cache_budget_bytes == floor,
+        working_set_bytes=floor,
+    )
+
+    return DatasetReport(variables=variables, config=cfg, memory=mem, notes=_notes(variables, cfg))
+
+
+def _name(fn: object) -> str:
+    return getattr(fn, "__name__", type(fn).__name__)
+
+
+def _bytes(n: int) -> str:
+    """Bytes in the unit people think in at that size -- B, KiB, MiB, GiB."""
+    if n < 1024:
+        return f"{n} B"
+    if n < 1 << 20:
+        return f"{n / 1024:.1f} KiB"
+    if n < 1 << 30:
+        return f"{n / (1 << 20):.1f} MiB"
+    return f"{n / (1 << 30):.2f} GiB"
+
+
+def _dims(t: tuple[int, ...]) -> str:
+    return "x".join(str(d) for d in t)
+
+
+def print_summary(report: DatasetReport, file: TextIO | None = None) -> None:
+    """Format :func:`describe` for a terminal. Numbers first, then what to do about them."""
+    out: list[str] = []
+    cfg, mem = report["config"], report["memory"]
+
+    out.append("insitubatch dataset")
+    out.append("")
+    out.append("variables")
+    for label, v in report["variables"].items():
+        window = f"  window +{v['offset']}" if v["offset"] else ""
+        out.append(f"  {label}{window}")
+        out.append(
+            f"    {_dims(v['shape'])} {v['dtype']}   chunks {_dims(v['chunks'])}"
+            f"   sample axis {v['sample_axis']}"
+        )
+        out.append(
+            f"    {v['n_chunks']} chunks of {v['sample_chunk_size']} sample(s)"
+            f"   field {_dims(v['inner_shape'])} in {v['stored_chunks_per_chunk']} stored"
+            f" chunk(s) of {_dims(v['inner_chunks'])}"
+        )
+        ragged = (
+            f"   ragged {v['ragged_multiplier']:.3f}x" if v["ragged_multiplier"] > 1.001 else ""
+        )
+        out.append(
+            f"    stored chunk {_bytes(v['stored_chunk_bytes'])}"
+            f"   resident per chunk {_bytes(v['slot_bytes'])}{ragged}"
+            f"   gather run {_bytes(v['gather_run_bytes'])}"
+        )
+        if v["output_inner_shape"] != v["inner_shape"] or v["output_dtype"] != v["dtype"]:
+            out.append(
+                f"    after chunk_transform: field {_dims(v['output_inner_shape'])}"
+                f" {v['output_dtype']}"
+            )
+
+    spc = cfg["samples_per_chunk"]
+    out.append("")
+    out.append("configuration (resolved)")
+    widened = (
+        f" (raised from {cfg['block_chunks_requested']})"
+        if cfg["block_chunks"] != cfg["block_chunks_requested"]
+        else ""
+    )
+    out.append(
+        f"  batch_size {cfg['batch_size']}   block_chunks {cfg['block_chunks']}{widened}"
+        f"   max_inflight {cfg['max_inflight']}   prefetch_depth {cfg['prefetch_depth']}"
+    )
+    quality = "n/a" if cfg["shuffle_quality"] is None else f"{cfg['shuffle_quality']:.2f}"
+    out.append(
+        f"  shuffle {'on' if cfg['shuffle'] else 'off'} (seed {cfg['seed']}, quality {quality})"
+        f"   window {'yes' if cfg['windowed'] else 'no'}"
+        f"   shuffle pool {cfg['block_chunks'] * spc} samples"
+        f" for a {cfg['batch_size']}-sample batch"
+    )
+    splits = "  ".join(f"{k} {n}" for k, n in cfg["split_chunks"].items())
+    out.append(f"  splits (chunks)  {splits}")
+    cache = cfg["cache_dir"] or "heap"
+    persist = ", persist" if cfg["persist"] else ""
+    out.append(f"  cache backing {cache}{persist}")
+    if cfg["chunk_transforms"]:
+        out.append(f"  chunk_transforms {', '.join(cfg['chunk_transforms'])} (slot assembles)")
+    if cfg["batch_transforms"]:
+        out.append(f"  batch_transforms {', '.join(cfg['batch_transforms'])}")
+
+    auto = " (automatic: the working-set floor)" if mem["budget_is_automatic"] else ""
+    out.append("")
+    out.append(f"memory, accounted, for {mem['iterations']} concurrent iteration(s)")
+    out.append(f"  residency   {_bytes(mem['residency_bytes']):>12}   budget{auto}")
+    out.append(f"  in flight   {_bytes(mem['inflight_bytes']):>12}   max_inflight x stored chunk")
+    out.append(f"  batch queue {_bytes(mem['queue_bytes']):>12}   (prefetch_depth + 1) x batch")
+    if mem["scratch_bytes"]:
+        out.append(f"  scratch     {_bytes(mem['scratch_bytes']):>12}   chunk_transform assembly")
+    out.append(f"  accounted   {_bytes(mem['accounted_bytes']):>12}   sum of the rows above")
+    out.append(
+        f"  ESTIMATED   {_bytes(mem['estimated_peak_bytes']):>12}"
+        f"   accounted x {ALLOCATOR_RETENTION} -- plan for this"
+    )
+    out.append("")
+    footnotes = [
+        f"The x{ALLOCATOR_RETENTION} is allocator retention, not slack we can spend: slot "
+        "buffers are freed per chunk and glibc keeps them under its dynamic mmap threshold "
+        "instead of returning them to the kernel. It is a rule of thumb measured on one "
+        "geometry (#36); your own ratio can differ.",
+    ]
+    if mem["iterations"] == 1:
+        footnotes.append(
+            "Sized for ONE iteration. Every active iteration shares this pool and holds its "
+            "own chunk references, so zip(ds.train, ds.val) or two DataLoaders need ~N x the "
+            "residency. Pass describe(iterations=N) to size it, cache_budget_bytes to buy it."
+        )
+    for note in footnotes:
+        out.append(f"  {_wrap(note, width=88, indent=4)}")
+
+    warns = [n for n in report["notes"] if n["severity"] == "warn"]
+    notes = [n for n in report["notes"] if n["severity"] == "note"]
+    for heading, group in (("warnings", warns), ("notes", notes)):
+        if not group:
+            continue
+        out.append("")
+        out.append(heading)
+        for n in group:
+            body = _wrap(n["message"], width=88, indent=6)
+            out.append(f"  [{n['subject']}] {body.lstrip()}")
+
+    print("\n".join(out), file=file)
+
+
+def _wrap(text: str, *, width: int, indent: int) -> str:
+    words, lines, cur = text.split(), [], ""
+    for w in words:
+        if cur and len(cur) + 1 + len(w) > width:
+            lines.append(cur)
+            cur = w
+        else:
+            cur = f"{cur} {w}" if cur else w
+    lines.append(cur)
+    pad = " " * indent
+    return f"\n{pad}".join(lines)
+
+
+__all__ = ["DatasetReport", "describe", "print_summary", "working_set_bytes"]

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,299 @@
+"""``describe()`` is a promise about what will happen before anything runs, so the tests
+that matter are the ones that catch it *disagreeing with the engine*: a report that
+predicts a budget the loader does not use, or stays quiet about a layout that will cost
+2x, is worse than no report at all.
+"""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pytest
+import zarr
+
+from insitubatch import ensure_local_dir, obstore_store, open_geometries, split_by_chunk
+from insitubatch.source import InSituDataset
+from insitubatch.summary import (
+    ALLOCATOR_RETENTION,
+    MIN_GATHER_RUN_BYTES,
+    describe,
+    gather_run_bytes,
+    print_summary,
+    working_set_bytes,
+)
+from insitubatch.types import ArrayGeometry, SplitName
+
+
+def _geom(shape, chunks, *, dtype="f4", sample_axis=0):
+    return ArrayGeometry(
+        path="v",
+        shape=shape,
+        chunks=chunks,
+        dtype=np.dtype(dtype),
+        sample_axis=sample_axis,
+    )
+
+
+def _write_tiled(tmp_path, *, n, spc, inner, inner_chunks, variables=("t2m",)):
+    """A store whose *inner* axes are chunked too -- what the fixture cannot make, and the
+    only shape in which a ragged grid or a multi-tile chunk exists at all."""
+    url = f"file://{tmp_path}/tiled.zarr"
+    ensure_local_dir(url)
+    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
+    for var in variables:
+        arr = group.create_array(var, shape=(n, *inner), chunks=(spc, *inner_chunks), dtype="f4")
+        arr[:] = np.zeros((n, *inner), dtype="f4")
+    store = obstore_store(url)
+    geoms = open_geometries(store, list(variables))
+    return store, geoms, split_by_chunk(geoms[variables[0]])
+
+
+def _dataset(write_zarr, *, variables=("t2m",), **kw):
+    url, srcs = write_zarr(
+        variables=variables, **{k: kw.pop(k) for k in ("n", "spc", "inner") if k in kw}
+    )
+    store = obstore_store(url)
+    geoms = open_geometries(store, list(variables))
+    manifest = split_by_chunk(geoms[variables[0]])
+    return InSituDataset(store, manifest, geometries=geoms, **kw), srcs
+
+
+# --- the run length is set by the innermost extent, which is the whole advice ---------
+
+
+def test_gather_run_is_the_whole_tile_when_every_inner_axis_spans():
+    g = _geom((8, 721, 1440), (1, 721, 1440))
+    assert gather_run_bytes(g) == 721 * 1440 * 4
+
+
+def test_gather_run_of_a_full_width_slab_is_the_row_block():
+    # (k, W) tiles keep the last axis whole, so the run is k rows, not one.
+    assert gather_run_bytes(_geom((8, 720, 1440), (1, 180, 1440))) == 180 * 1440 * 4
+
+
+def test_gather_run_of_a_square_tile_is_one_row_of_the_tile():
+    # The same bytes per tile as the slab above, and 1/180th the run: this is the pair
+    # the short-run warning exists to separate.
+    assert gather_run_bytes(_geom((8, 720, 1440), (1, 180, 360))) == 360 * 4
+
+
+def test_gather_run_includes_the_first_partial_axis_when_everything_inside_it_spans():
+    # 10 consecutive planes, each whole: the tile is one contiguous block of the batch,
+    # so the run is the partial axis's chunk width too -- it stops *after* it, not before.
+    g = _geom((8, 100, 100, 100), (1, 10, 100, 100))
+    assert gather_run_bytes(g) == 10 * 100 * 100 * 4
+
+
+def test_gather_run_follows_the_sample_axis_not_axis_zero():
+    g = _geom((721, 1440, 8), (721, 360, 1), sample_axis=2)
+    assert gather_run_bytes(g) == 360 * 4
+
+
+# --- one formula, called twice: the report must not predict a budget the engine ignores
+
+
+def test_report_reproduces_the_budget_the_engine_actually_chose(write_zarr):
+    ds, _ = _dataset(write_zarr, n=96, spc=4, inner=(6, 6), block_chunks=2, batch_size=4)
+    report = ds.describe()
+    assert report["memory"]["working_set_bytes"] == ds.cache_budget_bytes
+    assert report["memory"]["budget_is_automatic"] is True
+
+
+def test_an_explicit_budget_is_not_reported_as_automatic(write_zarr):
+    ds, _ = _dataset(
+        write_zarr,
+        n=96,
+        spc=4,
+        inner=(6, 6),
+        block_chunks=2,
+        batch_size=4,
+        cache_budget_bytes=64 << 20,
+    )
+    report = ds.describe()
+    assert report["memory"]["residency_bytes"] == 64 << 20
+    assert report["memory"]["budget_is_automatic"] is False
+
+
+def test_working_set_charges_the_padded_stored_chunk_not_the_logical_one():
+    # 7x7 field on a 4x4 grid: four stored chunks, 64 elements held for 49 wanted.
+    g = _geom((32, 7, 7), (4, 4, 4))
+    manifest = split_by_chunk(g)
+    padded = working_set_bytes(
+        [g], [g], manifest, block_chunks=2, ref_spc=4, shuffle=True, assembles=False
+    )
+    assert padded == 2 * 2 * (4 * 64 * 4)
+
+
+# --- the findings ---------------------------------------------------------------------
+
+
+def _codes(report, subject=None):
+    return [n["code"] for n in report["notes"] if subject in (None, n["subject"])]
+
+
+def test_short_gather_run_warns_on_a_square_tile(write_zarr):
+    ds, _ = _dataset(write_zarr, n=64, spc=4, inner=(6, 6), batch_size=4, block_chunks=2)
+    report = ds.describe()
+    (note,) = [n for n in report["notes"] if n["code"] == "short-gather-run"]
+    assert note["severity"] == "warn"
+    assert note["subject"] == "t2m"
+    assert report["variables"]["t2m"]["gather_run_bytes"] < MIN_GATHER_RUN_BYTES
+
+
+def test_a_long_run_is_not_flagged(write_zarr):
+    ds, _ = _dataset(write_zarr, n=64, spc=4, inner=(4, 512), batch_size=4, block_chunks=2)
+    assert "short-gather-run" not in _codes(ds.describe())
+
+
+def test_ragged_grid_is_reported_with_the_multiplier_it_costs(tmp_path):
+    # 7x7 field on a 4x4 grid: four stored chunks, 64 elements held for the 49 wanted.
+    store, geoms, manifest = _write_tiled(tmp_path, n=32, spc=4, inner=(7, 7), inner_chunks=(4, 4))
+    ds = InSituDataset(store, manifest, geometries=geoms, batch_size=4, block_chunks=2)
+    report = ds.describe()
+    v = report["variables"]["t2m"]
+    assert v["stored_chunks_per_chunk"] == 4
+    assert v["ragged_multiplier"] == pytest.approx(64 / 49)
+    assert v["slot_bytes"] == 4 * 64 * 4
+    (note,) = [n for n in report["notes"] if n["code"] == "ragged-grid"]
+    assert note["severity"] == "note"
+    assert "1.306x" in note["message"]
+
+
+def test_a_dividing_grid_is_not_called_ragged(tmp_path):
+    store, geoms, manifest = _write_tiled(tmp_path, n=32, spc=4, inner=(8, 8), inner_chunks=(4, 4))
+    ds = InSituDataset(store, manifest, geometries=geoms, batch_size=4, block_chunks=2)
+    report = ds.describe()
+    assert report["variables"]["t2m"]["ragged_multiplier"] == 1.0
+    assert "ragged-grid" not in _codes(report)
+    assert "single-inner-fat-chunk" not in _codes(report)
+
+
+def test_one_stored_chunk_per_outer_chunk_is_reported_at_any_size(write_zarr):
+    # Small field: still coupled concurrency and memory, so it is still worth saying.
+    ds, _ = _dataset(write_zarr, n=64, spc=4, inner=(4, 4), batch_size=4, block_chunks=2)
+    report = ds.describe()
+    assert report["variables"]["t2m"]["stored_chunks_per_chunk"] == 1
+    assert "single-inner-fat-chunk" in _codes(report)
+
+
+def test_block_chunks_widened_is_reported_against_what_was_asked_for(write_zarr):
+    ds, _ = _dataset(write_zarr, n=128, spc=2, inner=(4, 4), batch_size=16, block_chunks=1)
+    report = ds.describe()
+    assert report["config"]["block_chunks_requested"] == 1
+    assert report["config"]["block_chunks"] > 1
+    assert "block-chunks-widened" in _codes(report, subject="config")
+
+
+def test_variable_findings_come_before_global_ones(write_zarr):
+    ds, _ = _dataset(write_zarr, n=128, spc=2, inner=(6, 6), batch_size=16, block_chunks=1)
+    subjects = [n["subject"] for n in ds.describe()["notes"]]
+    assert "t2m" in subjects and "config" in subjects
+    assert subjects.index("config") > max(i for i, s in enumerate(subjects) if s == "t2m")
+
+
+def test_the_always_true_facts_are_not_notes(write_zarr):
+    # They hold for every dataset; a note that always fires trains people to skip the
+    # section, so they are footnotes on the memory block instead.
+    ds, _ = _dataset(write_zarr, n=64, spc=4, inner=(6, 6), batch_size=4, block_chunks=2)
+    codes = _codes(ds.describe())
+    assert "allocator-retention" not in codes
+    assert "budget-sized-for-one-iteration" not in codes
+
+
+# --- the memory block -------------------------------------------------------------------
+
+
+def test_estimated_peak_applies_the_measured_retention_factor(write_zarr):
+    ds, _ = _dataset(write_zarr, n=64, spc=4, inner=(6, 6), batch_size=4, block_chunks=2)
+    mem = ds.describe()["memory"]
+    assert mem["accounted_bytes"] == (
+        mem["residency_bytes"] + mem["inflight_bytes"] + mem["queue_bytes"] + mem["scratch_bytes"]
+    )
+    assert mem["estimated_peak_bytes"] == int(mem["accounted_bytes"] * ALLOCATOR_RETENTION)
+    assert mem["estimated_peak_bytes"] > mem["accounted_bytes"]
+
+
+def test_concurrent_iterations_multiply_residency_only(write_zarr):
+    ds, _ = _dataset(write_zarr, n=64, spc=4, inner=(6, 6), batch_size=4, block_chunks=2)
+    one, two = ds.describe()["memory"], ds.describe(iterations=2)["memory"]
+    assert two["residency_bytes"] == 2 * one["residency_bytes"]
+    assert two["inflight_bytes"] == one["inflight_bytes"]
+    assert two["queue_bytes"] == one["queue_bytes"]
+
+
+def test_iterations_must_be_at_least_one(write_zarr):
+    ds, _ = _dataset(write_zarr, n=64, spc=4, inner=(6, 6), batch_size=4, block_chunks=2)
+    with pytest.raises(ValueError, match="iterations must be >= 1"):
+        ds.describe(iterations=0)
+
+
+def test_describe_opens_nothing(write_zarr, monkeypatch):
+    ds, _ = _dataset(write_zarr, n=64, spc=4, inner=(6, 6), batch_size=4, block_chunks=2)
+
+    def boom(*a, **k):
+        raise AssertionError("describe() must not touch the store")
+
+    monkeypatch.setattr(type(ds.store), "get", boom, raising=False)
+    ds.describe()
+
+
+# --- rendering ---------------------------------------------------------------------------
+
+
+def _render(ds, **kw):
+    buf = io.StringIO()
+    ds.print_summary(file=buf, **kw)
+    return buf.getvalue()
+
+
+def test_rendering_carries_the_numbers_and_the_footnotes(write_zarr):
+    ds, _ = _dataset(write_zarr, n=64, spc=4, inner=(6, 6), batch_size=4, block_chunks=2)
+    text = _render(ds)
+    assert "variables" in text and "t2m" in text
+    assert "ESTIMATED" in text
+    assert f"accounted x {ALLOCATOR_RETENTION}" in text
+    assert "Sized for ONE iteration" in text
+    assert "warnings" in text  # the short gather run on a 6x6 field
+
+
+def test_the_one_iteration_footnote_goes_away_when_you_asked_for_more(write_zarr):
+    ds, _ = _dataset(write_zarr, n=64, spc=4, inner=(6, 6), batch_size=4, block_chunks=2)
+    assert "Sized for ONE iteration" not in _render(ds, iterations=3)
+    assert "3 concurrent iteration" in _render(ds, iterations=3)
+
+
+def test_short_runs_render_in_bytes_and_big_ones_in_binary_units(write_zarr):
+    ds, _ = _dataset(write_zarr, n=64, spc=4, inner=(6, 6), batch_size=4, block_chunks=2)
+    assert "gather run 144 B" in _render(ds)
+    big, _ = _dataset(write_zarr, n=64, spc=1, inner=(512, 512), batch_size=4, block_chunks=2)
+    assert "gather run 1.0 MiB" in _render(big)
+
+
+def test_print_summary_takes_a_report(write_zarr):
+    ds, _ = _dataset(write_zarr, n=64, spc=4, inner=(6, 6), batch_size=4, block_chunks=2)
+    buf = io.StringIO()
+    print_summary(describe(ds), file=buf)
+    assert buf.getvalue() == _render(ds)
+
+
+def test_two_variables_each_get_their_own_block(write_zarr):
+    ds, _ = _dataset(
+        write_zarr,
+        variables=("t2m", "u10"),
+        n=64,
+        spc=4,
+        inner=(6, 6),
+        batch_size=4,
+        block_chunks=2,
+    )
+    text = _render(ds)
+    assert "  t2m\n" in text and "  u10\n" in text
+    assert ds.describe()["config"]["n_chunks"] == {"t2m": 16, "u10": 16}
+
+
+def test_split_chunk_counts_are_reported(write_zarr):
+    ds, _ = _dataset(write_zarr, n=64, spc=4, inner=(6, 6), batch_size=4, block_chunks=2)
+    cfg = ds.describe()["config"]
+    assert sum(cfg["split_chunks"].values()) == 16
+    assert cfg["split_chunks"][SplitName.TRAIN.value] > 0


### PR DESCRIPTION
## Summary

Closes #43.

`InSituDataset.describe()` returns a dict; `InSituDataset.print_summary()` renders it. Both
answer from **geometry and configuration alone** — no store access, no pass, no read. That
constraint is the feature: a report that had to touch the store would be unusable in exactly
the situation you want one.

The facts it surfaces are the ones that decide whether a run is fast or twice as slow, and
that today are only discoverable by running it:

- a **short gather run** (360 B costs 1.8–2.2x on the placement path; 1440 B is at parity),
  and the actionable half — the run is set by the *innermost* extent, so `(1, k, W)` slabs
  win where square tiles of the same byte size lose;
- a **ragged chunk grid**, where stored chunks are kept whole and residency is 1.248x the
  logical chunk size on ERA5 721x1440 @ 180x360 — real memory the budget already charges;
- **`block_chunks` widened** under you so a batch fits one shuffle block;
- **one stored chunk per outer chunk**, which couples concurrency to memory;
- a **budget sized for one iteration** when you meant to `zip(ds.train, ds.val)`.

It is on demand, not on construction: layout advice printed on every dataset you build
teaches people to skim our logs.

Sample output (inner-tiled 180x360 on 721x1440, two variables):

```
variables
  t2m
    512x721x1440 float32   chunks 8x180x360   sample axis 0
    64 chunks of 8 sample(s)   field 721x1440 in 20 stored chunk(s) of 180x360
    stored chunk 2.0 MiB   resident per chunk 39.6 MiB   ragged 1.248x   gather run 1.4 KiB
...
memory, accounted, for 1 concurrent iteration(s)
  residency      632.8 MiB   budget (automatic: the working-set floor)
  in flight       63.3 MiB   max_inflight x stored chunk
  batch queue    760.4 MiB   (prefetch_depth + 1) x batch
  accounted       1.42 GiB   sum of the rows above
  ESTIMATED       1.78 GiB   accounted x 1.25 -- plan for this
```

**The working-set formula moved out of `InSituDataset.__init__` into
`summary.working_set_bytes` and is now called from both.** One formula: a report that
predicted a different number from the one the engine sizes its budget with would be worse
than no report. Behavior is unchanged — same expression, same inline rationale, plus a test
asserting `report["memory"]["working_set_bytes"] == ds.cache_budget_bytes`.

**The `ESTIMATED` row is `accounted x 1.25`**, for glibc's retention of freed slot buffers.
That factor was re-measured on this branch's tree rather than reused: see #36 for the four
arms. It is stated in the report as a rule of thumb from one geometry, with a footnote saying
so, rather than as a model — one spc=1 heap-backed store is not a basis for a per-dataset
multiplier.

Runtime observability (queue depths, per-stage timing, cache hits, peak residency) was split
out of #43 during scoping and is #45. Nothing here reads a counter that only exists mid-run.

Also in this PR:

- `docs/tuning.md`: the headline sizing formula said `block_chunks x outer_chunk_bytes`, which
  is optimistic on a ragged grid — corrected to `resident_chunk_bytes` in both places (the
  last bullet on #43), plus a pointer to `print_summary()` where the reader is first asked to
  do the arithmetic by hand.
- `DatasetReport` exported from the package root (so the page's "public surface is `__all__`"
  claim stays true) and an API-docs section for the returned shapes.
- `CLAUDE.md`: the one-framework-per-env rule, which is in the README and enforced by CI but
  was missing from the working-notes Verify line — a local `.venv` with torch+JAX+TF segfaults
  mid-suite and reads as a regression. Separate commit.

## For reviewers

**Where I would most value a second look:**

1. **The `working_set_bytes` extraction** (`source.py` -> `summary.py`). This is the only
   behavior-bearing move in the PR. It is meant to be byte-identical; the rationale comments
   moved with it verbatim, but please check I did not drop a branch.
2. **What earns a note, and what does not.** The two facts that hold for *every* dataset
   (budget covers one iteration; glibc retains) are footnotes on the memory block rather than
   notes, on the argument that a note which always fires trains people to skip the section.
   The consequence is that a well-laid-out dataset now prints no `warnings` and no `notes` at
   all, which I think is the right signal — but it is a judgment call.
3. **`MIN_GATHER_RUN_BYTES = 1024`.** Chosen to sit inside the measured band (parity at
   1440 B, 1.8–2.2x at 360 B), so it flags the losing side without crying wolf at parity.
   A threshold is a promise; this one is drawn from one measurement series.
4. **Whether `single-inner-fat-chunk` should fire at any size.** It now does (the 8 MiB
   threshold is gone, per review discussion). On a small field the statement is still true
   but less urgent.

**What I am confident in:** the geometry arithmetic. `gather_run_bytes` is unit-tested
against the slab-vs-square pair that motivates the advice, on a non-zero `sample_axis`, and
on the case where the run extends *through* the first partial axis; the ragged multiplier is
checked against a hand-computed 64/49 on a 7x7 field with a 4x4 grid, and the ERA5 1.248x
matches the number from the pool work.

## Rebased, plus one unrelated docs commit

Rebased onto `main` after #41 and #49 landed. `cb0944c` dropped (already in `main` via #41); no conflicts, and all four of #49's docs corrections verified intact.

`f5aba96` is **not part of `describe()`** and is here only because the rebase surfaced it: #49 corrected "worker processes cannot drive async obstore" in six places and missed a seventh, `docs/contributing.md:55`. A worker *can* drive async obstore — zarr-python's sync API runs a process-wide event loop — so the true claim is that it cannot fan out past the one sample `__getitem__` returns. CLAUDE.md pairs that page with the load-bearing invariants and says neither may be weakened alone, so it should not sit on `main` stating the falsifiable version. One line; drop the commit if you would rather it went separately.

Re-verified after the rebase: **365 passed / 6 skipped**, plus **2 passed** for `tests/test_tf.py` run alone. ruff, mypy and `mkdocs build --strict` clean.

## Author attestation

- [x] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

## Checklist

- [x] Tests added or updated — 26 new in `tests/test_summary.py`
- [x] `uv run ruff check src tests bench examples`, `uv run mypy src bench examples` and
      `uv run pytest -q` are green locally — **355 passed, 9 skipped**, run as
      `--ignore=tests/test_tf.py` plus `tests/test_tf.py` alone, because this dev box has
      torch+JAX+TF co-installed (see the CLAUDE.md commit); CI's one-job-per-framework layout
      does not have this constraint
- [x] Docstrings and API docs for any new or changed public surface
- [x] User-facing behavior documented in `docs/*.md`
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] No load-bearing invariant is broken — the report is static and off the hot path
- [ ] ~~free-threaded run~~ — does not touch `ChunkPool`, the scheduler, or cross-thread
      readiness
- [ ] ~~performance claim~~ — the 1.8–2.2x and 1.25x figures are cited from #41 and #36
      rather than newly claimed here

<!-- Attestation deliberately left unticked: it is the human author's to tick, and this
     description was drafted by an assistant. -->

