### PR TITLE
docs: correct claims stronger than the mechanism, and stale ones the code outgrew

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -70,8 +70,10 @@ Three frictions with cloud Zarr:
 
 1. **No shared chunk cache** across workers → one chunk fetched + decompressed
    once *per worker* whose samples land in it.
-2. **Sync `getitem` can't drive async obstore** → you can't fan out 200 concurrent
-   range reads from inside a worker.
+2. **Fan-out is one sample deep** → a worker *can* drive async obstore (zarr's sync
+   API runs a process-wide event loop), but `__getitem__` returns one sample before
+   the next starts, so concurrency never spans the samples a batch needs — and the
+   budget is per-process, multiplied N times against the store.
 3. **dask thread pool nested in each worker** → procs × threads oversubscription,
    slow fork startup, fat memory.
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ spectra without building anything:
 
 The classic PyTorch `DataLoader` spreads work across worker **processes**, each
 running a *synchronous* `__getitem__`. Against cloud Zarr that means no shared
-chunk cache (every worker re-reads the same chunk), no way to drive async
-obstore, and dask thread pools nested inside forked workers. `insitubatch`
-**inverts** it: one async event loop streams stored chunks under a single
+chunk cache (every worker re-reads the same chunk), read concurrency that reaches no
+further than one sample, and dask thread pools nested inside forked workers.
+`insitubatch` **inverts** it: one async event loop streams stored chunks under a single
 concurrency budget into a bounded pool that holds them and assembles batches on
 demand — the pool doubles as the cache; torch runs `num_workers=0`.
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ demand — the pool doubles as the cache; torch runs `num_workers=0`.
 
 The payoff is a **two-regime** story against the worker-process `DataLoader`. On a
 **well-chunked** store it **matches a hand-tuned worker/xbatcher pool** (swept to 32 workers)
-while running in **one process at bounded memory**, reaching first batch in ~ms rather than
-seconds of pool cold-start. When the chunk layout **isn't sample-optimized** — fat time-chunks,
-overlapping windows, verification grids — it pulls **far ahead of even a tuned pool**: read
-planning decodes each shared chunk **once** where a per-sample `__getitem__` re-reads it, so the
-win **grows with samples-per-chunk** (to ~25× at the fat end of the ERA5 sweep) and cross-epoch
+while running in **one process at bounded memory**, reaching first batch in a fraction of a
+second rather than the seconds a worker pool spends starting. When the chunk layout **isn't
+sample-optimized** — fat time-chunks, overlapping windows, verification grids — it pulls
+**far ahead of even a tuned pool**: read planning decodes each shared chunk **once** where a
+per-sample `__getitem__` re-reads it, so the win **grows with samples-per-chunk** (to ~25× at the fat end of the ERA5 sweep) and cross-epoch
 caching compounds it. The **honest boundary**: at the one-sample-per-chunk (GRIB) end there is
 nothing to amortize, so a tuned pool edges ahead on single-pass throughput, and against an
 *unbounded* concurrent gather on large fields bounded-inflight streaming trails per byte — the
@@ -57,11 +57,14 @@ sweet spot is streaming with bounded memory, not a universal speed win. Full com
 ## Status
 
 🚧 **alpha, but validated on real cloud IO.** On an in-region S3 run
-(`c6id.8xlarge`, ERA5-shaped `721×1440` fields, `sample_chunk=8`), insitubatch
-delivers **~8× the throughput** of a *tuned* `xbatcher`/worker `DataLoader`
-baseline (swept to 32 workers) and reaches its first batch **~10× sooner** — the
+(`c6id.8xlarge`, 32 vCPU, coarsened ERA5 `361×720` fields), at fat chunks
+(`sample_chunk=16`) insitubatch delivers **~19× the throughput** of a *tuned*
+`xbatcher`/worker `DataLoader` baseline (swept to 32 workers), in **~8× less
+memory**, and reaches its first batch **~22× sooner** (0.7 s vs 15.6 s) — the
 map-style baseline re-decodes a whole chunk per sample; insitubatch reads each
-chunk once. Full numbers + methodology:
+chunk once. That is the *fat* end of the sweep, where the advantage is largest;
+at one sample per chunk there is nothing to amortize and a tuned pool edges ahead
+on single-pass throughput. Full numbers + methodology:
 [the benchmarks page](https://emfdavid.github.io/insitubatch/benchmarks/).
 
 The engine is the **decoupled fetch scheduler**: reads flatten to *stored chunks*
@@ -130,11 +133,19 @@ the same is enforced in CI.
 
 ### Free-threaded (3.13t)
 
-The engine is free-threading-correct by construction: a delivering thread does its
+The `ChunkPool` is free-threading-correct **by construction**: a delivering thread does its
 write **before** the lock — each tile is its own key, so writers never collide — and
 publishes readiness **under** it, so the lock, not the GIL, is the happens-before edge
 to the consuming gather. The race probe is
 `test_pool_concurrent_scatter_is_race_free` (64 tiles, 32 threads).
+
+The batch-buffer pool is *enforced* rather than structural, and the distinction is worth
+knowing: it decides a buffer is free by reading `sys.getrefcount` on the buffer's owner
+against a calibrated idle baseline, and a refcount read off-GIL can be stale. Reading
+*high* only wastes a buffer (the pool allocates another). Reading *low* would hand live
+memory to a second writer, so the pool treats a below-baseline count as impossible and
+**raises** rather than lending — see `buffers.py`. That guard is what makes the mechanism
+safe on 3.13t; it is not the same claim as the pool scatter's.
 
 Run the suite GIL-free on a free-threaded interpreter:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -470,9 +470,12 @@ samples in order — for eval / inference / reconstruction.)
 
 The pipeline holds two guarantees, and they are **orthogonal** — batch size touches neither:
 
-- **read-once** — a stored tile is fetched and decoded exactly once, however many samples,
-  batches, or epochs reference it (the read plan dedups; the `ChunkPool` keeps it resident;
-  gather reads from the slot).
+- **read-once** — a stored tile is fetched and decoded exactly once, however many samples
+  and batches reference it (the read plan dedups; the `ChunkPool` keeps it resident; gather
+  reads from the slot). Across **epochs** it holds only while the tile stays resident: the
+  default budget is the working set, which is read-once *per epoch*; raise
+  `cache_budget_bytes` past it and an unevicted chunk is a cross-epoch hit too
+  (see [The caching continuum](#the-caching-continuum)).
 - **sample-once** — each valid sample lands in exactly one batch.
 
 `order` is the ledger for sample-once: an `(N, 2)` array of `[chunk_id, within]`, one row per

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,8 @@ how downstream frameworks integrate. For the why behind the project see
 Classic `DataLoader`: parallelism lives in **`num_workers` OS processes**, each
 running a *synchronous* `__getitem__`. insitubatch: parallelism lives in **one
 async event loop**; batch assembly is the consumer. That move is what unlocks
-async obstore, a shared chunk cache, bounded memory, and prefetch overlap.
+read concurrency across a whole batch, a shared chunk cache, bounded memory, and
+prefetch overlap.
 
 ## Classic worker-based loader
 
@@ -36,8 +37,10 @@ Frictions against cloud ndim zarr:
 
 - **No shared chunk cache** — a chunk is fetched + decompressed once *per worker*
   whose samples land in it.
-- **Sync `getitem` can't drive async obstore** — no way to fan out concurrent
-  range reads from inside a worker.
+- **Fan-out is one sample deep** — a worker *can* drive async obstore (zarr's sync
+  API runs a process-wide event loop), but `__getitem__` returns one sample before
+  the next starts, so concurrency never spans the samples a batch needs, and the
+  budget is per-process, multiplied N times against the store.
 - **dask thread pool nested in each worker** — procs × threads oversubscription,
   slow fork startup, fat memory.
 - **The fork-safety tax** — a modern object store (obstore) runs a Rust **tokio**
@@ -56,7 +59,7 @@ Frictions against cloud ndim zarr:
   we prefetch is.
 
 > **Why this is the argument for the single loop.** Every friction above — no
-> shared cache, sync IO that can't drive obstore, thread oversubscription, the
+> shared cache, per-sample fan-out, thread oversubscription, the
 > fork-safety tax — follows from putting parallelism in OS *processes*.
 > insitubatch drives one in-process event loop (`num_workers=0`): there is no
 > fork, so there is no fork-safety tax, no per-worker runtime to relaunch, and the
@@ -123,13 +126,17 @@ and amortized across every sample that touches it; **read concurrency
 total memory is the budget + the prefetch queue (depth `d`) + the in-flight tiles —
 every term a tunable cap, none scaling with batch size or epoch length.
 
-The batch buffers themselves are **not** pooled: `gather` allocates a fresh array per
-batch (the DLPack export aliases it into the consumer's tensor, so safe reuse would
-need lifetime tracking against the prefetch window), and host memory is **not pinned**
-yet, so host→device copies are pageable. Both are one deferred fix — a small ring of
-pre-pinned buffers (depth ≈ `prefetch_depth`) reused round-robin, which kills the
-per-batch allocation *and* enables `non_blocking` transfer together. See Known
-limitations in
+The batch buffers are **pooled** too, on different machinery: `gather` takes one from a
+reuse pool that allocates on a miss and reclaims a buffer once nothing outside the pool
+references it. Lifetime tracking is what makes that safe against the DLPack export, which
+aliases the buffer into the consumer's tensor — so *retaining a batch retains its buffer*
+automatically and the pool just allocates elsewhere. There is no depth parameter (it
+converges on however many buffers are genuinely in flight) and a short final batch is a
+prefix view, costing neither an allocation nor a copy. `INSITUBATCH_NO_BUFFER_REUSE` is the
+escape hatch back to one fresh array per batch. Host memory is pageable by default;
+`as_torch(view, device=...)` swaps in a page-locked allocator, which is what makes the H2D
+copy genuinely asynchronous — pinning is coupled to `device` on purpose, since it is only
+safe when whoever issues the copy also knows when it landed. See Known limitations in
 [DESIGN.md](https://github.com/emfdavid/insitubatch/blob/main/DESIGN.md#known-limitations--defects).
 
 ### One event loop, one decode pool
@@ -833,7 +840,7 @@ shortcut: it is exactly what lets xbatcher's cache survive process exit today.
 | dimension | insitubatch — chunk pool | xbatcher — batch cache |
 |---|---|---|
 | unit cached | decoded + chunk-transformed **chunk** (deduped) | **assembled batch**, in batch layout |
-| extra copy | none — `gather` views the slot in place | a separate materialized copy |
+| extra copy | none beyond the batch — `gather` copies rows from the slot straight into it | the batch, **plus** a separate materialized copy in the cache |
 | key | `(array, chunk_index)` | batch index → zarr store |
 | backing | heap or mmap'd `.npy` (reclaimable NVMe page cache) | zarr store (local dir or cloud) |
 | cross-epoch reuse | intrinsic (just don't evict) | yes |
@@ -842,7 +849,7 @@ shortcut: it is exactly what lets xbatcher's cache survive process exit today.
 | sweet spot | many samples per chunk, fat-chunk, multi-epoch, scoring reuse | one-sample-per-chunk, stable batch defs reused across runs |
 
 Both persist across runs now; the distinction is the **unit**. insitu caches deduped
-decoded chunks (no second copy, `gather` views the slot in place) and keeps a stronger
+decoded chunks (stored once, with nothing staged between slot and batch) and keeps a stronger
 per-epoch shuffle because the cache is *upstream* of shuffling; xbatcher caches
 materialized batches with frozen composition. Pick by regime, not by a missing feature.
 
@@ -907,8 +914,9 @@ isn't working is loud, not silent.
 - The cache key is `(array_path, global chunk_index)` — the *absolute* zarr chunk index,
   not relative to a split or `sample_range`. So overlapping subsets/splits and a later
   fuller run **share** entries: chunk 5 is always the same `.npy`.
-- A hit returns the **prepped** chunk (post-`chunk_transform`), no copy — `gather` views
-  the slot in place.
+- A hit returns the **prepped** chunk (post-`chunk_transform`): no fetch, no decode, no
+  transform. `gather` copies its rows straight into the batch, with nothing staged in
+  between.
 - **Crash-safe:** each *completed* chunk is appended to the log as it finishes (flushed to
   the OS page cache, which survives process death), so a killed run keeps everything it
   decoded. The log is self-deduplicating (a re-completed chunk across epochs/runs is not

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,8 +22,9 @@ resharded. See [Examples](examples.md) and the
 
 **Where it wins.** On a well-chunked store it **matches a hand-tuned worker `DataLoader`**
 (swept to its best worker count) **at a fraction of the memory** — one process, bounded
-residency, ~ms to first batch instead of seconds of pool cold-start. When the chunk layout
-**isn't sample-optimized** — fat time-chunks, overlapping windows, verification grids — it pulls
+residency, a fraction of a second to first batch instead of the seconds a worker pool spends
+starting. When the chunk layout **isn't sample-optimized** — fat time-chunks, overlapping
+windows, verification grids — it pulls
 **far ahead of even a tuned worker pool**, because read planning decodes each shared chunk once
 where per-sample workers re-read it (the win grows with samples-per-chunk). It is **not** a
 universal speed win: at the one-sample-per-chunk (GRIB) end, or against an unbounded gather on

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,9 +47,10 @@ an offline synthetic mode so it runs with no network or credentials. Details and
 
 The classic PyTorch `DataLoader` puts parallelism in worker **processes**, each running a
 *synchronous* `__getitem__`. Against cloud Zarr that fights itself: no shared chunk cache
-(every worker re-reads the same chunk), no way to drive async obstore, and dask thread
-pools nested inside forked workers. The usual escape — **resharding** to one-sample-per-file
-— is a second copy of the dataset that throws away the chunk locality the store already has.
+(every worker re-reads the same chunk), read concurrency that reaches no further than one
+sample, and dask thread pools nested inside forked workers. The usual escape — **resharding**
+to one-sample-per-file — is a second copy of the dataset that throws away the chunk locality
+the store already has.
 
 `insitubatch` keeps the data in place and **inverts the loader**:
 
@@ -57,8 +58,8 @@ pools nested inside forked workers. The usual escape — **resharding** to one-s
 > synchronous `__getitem__`. insitubatch: parallelism lives in **one async event loop**;
 > batch assembly is the consumer.
 
-That single move unlocks async obstore, a **shared chunk cache**, bounded memory, and
-**prefetch overlap** with the training step; torch runs `num_workers=0`.
+That single move unlocks read concurrency across a whole batch, a **shared chunk cache**,
+bounded memory, and **prefetch overlap** with the training step; torch runs `num_workers=0`.
 [Architecture](architecture.md) has the full frictions breakdown, the loader/prefetch
 diagrams, and the read-plan abstraction;
 [DESIGN.md](https://github.com/emfdavid/insitubatch/blob/main/DESIGN.md) has the why.


### PR DESCRIPTION
## Summary

Docs only. Fixes the three defects in #47, then sweeps the front doors for the same two failure modes: a claim stronger than the mechanism supports, and a claim the code has outgrown.

Closes #47.

Found while drafting the Pangeo Showcase abstract, which is why these are the ones an outside reader meets first.

**The three from the issue.** "Sync `getitem` can't drive async obstore" is false — zarr-python's sync API runs a process-wide event loop, so `arr[...]` inside a worker drives async obstore fine. The true claim is scope, not capability: `__getitem__` returns one sample before the next starts, so fan-out never spans the samples a batch needs, and the budget is per-process. That claim had spread to **six sites across four files**. "Batch buffers are not pooled … host memory is not pinned yet" has been stale since #21 and offered the shipped work as "one deferred fix". "No copy — `gather` views the slot in place" is false at three sites; `gather` allocates from the buffer pool and copies each chunk's rows in.

**The sweep.** "~ms to first batch" (README, landing page) was off by ~10× — measured TTFB is 0.2 s at c1, 0.7 s at c16, ~320 ms on WB2. The README Status block cited a run that does not match the benchmarks page. "Free-threading-correct by construction" was one claim covering two mechanisms with different guarantees. `read-once` claimed cross-epoch reuse the default budget does not give.

## For reviewers

**The README Status block is what most needs a second look.** It claimed `721×1440` fields where `docs/benchmarks.md` says coarsened `361×720`, and "~8× the throughput" where the page reports ~8× **memory** and ~19× **throughput** — which looks like a transposition. I realigned every figure to the published c16 table (`docs/benchmarks.md:230-244`), so the throughput claim goes **up**, 8× → 19×, and added the caveat that this is the fat end of the sweep where a tuned pool loses hardest. **If those original numbers came from a real run that simply is not on the benchmarks page, this replaces real data with different real data.** You would know that; I would not.

Second: the free-threading split in the README. "The engine is free-threading-correct by construction" now applies only to the `ChunkPool` scatter, which earns it structurally. The batch-buffer pool is described separately as *enforced* — it reads `sys.getrefcount` against a calibrated baseline, which off-GIL can be stale, and a below-baseline count raises rather than lending. That distinction is not documented anywhere in the repo today, and I wrote only what `buffers.py` and `DESIGN.md:565-575` support. No measured cost of stale-high readings is claimed, because there is no in-repo measurement to cite.

Confident in the rest: the six-site defect-1 rewrite, the buffer-pool paragraph (verified against `buffers.py:261` and `frameworks.py:281`), and the `gather` copy claims (verified against `pool.py:1226`, `out[(mask, *dst[1:])] = tile[(rows, *src[1:])]`).

**Rebased onto #41** after it landed mid-review. Two conflicts in `README.md`, both resolved by keeping #41's newer mechanism wording and re-applying this branch's correction on top: the pool sentence now reads "holds them and assembles batches on demand" (#41's), and the free-threading paragraph keeps #41's "each tile is its own key, so writers never collide" while taking this branch's split between the `ChunkPool` claim and the batch-buffer pool's. Every edit was re-verified against post-#41 code.

## Author attestation

- [x] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

## Checklist

- [x] `uv run ruff check src tests bench examples`, `uv run mypy src bench examples` are green locally; `uv run --extra docs mkdocs build --strict` is clean
- [x] User-facing behavior documented in `docs/*.md`
- [ ] A bullet added under `## Unreleased` in `CHANGELOG.md` — **deliberately skipped** at the maintainer's direction; this corrects existing docs rather than changing behavior
- [x] No load-bearing invariant is broken — docs only, no code touched

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nhMRqZosrp81VjwkJn1zC
