### PR TITLE
fix: one writer per cache_dir, and chunk files that are replaced, not truncated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 ## Unreleased
 
+- **One writer per `cache_dir` — the silent corruption two jobs on one cache could cause is
+  now an error.** Two Earth2Studio inference jobs pointed at one `cache_dir` — the obvious
+  thing to do, and what the supply-chain audit on
+  [NVIDIA/earth2studio#962](https://github.com/NVIDIA/earth2studio/pull/962) found the feed
+  invites — could corrupt each other with nothing to show for it. The window is re-admission
+  after eviction: process B revives a cached chunk and holds its mapping, process A misses
+  the same chunk and re-admits it, and `open_memmap(mode="w+")` truncates the file *under
+  B*, which reads zero pages as data. Right shape, right dtype, wrong numbers — throughput,
+  shapes and smoke tests all pass, and only a model-free baseline like persistence RMSE
+  would have noticed.
+
+  Two changes, and the first stands on its own: a chunk file is now written under a temp
+  name and `rename`d into place, so a held mapping keeps its inode and its data no matter
+  who re-admits the chunk. On top of that the pool takes an advisory `flock` on the cache
+  directory for its lifetime, so a second writer **fails fast** — with the holder's PID and
+  host, what to do in either case, and the two commands that answer "who?" — instead of
+  quietly disagreeing with the first. The lock keys on **`cache_dir` being set, not on
+  `persist=True`**: `_alloc` writes the same filenames in ephemeral spill mode, so scoping
+  it to persist would have left the identical hole open.
+
+  New `readonly_cache=True` (on `InSituDataset` and `ChunkPool`) is the workload this is
+  shaped around — one job warms a cache, several score against it. It takes the lock shared,
+  so any number coexist; it writes nothing; and **a cache miss raises**, naming the array
+  and chunk. That is what makes it a contract — *this cache is complete for what I am about
+  to read* — rather than a slow path that silently re-fetches whatever the warming run's
+  split or transforms left out.
+
+  Two things the docs now have to say because users will otherwise get them wrong. There is
+  no such thing as a stale `flock` — the kernel releases it when the process dies, `SIGKILL`
+  and spot preemption included — so there is no cleanup procedure, and **deleting the
+  lockfile is actively harmful**: it releases nothing and makes the next two processes lock
+  different inodes, reintroducing the corruption. And a network `cache_dir` (where `flock`
+  may be emulated per client) or a platform without POSIX locking is still unarbitrated;
+  both now warn at construction saying exactly that, because it is the one configuration
+  where two writers can still corrupt each other. Which also forced the project's first
+  **platform-support statement** (README, contributing, classifiers): Linux supported and
+  the only thing CI proves, macOS untested, Windows untested and unarbitrated — *untested*,
+  not *unsupported*.
+
+  Part 1 of #42. Per-variable cache identity (part 2) needs a manifest bump and is
+  unchanged; this fixes the corruption without invalidating anybody's cache.
+
 - **`InSituDataset.last_pass` — which stage was the bottleneck, and what to do about it.**
   Every producer-side problem presents the same way, as an empty batch queue: slow storage,
   a saturated decode pool, and a residency budget too small to admit the next chunk are

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -665,6 +665,28 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   so any consumer can detect silent shrinkage without re-deriving `valid_anchor_range`. An
   opt-in `on_edge="drop"|"raise"` is deliberately **deferred as YAGNI** until a second
   inference-style consumer appears — don't add the knob for one caller.
+- ~~**A shared `cache_dir` had no cross-process arbitration.**~~ **FIXED (part 1 of #42).**
+  Two processes on one `cache_dir` corrupted each other *silently*. Not a torn read on a
+  half-written chunk — the manifest gates that. The window is **re-admission after
+  eviction**: B revives a persisted chunk and holds its mapping; A misses the same chunk and
+  re-admits it; `open_memmap(mode="w+")` **truncates the file under B**, which then reads
+  zero pages as data. Right shape, right dtype, wrong numbers, so throughput, shapes and
+  smoke tests all pass. Surfaced in the supply-chain audit on
+  [NVIDIA/earth2studio#962](https://github.com/NVIDIA/earth2studio/pull/962), where
+  `InSituForecastFeed` exposes `cache_dir` with no warning. Two changes: (1) a slot file is
+  written under a temp name and `rename`d into place — POSIX keeps the old inode alive for
+  anyone holding it, so the truncation window is gone *independently of any locking*; (2) the
+  pool takes an advisory `flock` on the cache dir for its lifetime, exclusive to write and
+  shared under the new `readonly_cache=True`, so a second writer fails fast naming the holder
+  rather than corrupting the first. The lock keys on **`cache_dir` being set, not on
+  `persist`** — a correction to the issue as filed: `_alloc` writes the same filenames in
+  ephemeral spill mode, so scoping it to persist would have left the hole open. There is no
+  stale-lock procedure to document, because there is no stale lock: the kernel releases it
+  when the process dies, `SIGKILL` included. Deleting the lockfile is actively harmful — it
+  releases nothing and makes the next two processes lock *different inodes*, reintroducing
+  the corruption. **What remains open** is named where the user meets it: a network
+  `cache_dir` (`flock` may be emulated per client) and a platform with no POSIX locking are
+  still unarbitrated, and both warn at construction saying so. Detection is not a fix.
 - **Cache invalidation is whole-pipeline, not per-variable.** `chunk_transforms` is one list
   applied to every variable (each transform self-gates by name and no-ops on the rest), and
   the fingerprint hashes the **whole list once** → a single `pipeline_hash` on every array's

--- a/README.md
+++ b/README.md
@@ -105,16 +105,14 @@ uv sync --extra gpu      # CUDA box only: cupy + kvikio zero-copy path
 
 ### Platform support
 
-Stated honestly, because until now it was not stated at all:
-
 | platform | status |
 |---|---|
 | **Linux** | supported, and the only thing CI proves — every job is `ubuntu-latest` |
 | **macOS** | expected to work; **untested** — no CI job, no regular local runs |
 | **Windows** | **untested**, and unarbitrated: there is no POSIX advisory locking, so two processes sharing a `cache_dir` cannot be stopped from corrupting each other. The loader warns at construction |
 
-*Untested* is not *unsupported*: we have no evidence either way, and claiming support we do
-not test is exactly the overclaim we removed elsewhere. Reports (or a CI job) welcome.
+*Untested* is not *unsupported*: there is no evidence either way. Reports — or a CI job —
+are welcome.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ uv sync --extra tf       # add the TF handoff (frameworks.as_tf_dataset)
 uv sync --extra gpu      # CUDA box only: cupy + kvikio zero-copy path
 ```
 
+### Platform support
+
+Stated honestly, because until now it was not stated at all:
+
+| platform | status |
+|---|---|
+| **Linux** | supported, and the only thing CI proves — every job is `ubuntu-latest` |
+| **macOS** | expected to work; **untested** — no CI job, no regular local runs |
+| **Windows** | **untested**, and unarbitrated: there is no POSIX advisory locking, so two processes sharing a `cache_dir` cannot be stopped from corrupting each other. The loader warns at construction |
+
+*Untested* is not *unsupported*: we have no evidence either way, and claiming support we do
+not test is exactly the overclaim we removed elsewhere. Reports (or a CI job) welcome.
+
 ## Tests
 
 ```bash

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -111,6 +111,17 @@ uv sync --extra docs       # MkDocs site
 uv sync --extra gpu        # CUDA box only: cupy + kvikio zero-copy path
 ```
 
+### Which platform
+
+**Linux is what CI runs, and the only platform we claim.** macOS is expected to work and is
+*untested* — no CI job, no regular local runs. Windows is untested too, and additionally has
+no POSIX advisory locking, so it cannot arbitrate two processes sharing a `cache_dir`; the
+loader warns at construction when it finds itself there.
+
+*Untested* is not *unsupported*: we have no evidence either way, and claiming support we do
+not test is an overclaim. If you develop on macOS or Windows, a bug report — or a CI job —
+is a genuinely useful contribution.
+
 Code lives in `src/insitubatch/`, tests in `tests/`, the benchmark suite in `bench/`, and
 runnable examples in `examples/`. DESIGN.md's
 [**Module map**](https://github.com/emfdavid/insitubatch/blob/main/DESIGN.md#module-map) is the

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -168,20 +168,23 @@ hands out ordinary pageable memory and warns once, rather than raising or stalli
 
 ## Sharing a `cache_dir` between processes
 
-**One process at a time may write a given `cache_dir`.** The loader enforces it: the pool
-takes an advisory lock on the directory for its lifetime, and a second writer fails fast
-with an error naming the holder rather than corrupting the first one's chunks. This applies
-whenever `cache_dir` is set — with or without `persist=True` — because the two write the
-same filenames.
+**One writer at a time, or any number of readers — never both.** The pool takes an advisory
+lock on the directory for its lifetime, so the second opener is refused at construction
+rather than corrupting the first:
 
-The failure it replaces was silent. A cached chunk is an mmap'd `.npy`; a second process
-re-admitting a chunk the first has mapped used to truncate the file underneath it, and the
-reader carried on with right-shape, right-dtype, wrong numbers. Throughput, shapes and
-smoke tests all pass. Chunk files are now replaced rather than truncated in place, so a
-held mapping keeps reading real data; the lock is what keeps two writers from disagreeing
-about *what* should be there in the first place.
+| already open | second opener | |
+|---|---|---|
+| writer | writer | refused |
+| writer | reader (`readonly_cache=True`) | refused |
+| reader | writer | refused |
+| reader | reader | **allowed** |
 
-The workload this is shaped around — one job warms a cache, several score against it — is
+This applies whenever `cache_dir` is set — with or without `persist=True` — because the two
+write the same filenames. What it replaces was silent: a second process re-admitting a chunk
+the first had mapped used to truncate the file underneath it, and the reader carried on with
+right-shape, right-dtype, wrong numbers.
+
+The workload it is shaped around — one job warms a cache, several score against it — is
 spelled `readonly_cache=True`:
 
 ```python
@@ -194,64 +197,48 @@ warm.close()
 ds = InSituDataset(store, manifest, cache_dir="/data/era5-cache", readonly_cache=True)
 ```
 
-A read-only opener takes the lock *shared*: any number coexist with each other, none with a
-writer. It writes nothing — no chunk files, no log entries — and **a cache miss raises**.
-That is deliberate: the flag asserts *this cache is complete for what I am about to read*,
-and a silent fall-back to fetching would make it a performance hint instead of a contract.
-The error names the array and chunk, and the usual cause is a different split,
-`sample_range` or transform set than the run that warmed it. `reset_stale_cache=True` is
-rejected in this mode — a reader may not delete files another process is using.
+A read-only opener writes nothing — no chunk files, no log entries — and **a cache miss
+raises**, naming the array and chunk. That is what makes it a contract (*this cache is
+complete for what I am about to read*) rather than a performance hint; the usual cause of a
+miss is a different split, `sample_range` or transform set than the run that warmed it.
+`reset_stale_cache=True` is rejected in this mode. Excluding a reader from a *live* writer
+follows from the same promise: a cache still being warmed is not complete, so it is better
+refused at construction than failed forty batches in.
 
-### What happens to active readers when a writer invalidates the cache
-
-Nothing, because the writer never starts. Invalidation — `reset_stale_cache=True` deleting
-every entry, or a run re-admitting chunks it evicted — is work a *writer* does, and a writer
-cannot open the directory while any reader holds it. The exclusion is at construction, before
-the writer can allocate, evict or delete anything.
-
-The layer underneath does not depend on that, though, which matters on the configurations
-where the lock is not available. A reader that already holds a chunk's mapping keeps reading
-real data even if the file is replaced (the new content goes to a new inode) *or* deleted
-(POSIX keeps the inode alive until the last reference goes). So the worst a bypassed lock
-can do to an active reader is cost it a **future** open — a miss, which `readonly_cache`
-turns into a loud error — never wrong numbers in a batch that looks fine.
-
-Both properties are pinned by tests rather than left as reasoning:
-`test_a_writer_cannot_start_while_another_process_is_reading` and
-`test_deleting_a_cached_file_does_not_disturb_a_held_mapping`.
+Invalidation — `reset_stale_cache` deleting entries, or a run re-admitting chunks it evicted
+— is therefore something no reader is ever present for. Underneath that, chunk files are
+replaced rather than truncated, so a reader holding a mapping keeps reading real data even
+if the file is replaced or deleted. That second layer is what stands where the lock cannot
+be taken (below): the worst a bypassed lock costs an active reader is a *future* open — a
+miss — never wrong numbers.
 
 ### If you hit the lock
 
-```
-insitubatch: cache_dir '/data/era5-cache' is already open for writing by another
-process (PID 44315 on host gpu-07, since 14:22:10).
-```
-
-To find the holder:
+The error names the holder's PID, host and start time. That is a **hint** read from the
+lockfile; the lock itself is authoritative, so confirm with:
 
 ```bash
 fuser -v /data/era5-cache/.insitu.lock
 lsof /data/era5-cache/.insitu.lock
 ```
 
-**Do not delete the lockfile.** It is the first thing people try and it is actively
-harmful. The lock is held by the kernel against an open file description, not by the file:
-deleting it releases nothing, and it makes the next two processes lock *different inodes* —
-reintroducing exactly the corruption the check prevents. The PID/host/time in the file are
-a **hint** for the message; the lock itself is authoritative.
+**Do not delete the lockfile.** It is the first thing people try and it is actively harmful:
+the lock is held by the kernel against an open file description, not by the file, so
+deleting it releases nothing — and it makes the next two processes lock *different inodes*,
+reintroducing exactly the corruption the check prevents.
 
-There is also no such thing as a stale lock, so there is no cleanup procedure to run. The
-kernel releases it when the process dies — `SIGKILL`, OOM and spot preemption included. If
-you are seeing the error, that process is alive.
+There is no such thing as a stale lock, and so no cleanup procedure. The kernel releases it
+when the process dies — `SIGKILL`, OOM and spot preemption included. If you are seeing the
+error, that process is alive.
 
 ### Put `cache_dir` on local NVMe, not NFS
 
 This is the mmap tier used as designed, not a new restriction. Over a network filesystem it
-is slow, and — more to the point — **unarbitrated**: `flock` may be emulated per client, so
-two processes on different hosts can each believe they hold the write lock. The loader
-warns when it can detect one (Linux, via the mount table), but detection is not a fix. A
-network `cache_dir` and a platform with no POSIX locking (Windows) are the two
-configurations where two writers can still corrupt each other, and both warn saying so.
+is slow and — more to the point — **unarbitrated**: `flock` may be emulated per client, so
+two processes on different hosts can each believe they hold the write lock. The loader warns
+when it can detect one (Linux, via the mount table), but detection is not a fix. A network
+`cache_dir` and a platform with no POSIX locking (Windows) are the two configurations where
+two writers can still corrupt each other, and both warn saying so.
 
 ## Shuffle quality
 

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -180,9 +180,9 @@ rather than corrupting the first:
 | reader | reader | **allowed** |
 
 This applies whenever `cache_dir` is set — with or without `persist=True` — because the two
-write the same filenames. What it replaces was silent: a second process re-admitting a chunk
-the first had mapped used to truncate the file underneath it, and the reader carried on with
-right-shape, right-dtype, wrong numbers.
+write the same filenames. Without it, a second process re-admitting a chunk the first has
+mapped truncates the file underneath it, and the reader carries on with right-shape,
+right-dtype, wrong numbers.
 
 The workload it is shaped around — one job warms a cache, several score against it — is
 spelled `readonly_cache=True`:
@@ -206,11 +206,11 @@ follows from the same promise: a cache still being warmed is not complete, so it
 refused at construction than failed forty batches in.
 
 Invalidation — `reset_stale_cache` deleting entries, or a run re-admitting chunks it evicted
-— is therefore something no reader is ever present for. Underneath that, chunk files are
-replaced rather than truncated, so a reader holding a mapping keeps reading real data even
-if the file is replaced or deleted. That second layer is what stands where the lock cannot
-be taken (below): the worst a bypassed lock costs an active reader is a *future* open — a
-miss — never wrong numbers.
+— is therefore something no reader is ever present for. Underneath that, a chunk file is
+written to a temp name and renamed into place, so a reader holding a mapping keeps its own
+inode and keeps reading real data whether that file is replaced or deleted. That second
+layer is what stands where the lock cannot be taken (below): the worst a bypassed lock costs
+an active reader is a *future* open — a miss — never wrong numbers.
 
 ### If you hit the lock
 
@@ -233,7 +233,7 @@ error, that process is alive.
 
 ### Put `cache_dir` on local NVMe, not NFS
 
-This is the mmap tier used as designed, not a new restriction. Over a network filesystem it
+The cache is an mmap tier, so this is what it is built for. Over a network filesystem it
 is slow and — more to the point — **unarbitrated**: `flock` may be emulated per client, so
 two processes on different hosts can each believe they hold the write lock. The loader warns
 when it can detect one (Linux, via the mount table), but detection is not a fix. A network

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -202,6 +202,24 @@ The error names the array and chunk, and the usual cause is a different split,
 `sample_range` or transform set than the run that warmed it. `reset_stale_cache=True` is
 rejected in this mode — a reader may not delete files another process is using.
 
+### What happens to active readers when a writer invalidates the cache
+
+Nothing, because the writer never starts. Invalidation — `reset_stale_cache=True` deleting
+every entry, or a run re-admitting chunks it evicted — is work a *writer* does, and a writer
+cannot open the directory while any reader holds it. The exclusion is at construction, before
+the writer can allocate, evict or delete anything.
+
+The layer underneath does not depend on that, though, which matters on the configurations
+where the lock is not available. A reader that already holds a chunk's mapping keeps reading
+real data even if the file is replaced (the new content goes to a new inode) *or* deleted
+(POSIX keeps the inode alive until the last reference goes). So the worst a bypassed lock
+can do to an active reader is cost it a **future** open — a miss, which `readonly_cache`
+turns into a loud error — never wrong numbers in a batch that looks fine.
+
+Both properties are pinned by tests rather than left as reasoning:
+`test_a_writer_cannot_start_while_another_process_is_reading` and
+`test_deleting_a_cached_file_does_not_disturb_a_held_mapping`.
+
 ### If you hit the lock
 
 ```

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -166,6 +166,75 @@ kernel cannot reclaim — so it is bounded separately at RAM/8 by default. Past 
 hands out ordinary pageable memory and warns once, rather than raising or stalling; raise
 `pin_budget_bytes` if you meant to exceed it.
 
+## Sharing a `cache_dir` between processes
+
+**One process at a time may write a given `cache_dir`.** The loader enforces it: the pool
+takes an advisory lock on the directory for its lifetime, and a second writer fails fast
+with an error naming the holder rather than corrupting the first one's chunks. This applies
+whenever `cache_dir` is set — with or without `persist=True` — because the two write the
+same filenames.
+
+The failure it replaces was silent. A cached chunk is an mmap'd `.npy`; a second process
+re-admitting a chunk the first has mapped used to truncate the file underneath it, and the
+reader carried on with right-shape, right-dtype, wrong numbers. Throughput, shapes and
+smoke tests all pass. Chunk files are now replaced rather than truncated in place, so a
+held mapping keeps reading real data; the lock is what keeps two writers from disagreeing
+about *what* should be there in the first place.
+
+The workload this is shaped around — one job warms a cache, several score against it — is
+spelled `readonly_cache=True`:
+
+```python
+# Run once: warm the cache.
+warm = InSituDataset(store, manifest, cache_dir="/data/era5-cache", persist=True)
+for batch in warm.all: ...
+warm.close()
+
+# Then, concurrently, as many readers as you like.
+ds = InSituDataset(store, manifest, cache_dir="/data/era5-cache", readonly_cache=True)
+```
+
+A read-only opener takes the lock *shared*: any number coexist with each other, none with a
+writer. It writes nothing — no chunk files, no log entries — and **a cache miss raises**.
+That is deliberate: the flag asserts *this cache is complete for what I am about to read*,
+and a silent fall-back to fetching would make it a performance hint instead of a contract.
+The error names the array and chunk, and the usual cause is a different split,
+`sample_range` or transform set than the run that warmed it. `reset_stale_cache=True` is
+rejected in this mode — a reader may not delete files another process is using.
+
+### If you hit the lock
+
+```
+insitubatch: cache_dir '/data/era5-cache' is already open for writing by another
+process (PID 44315 on host gpu-07, since 14:22:10).
+```
+
+To find the holder:
+
+```bash
+fuser -v /data/era5-cache/.insitu.lock
+lsof /data/era5-cache/.insitu.lock
+```
+
+**Do not delete the lockfile.** It is the first thing people try and it is actively
+harmful. The lock is held by the kernel against an open file description, not by the file:
+deleting it releases nothing, and it makes the next two processes lock *different inodes* —
+reintroducing exactly the corruption the check prevents. The PID/host/time in the file are
+a **hint** for the message; the lock itself is authoritative.
+
+There is also no such thing as a stale lock, so there is no cleanup procedure to run. The
+kernel releases it when the process dies — `SIGKILL`, OOM and spot preemption included. If
+you are seeing the error, that process is alive.
+
+### Put `cache_dir` on local NVMe, not NFS
+
+This is the mmap tier used as designed, not a new restriction. Over a network filesystem it
+is slow, and — more to the point — **unarbitrated**: `flock` may be emulated per client, so
+two processes on different hosts can each believe they hold the write lock. The loader
+warns when it can detect one (Linux, via the mount table), but detection is not a fix. A
+network `cache_dir` and a platform with no POSIX locking (Windows) are the two
+configurations where two writers can still corrupt each other, and both warn saying so.
+
 ## Shuffle quality
 
 `block_chunks` is also the shuffle-quality knob. Each batch is drawn from the samples in the

--- a/examples/fit_scaler.py
+++ b/examples/fit_scaler.py
@@ -97,6 +97,8 @@ def run_demo(
     *,
     url: str | None = None,
     cache_dir: str | None = None,
+    persist: bool = False,
+    readonly_cache: bool = False,
     variables: list[str] | None = None,
     verbose: bool = True,
     **store_kwargs: Any,
@@ -118,6 +120,8 @@ def run_demo(
     manifest = split_by_chunk(geoms[var0], fractions=(1.0, 0.0, 0.0))
 
     # A cache big enough to hold the split: the fit pass warms it, training reuses it.
+    # With --persist that reuse survives the process; --readonly-cache reads a cache
+    # another run warmed and refuses to write it. One writer per cache_dir.
     ds = InSituDataset(
         store,
         manifest,
@@ -127,6 +131,8 @@ def run_demo(
         shuffle=False,
         cache_dir=cache_dir or (f"{tmp}/cache" if tmp else None),
         cache_budget_bytes=4 << 30,
+        persist=persist,
+        readonly_cache=readonly_cache,
     )
 
     # 1) fit over the loader (cold: decode + cache) -----------------------------------
@@ -188,6 +194,16 @@ def main() -> None:
     p.add_argument("--url", default=None, help="zarr URL (default: synthetic file://)")
     p.add_argument("--cache-dir", default=None, help="spill the cache to this dir (NVMe)")
     p.add_argument(
+        "--persist",
+        action="store_true",
+        help="keep the --cache-dir files across runs (a cross-run cache). One writer at a time",
+    )
+    p.add_argument(
+        "--readonly-cache",
+        action="store_true",
+        help="read a --cache-dir another run warmed, without writing it; a miss is an error",
+    )
+    p.add_argument(
         "--variables",
         default=None,
         help="comma list; must share the sample axis + chunking. --wb2 default: two "
@@ -205,7 +221,13 @@ def main() -> None:
         variables = ["2m_temperature", "10m_u_component_of_wind"]
     else:
         variables = None
-    run_demo(url=url, cache_dir=a.cache_dir, variables=variables)
+    run_demo(
+        url=url,
+        cache_dir=a.cache_dir,
+        persist=a.persist,
+        readonly_cache=a.readonly_cache,
+        variables=variables,
+    )
 
 
 if __name__ == "__main__":

--- a/examples/wb2_arraylake.py
+++ b/examples/wb2_arraylake.py
@@ -88,6 +88,8 @@ def run(
     sample_range: tuple[int, int] | None = None,
     cache_resident: bool = False,
     cache_dir: str | None = None,
+    persist: bool = False,
+    readonly_cache: bool = False,
     train_step_ms: float = 0.0,
     num_epochs: int = 1,
     max_batches: int = 0,
@@ -109,6 +111,10 @@ def run(
     first batch. Pick a window (e.g. one year of 6-hourly steps) so the cache fits; pair
     with ``cache_dir`` to spill the slots to NVMe (mmap) instead of RAM. With a bounded,
     cached split, epoch 2+ is served decode-once from the pool (no re-fetch).
+
+    ``persist`` keeps those files across runs; ``readonly_cache`` reads a cache another run
+    warmed without writing it. Only one process at a time may write a given ``cache_dir``
+    -- a second is an error, not a corruption.
     """
     qual = f"{group}/{var}" if group else var
     geom = open_geometries(store, variables=[qual])[qual]
@@ -144,6 +150,8 @@ def run(
         max_inflight=max_inflight,
         cache_budget_bytes=cache_budget_bytes,
         cache_dir=cache_dir,
+        persist=persist,
+        readonly_cache=readonly_cache,
         shuffle=shuffle,
         seed=seed,
         batch_transforms=[_crop(patch, seed)],
@@ -231,6 +239,16 @@ def main() -> None:
         help="hold the (subset) train split resident -> epoch 2+ is decode-once (no re-fetch)",
     )
     p.add_argument("--cache-dir", default=None, help="spill cached slots to this NVMe dir (mmap)")
+    p.add_argument(
+        "--persist",
+        action="store_true",
+        help="keep the --cache-dir files across runs (a cross-run cache). One writer at a time",
+    )
+    p.add_argument(
+        "--readonly-cache",
+        action="store_true",
+        help="read a --cache-dir another run warmed, without writing it; a miss is an error",
+    )
     add_log_level(p)
     a = p.parse_args()
     configure_logging(a.log_level)
@@ -251,6 +269,8 @@ def main() -> None:
         sample_range=a.sample_range,
         cache_resident=a.cache_resident,
         cache_dir=a.cache_dir,
+        persist=a.persist,
+        readonly_cache=a.readonly_cache,
     )
 
 

--- a/examples/wb2_dataloader.py
+++ b/examples/wb2_dataloader.py
@@ -110,6 +110,8 @@ def run_demo(
     prefetch_depth: int = 2,
     cache_resident: bool = False,
     cache_dir: str | None = None,
+    persist: bool = False,
+    readonly_cache: bool = False,
     train_step_ms: float = 0.0,
     num_epochs: int = 1,
     max_batches: int = 0,
@@ -144,6 +146,8 @@ def run_demo(
     # Caching is the pool's policy (V2: "don't evict"). --cache-resident sizes the budget
     # to hold the whole train split, so epoch 2+ is served from the pool (decode-once);
     # --cache-dir spills the slots to NVMe (mmap) instead of heap. Default: read-once.
+    # --persist keeps those files across runs (a cross-run cache); --readonly-cache reads
+    # one another run warmed without writing it. One writer per cache_dir, always.
     cache_budget_bytes = None
     if cache_resident:
         per_chunk = geom.sample_chunk_size * int(np.prod(geom.inner_shape)) * geom.dtype.itemsize
@@ -158,6 +162,8 @@ def run_demo(
         prefetch_depth=prefetch_depth,
         cache_dir=cache_dir,
         cache_budget_bytes=cache_budget_bytes,
+        persist=persist,
+        readonly_cache=readonly_cache,
         shuffle=shuffle,
         seed=seed,
         batch_transforms=[_subregion_crop(var, subregion, seed)],
@@ -229,6 +235,16 @@ def main() -> None:
         help="hold the whole train split in the pool -> epoch 2+ decode-once (else read-once)",
     )
     p.add_argument("--cache-dir", default=None, help="spill the resident cache to NVMe (mmap)")
+    p.add_argument(
+        "--persist",
+        action="store_true",
+        help="keep the --cache-dir files across runs (a cross-run cache). One writer at a time",
+    )
+    p.add_argument(
+        "--readonly-cache",
+        action="store_true",
+        help="read a --cache-dir another run warmed, without writing it; a miss is an error",
+    )
     p.add_argument("--train-step-ms", type=float, default=0.0)
     p.add_argument("--num-epochs", type=int, default=1)
     p.add_argument("--max-batches", type=int, default=0, help="cap batches per epoch (0 = all)")
@@ -253,6 +269,8 @@ def main() -> None:
         prefetch_depth=a.prefetch_depth,
         cache_resident=a.cache_resident,
         cache_dir=a.cache_dir,
+        persist=a.persist,
+        readonly_cache=a.readonly_cache,
         train_step_ms=a.train_step_ms,
         num_epochs=a.num_epochs,
         max_batches=a.max_batches,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering",
+    # Linux is what CI runs and therefore the only platform we claim. macOS is expected
+    # to work but untested; Windows is untested and, lacking POSIX advisory locking,
+    # cannot arbitrate two processes sharing a cache_dir. See README, "Platform support".
+    "Operating System :: POSIX :: Linux",
 ]
 dependencies = [
     "numpy>=1.26",

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -1748,10 +1748,16 @@ class ChunkPool:
             if self._log_fd is not None:
                 os.close(self._log_fd)
                 self._log_fd = None
-            self._release_lock()
             for k in list(self._slots):
                 slot = self._slots.pop(k)
                 self._free(slot, keep_file=self._persistent and slot.state is SlotState.READY)
+            # LAST, after the final mmap is closed. Releasing it earlier would open a window
+            # where another process may take the write lock while this one still has cache
+            # files mapped. Atomic replace means that window cannot corrupt data -- POSIX
+            # keeps our inode alive -- but the arbitration's invariant is "hold the lock for
+            # as long as you hold a mapping", and leaning on the other layer to cover it is
+            # how a fix quietly stops working.
+            self._release_lock()
             self._bytes = 0
             self._pinned.clear()
             self._buffers.clear()  # batch outputs too; a big-payload pool holds GBs of them

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -1241,7 +1241,12 @@ class ChunkPool:
         # The mapping *is* `path` now -- renaming does not disturb it -- but numpy recorded
         # the name it was opened under. Correct it: `_record_completed` names the cache entry
         # from here and `_free` unlinks through it, and both would otherwise chase a temp
-        # path that no longer exists.
+        # path that no longer exists (silently: a leaked spill file is just disk, and a log
+        # entry naming a vanished temp reads as a cold cache). Safe to assign -- `filename`
+        # is a plain instance attribute numpy sets in `__new__` and copies in
+        # `__array_finalize__`, and numpy never reads it for behavior (`flush` goes through
+        # `_mmap`/`base`), so this is bookkeeping catching up with the rename, not a trick.
+        # Pinned by test_a_slot_file_is_named_by_where_it_landed_not_where_it_was_written.
         cast("np.memmap", backing).filename = os.path.abspath(path)
         return backing
 

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -63,6 +63,7 @@ So the GIL build is just the serialized (slower) case; free threading is upside.
 
 from __future__ import annotations
 
+import codecs
 import contextlib
 import hashlib
 import inspect
@@ -70,13 +71,16 @@ import json
 import logging
 import os
 import re
+import socket
+import sys
 import threading
+import time
 from collections import OrderedDict
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, replace
 from enum import Enum
 from pathlib import Path
-from typing import TextIO, cast
+from typing import cast
 
 import numpy as np
 
@@ -88,9 +92,92 @@ try:  # optional: stronger transform fingerprint (closures + globals). `--extra 
 except ImportError:  # pragma: no cover - exercised by the no-cloudpickle fallback path
     cloudpickle = None
 
+try:  # POSIX advisory locking, which is what arbitrates writers of a shared cache dir.
+    import fcntl
+except ImportError:  # pragma: no cover - Windows; warned about at pool construction
+    fcntl = None  # type: ignore[assignment]
+
 logger = logging.getLogger(__name__)
 
 ChunkTransform = Callable[[DecodedChunk], DecodedChunk]
+
+
+#: Suffix of the private file a slot is written to before it is renamed into place
+#: (see :meth:`ChunkPool._alloc`). A crash between the two leaves one behind; the next
+#: writer to hold the cache lock sweeps them (:meth:`ChunkPool._sweep_tmp`).
+_TMP_SUFFIX = ".insitu-tmp"
+
+#: The advisory-lock file arbitrating writers of one cache dir (see :meth:`ChunkPool._lock`).
+_LOCK_NAME = ".insitu.lock"
+
+#: Filesystems on which the cache's arbitration does not hold. A **denylist**, not an
+#: allowlist: an unrecognized local filesystem stays quiet, and only the types we know
+#: break ``flock``/``rename`` semantics (or are ruinously slow for an mmap tier) warn.
+#: NFS in particular: ``flock`` may be emulated per-client (so two hosts both "hold" it),
+#: and a silently-dropped lock is exactly the case this arbitration exists to prevent.
+_NETWORK_FILESYSTEMS = frozenset(
+    {
+        "nfs",
+        "nfs4",
+        "cifs",
+        "smb3",
+        "fuse.sshfs",
+        "fuse.s3fs",
+        "fuse.gcsfuse",
+        "9p",
+        "lustre",
+        "ceph",
+        "glusterfs",
+    }
+)
+
+
+def _read_holder(fd: int) -> str:
+    """The lockfile's self-reported holder, rendered for an error message.
+
+    A **hint**: the ``flock`` is authoritative and this record can lie -- it names the last
+    process to take the lock for writing, while the lock may currently be held by readers.
+    Never let a parse failure mask the contention error we are on our way to raising.
+    """
+    try:
+        rec = json.loads(os.pread(fd, 4096, 0).decode() or "{}")
+        return f"PID {rec['pid']} on host {rec['host']}, since {rec['since']}"
+    except Exception:  # noqa: BLE001 - any unreadable record degrades to "unknown"
+        return "holder unknown -- the lockfile carries no readable record"
+
+
+def _filesystem_type(path: str | Path) -> str | None:
+    """The filesystem type backing ``path``, or ``None`` where we cannot tell.
+
+    Linux only, read from ``/proc/self/mountinfo`` by longest-prefix match on the
+    *resolved* path -- so a bind mount reports the type of what it is bound to, and a
+    cache dir under a deeper mount is attributed to that mount rather than to ``/``.
+    Returns ``None`` on macOS and Windows (no ``/proc``): we do not know, and a guess
+    would be worse than the honest absence, since the caller only ever *warns* on it.
+    """
+    try:
+        entries = Path("/proc/self/mountinfo").read_text().splitlines()
+    except OSError:
+        return None
+    target = os.path.realpath(path)
+    best: tuple[int, str] | None = None
+    for line in entries:
+        # mountinfo: <id> <parent> <maj:min> <root> <mount point> <opts> [<tag>...] - <fstype> ...
+        left, sep, right = line.partition(" - ")
+        fields, rest = left.split(), right.split()
+        if not sep or len(fields) < 5 or not rest:
+            continue
+        try:  # mount points escape spaces/tabs as octal (\040); decode before comparing
+            mount = codecs.decode(fields[4], "unicode_escape")
+        except UnicodeDecodeError:  # pragma: no cover - a mount point we cannot read
+            continue
+        if target != mount and not target.startswith(mount.rstrip("/") + "/"):
+            continue
+        # Longest prefix wins; on a tie the later line does, since a mount stacked on an
+        # existing mount point shadows the one beneath it.
+        if best is None or len(mount) >= best[0]:
+            best = (len(mount), rest[0])
+    return None if best is None else best[1]
 
 
 def _safe(name: str) -> str:
@@ -337,6 +424,16 @@ class ChunkPool:
     ready+drained, so an in-flight or in-use chunk is never dropped. Backing is heap
     or mmap (see ``backing_dir``); ``chunk_transforms`` run once per outer chunk on
     the *assembled* array, so a hit reflects decode + transform.
+
+    **One writer per ``backing_dir``** (#42). Whenever a backing dir is set -- with or
+    without ``persist``, since ``_alloc`` writes the same filenames either way -- the pool
+    takes an advisory lock on it for its lifetime and a second writer fails fast
+    (:meth:`_lock`). ``readonly_cache=True`` takes that lock *shared* instead: many such
+    openers coexist with each other, none with a writer, none of them writes anything, and
+    a miss **raises** (:meth:`_readonly_miss`) rather than fetching -- the flag is an
+    assertion that this cache is complete for what the run reads. Slot files are replaced,
+    never truncated in place (:meth:`_alloc`), so a reader holding a mapping keeps reading
+    real data even while a writer re-admits the same chunk.
     """
 
     _MANIFEST_NAME = "insitu_cache.jsonl"
@@ -357,6 +454,7 @@ class ChunkPool:
         backing_dir: str | Path | None = None,
         budget_bytes: int | None = None,
         persist: bool = False,
+        readonly_cache: bool = False,
         reset_stale_cache: bool = False,
     ) -> None:
         self._geom = geometries  # label -> geometry (a label is one (array, offset) view)
@@ -386,6 +484,20 @@ class ChunkPool:
             )
             for p, out in self._out_by_path.items()
         }
+        # Cross-process arbitration (#42). Validate before creating anything: a rejected
+        # configuration should leave no directory and no lockfile behind.
+        if persist and backing_dir is None:
+            raise ValueError("persist=True requires cache_dir (a backing_dir) to keep files in")
+        if readonly_cache and backing_dir is None:
+            raise ValueError("readonly_cache=True requires cache_dir -- there is no cache to read")
+        if readonly_cache and reset_stale_cache:
+            raise ValueError(
+                "readonly_cache=True and reset_stale_cache=True contradict each other: a "
+                "read-only opener may not delete a cache another process may be reading. "
+                "Reset it from the run that writes it."
+            )
+        self._readonly = readonly_cache
+        self._lock_fd: int | None = None
         # backing: heap (np.empty) or mmap'd .npy under backing_dir (point at NVMe).
         # A heap slot adopts the tile; the mmap tier writes it into its tile-major slice
         # and keeps the view. mmap keeps the working set as reclaimable page cache rather
@@ -394,7 +506,18 @@ class ChunkPool:
         # spill a working set past RAM or for cross-epoch reuse, not for plain streaming.
         self._dir = Path(backing_dir) if backing_dir is not None else None
         if self._dir is not None:
+            if readonly_cache and not self._dir.is_dir():
+                raise ValueError(
+                    f"readonly_cache=True but {self._dir} does not exist. A read-only opener "
+                    "reads a cache another run warmed; it never creates one."
+                )
             self._dir.mkdir(parents=True, exist_ok=True)
+            self._warn_environment()
+            # The lock keys on cache_dir being set, NOT on persist: `_alloc` writes
+            # `{array}__{cid}.npy` whenever a backing dir is set, so two processes sharing a
+            # spill dir with persist=False collide on identical filenames just as surely.
+            self._lock()
+            self._sweep_tmp()
         # Observability. hits/misses (+ the revive failure breakdown) are per-epoch --
         # reset by unpin_all at each epoch boundary -- so the driver can warn when a
         # configured persist cache served nothing. manifest_entries is load-time (how
@@ -408,29 +531,30 @@ class ChunkPool:
         # entries, and revive them on reopen. Requires a dir to keep the files in. The dir
         # path is the dataset+pipeline identity (the user buries a version in it); we only
         # auto-check shape/dtype on revive (a mismatch is a miss, not an error).
-        self._persistent = persist
+        # readonly_cache reads the cross-run cache without writing it, so it needs the same
+        # revive machinery persist does -- `persist` only additionally *writes*.
+        self._persistent = persist or readonly_cache
         # When the on-disk cache is *stale* (its chunk_transform fingerprint or the log format
         # differs from this run's), the default is to fail fast -- a stale cache is almost never
         # what the user intended. Setting this opts into deleting the stale files and rebuilding.
         self._reset_stale_cache = reset_stale_cache
-        if persist and self._dir is None:
-            raise ValueError("persist=True requires cache_dir (a backing_dir) to keep files in")
         # key -> on-disk filename for completed entries known to survive a run.
         self._persisted: dict[tuple[str, int], str] = {}
         # Keys already written to the on-disk log this pool's lifetime (loaded entries + entries
         # appended on completion). Gates the append so re-completing a chunk across epochs/runs
         # never duplicates a line -- the log is self-deduplicating and bounded to O(#chunks).
         self._recorded: set[tuple[str, int]] = set()
-        # The append-only manifest handle (persist mode), held open for the pool's lifetime so a
-        # completion is one write()+flush() -- no per-chunk open(). None in heap/spill mode.
-        self._log: TextIO | None = None
+        # The append-only manifest fd (persist mode), held open for the pool's lifetime so a
+        # completion is one os.write() -- no per-chunk open(). None in heap/spill mode, and in
+        # readonly_cache mode, which reads the log and never appends to it.
+        self._log_fd: int | None = None
         # Fingerprint of the chunk_transform pipeline (only chunk_transforms are baked into
         # cached chunks; batch_transforms run post-cache). A run whose fingerprint differs
         # from the manifest's discards the cache (changed transforms -> stale). batch
         # transforms and the store identity are out of scope (the cache_dir path is the
         # dataset identity -- see the class docstring).
         self._pipeline_fp = ""
-        if persist:
+        if self._persistent:
             self._pipeline_fp = hashlib.sha256(
                 "\n".join(_transform_token(t) for t in self._chunk_transforms).encode()
             ).hexdigest()
@@ -441,8 +565,18 @@ class ChunkPool:
                     "(source only; closure/global changes may not invalidate). Install "
                     "`insitubatch[cache]` or set a `cache_key` attribute for a stronger guarantee."
                 )
-            self._load_log()
-            self._open_log()
+            try:
+                self._load_log()
+                if not readonly_cache:
+                    self._open_log()
+            except BaseException:
+                # A stale cache raises here, and the pool never becomes an object anyone can
+                # close -- so release the lock ourselves. `__del__` cannot: `close()` reads
+                # attributes this half-built pool does not have yet, and its own error
+                # suppression would swallow that, leaving the dir locked until the process
+                # exits. The user is expected to fix the configuration and construct again.
+                self._release_lock()
+                raise
         # Batch *output* buffers, distinct from the chunk slots below: gather lends one per
         # variable per batch and reclaims it once the consumer's view is unreferenced. It
         # carries its own lock, and needs it -- one ChunkPool is shared by every active
@@ -478,6 +612,172 @@ class ChunkPool:
         # unpin, which is what lets the scheduler prove an admission starvation is
         # terminal rather than merely slow (see Scheduler._admit).
         self._waiting: dict[tuple[str, int], int] = {}  # key -> blocked waiter count
+
+    # -- cross-process arbitration (#42) -------------------------------------
+
+    def _warn_environment(self) -> None:
+        """Warn once, at construction, about the configurations we cannot arbitrate.
+
+        Both messages have to say plainly that this is where two writers can still
+        corrupt each other -- it is exactly where the lock that would prevent it cannot
+        be taken. A denylist, so an unrecognized local filesystem stays quiet.
+        """
+        assert self._dir is not None
+        fstype = _filesystem_type(self._dir)
+        if fstype in _NETWORK_FILESYSTEMS:
+            logger.warning(
+                "cache_dir %s is on a %s filesystem. The cache is an mmap tier: it wants "
+                "local NVMe, and over a network filesystem it is both slow and "
+                "**unarbitrated** -- flock may be emulated per client, so two processes on "
+                "different hosts can each believe they hold the write lock and silently "
+                "corrupt each other's chunks. This is the one configuration where that is "
+                "still possible. Point cache_dir at local disk.",
+                self._dir,
+                fstype,
+            )
+        if fcntl is None:
+            logger.warning(
+                "no POSIX advisory locking on this platform (%s), so insitubatch cannot "
+                "arbitrate writers of cache_dir %s. Two processes sharing it will silently "
+                "corrupt each other's chunks -- give each its own cache_dir. This is the one "
+                "configuration where that is still possible.",
+                sys.platform,
+                self._dir,
+            )
+
+    def _lock(self) -> None:
+        """Take the cache dir's advisory lock, held for the pool's lifetime.
+
+        ``LOCK_EX`` to write, ``LOCK_SH`` for ``readonly_cache``: one writer at a time, any
+        number of concurrent readers, never both. **Non-blocking** -- contention is a
+        configuration fact the user has to resolve, not a queue to join, so it raises with
+        the diagnosis rather than parking a training job indefinitely.
+
+        The lock cannot go stale. ``flock`` is held by the kernel on behalf of the open
+        file description, so it is released when the process dies -- ``SIGKILL``, OOM and
+        spot preemption included. There is therefore no cleanup procedure, and deleting the
+        lockfile is actively harmful: it releases nothing and makes the next two processes
+        lock different inodes, which is the corruption this exists to prevent.
+        """
+        assert self._dir is not None
+        path = self._dir / _LOCK_NAME
+        if fcntl is None:  # pragma: no cover - Windows; warned about in _warn_environment
+            return
+        flags = (os.O_RDONLY if self._readonly else os.O_RDWR) | os.O_CREAT
+        fd = os.open(path, flags, 0o644)
+        op = (fcntl.LOCK_SH if self._readonly else fcntl.LOCK_EX) | fcntl.LOCK_NB
+        try:
+            fcntl.flock(fd, op)
+        except OSError as exc:
+            holder = _read_holder(fd)
+            os.close(fd)
+            raise RuntimeError(self._contention_message(path, holder)) from exc
+        self._lock_fd = fd
+        if not self._readonly:
+            # Who holds it, for the *next* process's error message. A hint only -- the
+            # flock is authoritative and this record can lie (it names the last writer,
+            # while the lock may currently be held by readers).
+            os.ftruncate(fd, 0)
+            os.write(
+                fd,
+                json.dumps(
+                    {
+                        "pid": os.getpid(),
+                        "host": socket.gethostname(),
+                        "since": time.strftime("%Y-%m-%d %H:%M:%S"),
+                    }
+                ).encode()
+                + b"\n",
+            )
+
+    def _contention_message(self, path: Path, holder: str) -> str:
+        """What to tell the user when the cache lock is already held.
+
+        Two different situations, so two different leads: a writer blocked by anyone, and
+        a ``readonly_cache`` opener blocked by a live writer. Both end with the same
+        diagnostic instructions, because both are answered by the same commands.
+        """
+        how = (
+            f"To see who holds it:  fuser -v {path}\n"
+            f"                      lsof {path}\n"
+            "\n"
+            "Do NOT delete the lockfile. The lock is held by the kernel, not by the file, so\n"
+            "deleting it releases nothing -- it only makes the next two processes lock "
+            "different\ninodes, which is the corruption this check exists to prevent. A hard "
+            "kill (SIGKILL,\nOOM, spot preemption) cannot leave a stale lock: the kernel "
+            "releases it when the\nprocess dies. If you see this message, that process is "
+            "alive."
+        )
+        if self._readonly:
+            return (
+                f"insitubatch: cache_dir '{self._dir}' is being written right now "
+                f"({holder}), so it\ncannot be opened with readonly_cache=True. That flag "
+                "asserts the cache is complete\nfor what this run reads, and a cache still "
+                "being warmed is not. Wait for the writing\nrun to finish, or point this run "
+                f"at a cache_dir of its own.\n\n{how}"
+            )
+        return (
+            f"insitubatch: cache_dir '{self._dir}' is already open for writing by another\n"
+            f"process ({holder}).\n"
+            "\n"
+            "Is that expected?\n"
+            "  - If you meant to run two jobs against one cache: only one may write. Start "
+            "the\n    others with readonly_cache=True, once this one has finished warming "
+            "it.\n"
+            "  - If you did not: two writers silently corrupt each other's chunks, which is "
+            "why\n    this is an error rather than a warning. Point them at separate "
+            f"cache_dirs.\n\n{how}"
+        )
+
+    def _release_lock(self) -> None:
+        """Drop the cache dir's lock, if we hold one. Idempotent.
+
+        Closing the fd is what releases the ``flock`` -- the kernel holds it against the
+        open file description. The lockfile itself **stays**: it is the inode every process
+        locks, and unlinking it is precisely what would let the next two lock different
+        inodes and corrupt each other.
+        """
+        if self._lock_fd is not None:
+            os.close(self._lock_fd)
+            self._lock_fd = None
+
+    def _sweep_tmp(self) -> None:
+        """Delete temp files a crashed writer left behind.
+
+        ``_alloc`` writes ``<name>.<pid>.insitu-tmp`` and renames it into place; a process
+        killed between the two leaves one. Sweeping is safe **only** under the exclusive
+        lock -- that is what proves no other writer has one in flight -- so a read-only
+        opener never sweeps, and neither does a platform where no lock could be taken.
+        """
+        assert self._dir is not None
+        if self._lock_fd is None or self._readonly:
+            return
+        for stale in self._dir.glob(f"*{_TMP_SUFFIX}"):
+            with contextlib.suppress(OSError):
+                stale.unlink()
+
+    def _readonly_miss(self, array: str, chunk_index: int) -> RuntimeError:
+        """The error a ``readonly_cache`` miss raises -- the contract, not a slow path.
+
+        Two causes worth separating: the entry is not in the cache at all (the usual one,
+        and a configuration mismatch with the run that warmed it), or it is there and could
+        not be made resident (budget).
+        """
+        if self._persisted.get((array, chunk_index)) is not None:
+            return RuntimeError(
+                f"readonly_cache: chunk {chunk_index} of {array!r} is in the cache at "
+                f"{self._dir} but could not be made resident. Either its .npy is unreadable "
+                "or no longer matches the current geometry (the debug log names which), or "
+                "the byte budget is too small to hold the working set and nothing resident "
+                "is evictable -- raise cache_budget_bytes."
+            )
+        return RuntimeError(
+            f"readonly_cache: chunk {chunk_index} of {array!r} is not in the cache at "
+            f"{self._dir}, and a read-only opener may not fetch it. readonly_cache=True "
+            "asserts this cache is complete for what the run reads; it is not. The usual "
+            "cause is that the run that warmed it used a different split, sample_range or "
+            "transform set. Warm this configuration once with persist=True, then re-run."
+        )
 
     # -- ownership ----------------------------------------------------------
 
@@ -611,6 +911,16 @@ class ChunkPool:
                 # later epoch refetches instead of re-raising a stale error forever.
                 self._pin(key, owner)  # the pin IS this owner's claim (see wait_ready)
                 self._cv.notify_all()  # a ready hit may now satisfy a waiter
+                return True
+            if self._readonly:
+                # A read-only opener never allocates: the cache is its whole supply. A miss
+                # is the `readonly_cache` contract turning out to be false, so say so --
+                # raising is what makes it a contract rather than a silent slow path.
+                if not self._revive(key):
+                    raise self._readonly_miss(array, chunk_index)
+                self.hits += 1  # revived from disk -> no fetch (as in pin_if_ready)
+                self._pin(key, owner)
+                self._cv.notify_all()
                 return True
             if not self._make_room(nbytes):
                 return False
@@ -911,10 +1221,29 @@ class ChunkPool:
     def _alloc(
         self, array: str, chunk_index: int, shape: tuple[int, ...], dtype: np.dtype
     ) -> np.ndarray:
+        """Back one slot: heap, or a fresh ``.npy`` under the cache dir.
+
+        The mmap tier **never truncates an existing file in place**. ``open_memmap(mode=
+        "w+")`` opens with ``O_TRUNC``, which zeroes the pages of every mapping already
+        held on that inode -- including another process's, reading a revived cache entry
+        and getting right-shape, right-dtype, wrong numbers (#42). So write a private temp
+        file and ``replace()`` the directory entry: POSIX keeps the old inode alive for
+        anyone holding it, so their mapping stays intact while new openers see the new
+        file. The rename is atomic within a directory, so nobody sees a half-written entry
+        either.
+        """
         if self._dir is None:
             return np.empty(shape, dtype=dtype)
         path = self._dir / f"{_safe(array)}__{chunk_index}.npy"
-        return np.lib.format.open_memmap(path, mode="w+", dtype=dtype, shape=shape)
+        tmp = self._dir / f"{path.name}.{os.getpid()}{_TMP_SUFFIX}"
+        backing = np.lib.format.open_memmap(tmp, mode="w+", dtype=dtype, shape=shape)
+        tmp.replace(path)
+        # The mapping *is* `path` now -- renaming does not disturb it -- but numpy recorded
+        # the name it was opened under. Correct it: `_record_completed` names the cache entry
+        # from here and `_free` unlinks through it, and both would otherwise chase a temp
+        # path that no longer exists.
+        cast("np.memmap", backing).filename = os.path.abspath(path)
+        return backing
 
     @contextlib.contextmanager
     def tile_write(
@@ -1280,37 +1609,54 @@ class ChunkPool:
             return  # heap backing -- nothing on disk to record
         fname = Path(fname).name
         self._persisted[key] = fname
-        if self._log is not None and key not in self._recorded:
+        if self._log_fd is not None and key not in self._recorded:
             array, chunk_index = key
             self._append_entry(array, chunk_index, fname)
             self._recorded.add(key)
 
     def _append_entry(self, array: str, chunk_index: int, fname: str) -> None:  # under the lock
-        """Append one completed-entry line to the open log and flush it to the page cache.
+        """Append one completed-entry line to the open log."""
+        self._write_line({"array": array, "chunk_index": chunk_index, "file": fname})
 
-        ``flush`` (not ``fsync``) makes the entry durable against *process death* -- the target
-        failure mode (spot preemption / OOM / SIGTERM); the kernel flushes the page cache. Power
-        loss (which would need ``fsync`` per chunk) is out of scope.
+    def _write_line(self, record: dict[str, object]) -> None:
+        """Append one JSON record as a **single** ``os.write`` on an ``O_APPEND`` fd.
+
+        POSIX makes an append of less than ``PIPE_BUF`` atomic -- the seek to the end and the
+        write are one operation -- and entries are ~100 bytes, so a line can never interleave
+        with another writer's. The lock already gives us a single writer; this makes the
+        *format* robust independently of it, which is what keeps a log written on an
+        unarbitrated platform readable.
+
+        No ``flush``/``fsync``: the write lands in the page cache directly, which is durable
+        against *process death* -- the target failure mode (spot preemption / OOM / SIGTERM).
+        Power loss (which would need ``fsync`` per chunk) is out of scope. A short write would
+        leave a torn line and cannot be retried (a retry would land after another writer's
+        line), so it raises.
         """
-        assert self._log is not None
-        self._log.write(json.dumps({"array": array, "chunk_index": chunk_index, "file": fname}))
-        self._log.write("\n")
-        self._log.flush()
+        assert self._log_fd is not None
+        data = (json.dumps(record) + "\n").encode()
+        written = os.write(self._log_fd, data)
+        if written != len(data):  # pragma: no cover - only reachable on a full disk
+            raise OSError(
+                f"persist: short write to the cache log ({written} of {len(data)} bytes) -- "
+                "the disk is probably full. The log now ends in a torn line, which the next "
+                "run drops; the entries before it are intact."
+            )
 
     def _open_log(self) -> None:
         """Open the append-only manifest for the pool's lifetime; write the header on a cold
         start (or after a stale-cache reset removed the file). A warm reopen appends after the
         existing entries -- the ``_recorded`` gate (populated by :meth:`_load_log`) keeps those
-        from being re-appended."""
+        from being re-appended. ``readonly_cache`` never gets here: it reads the log and
+        never opens it for writing."""
         assert self._dir is not None
         path = self._dir / self._MANIFEST_NAME
         fresh = not path.exists()
-        self._log = path.open("a")
+        self._log_fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
         if fresh:
-            header = {"format_version": self._MANIFEST_FORMAT, "pipeline_hash": self._pipeline_fp}
-            self._log.write(json.dumps(header))
-            self._log.write("\n")
-            self._log.flush()
+            self._write_line(
+                {"format_version": self._MANIFEST_FORMAT, "pipeline_hash": self._pipeline_fp}
+            )
 
     def _load_log(self) -> None:
         """Populate the persisted-entry registry from a prior run's append-only log, if any.
@@ -1394,14 +1740,15 @@ class ChunkPool:
         logger.info("persist: stale cache at %s (%s changed) reset; rebuilding.", self._dir, why)
 
     def close(self) -> None:
-        """Free every remaining slot and release the log handle. Persist keeps ready cache files
+        """Free every remaining slot; release the log handle and the cache lock. Persist keeps
+        ready cache files
         (each already recorded in the log at completion, so there is nothing to rewrite -- just
         flush + close the handle); heap/spill mmap files are unlinked. Idempotent."""
         with self._cv:
-            if self._log is not None:
-                self._log.flush()
-                self._log.close()
-                self._log = None
+            if self._log_fd is not None:
+                os.close(self._log_fd)
+                self._log_fd = None
+            self._release_lock()
             for k in list(self._slots):
                 slot = self._slots.pop(k)
                 self._free(slot, keep_file=self._persistent and slot.state is SlotState.READY)

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -110,6 +110,16 @@ class InSituDataset:
       per-sample random augmentation; runs after the cache, so it is **never cached**.
 
     Runnable side-by-side example: ``examples/transforms.py``.
+
+    **One writer per ``cache_dir``.** The cache directory (and ``persist=True`` on top of
+    it) is arbitrated across processes by an advisory lock held for the dataset's
+    lifetime: one writer at a time, and a second fails fast rather than silently
+    corrupting the first's chunks. Several jobs may read one warm cache at once with
+    ``readonly_cache=True``, which takes the lock shared, never writes, and **raises on a
+    miss** -- it asserts the cache is complete for what this run reads, rather than
+    quietly falling back to fetching. Put ``cache_dir`` on local NVMe: over a network
+    filesystem the lock may be emulated per client and we can only warn. See
+    ``docs/tuning.md``, "Sharing a cache_dir between processes".
     """
 
     def __init__(
@@ -127,6 +137,7 @@ class InSituDataset:
         cache_dir: str | None = None,
         cache_budget_bytes: int | None = None,
         persist: bool = False,
+        readonly_cache: bool = False,
         reset_stale_cache: bool = False,
         on_bad_chunk: str = "raise",
         chunk_transforms: Sequence[Callable[[DecodedChunk], DecodedChunk]] = (),
@@ -190,6 +201,7 @@ class InSituDataset:
         }
         self._epoch = 0
         self._persist = persist
+        self._readonly_cache = readonly_cache
         self._cache_dir = cache_dir
         self.resident_peak = 0  # peak resident outer chunks (observability)
         self.cache_hits = 0  # chunks served without a fetch this epoch (cross-epoch/run)
@@ -241,12 +253,16 @@ class InSituDataset:
         # the dir path is the dataset+pipeline identity (bury a version in it).
         if persist and cache_dir is None:
             raise ValueError("persist=True requires cache_dir to keep the cache files in")
+        # One writer per cache_dir, arbitrated by an advisory lock the pool holds for its
+        # lifetime; `readonly_cache=True` opens it shared, serves only what is already
+        # cached, and raises on a miss. See ChunkPool._lock and docs/tuning.md.
         self._pool = ChunkPool(
             self.geometries,
             chunk_transforms=self.chunk_transforms,
             backing_dir=cache_dir,
             budget_bytes=self.cache_budget_bytes,
             persist=persist,
+            readonly_cache=readonly_cache,
             reset_stale_cache=reset_stale_cache,
         )
 

--- a/src/insitubatch/summary.py
+++ b/src/insitubatch/summary.py
@@ -95,6 +95,7 @@ class ConfigReport(TypedDict):
     cache_budget_bytes: int
     cache_dir: str | None
     persist: bool
+    readonly_cache: bool
     chunk_transforms: tuple[str, ...]
     batch_transforms: tuple[str, ...]
     assembles: bool
@@ -351,6 +352,7 @@ def describe(ds: InSituDataset, *, iterations: int = 1) -> DatasetReport:
         cache_budget_bytes=ds.cache_budget_bytes,
         cache_dir=str(ds._cache_dir) if ds._cache_dir is not None else None,
         persist=ds._persist,
+        readonly_cache=ds._readonly_cache,
         chunk_transforms=tuple(_name(t) for t in ds.chunk_transforms),
         batch_transforms=tuple(_name(t) for t in ds.batch_transforms),
         assembles=assembles,
@@ -477,8 +479,11 @@ def print_summary(report: DatasetReport, file: TextIO | None = None) -> None:
     splits = "  ".join(f"{k} {n}" for k, n in cfg["split_chunks"].items())
     out.append(f"  splits (chunks)  {splits}")
     cache = cfg["cache_dir"] or "heap"
-    persist = ", persist" if cfg["persist"] else ""
-    out.append(f"  cache backing {cache}{persist}")
+    # read-only is worth a line of its own: it changes what the run *does* (serves only what
+    # is already cached, and raises on a miss rather than fetching), which is exactly what a
+    # "what will this cost" report exists to tell you before it costs it.
+    mode = ", read-only" if cfg["readonly_cache"] else (", persist" if cfg["persist"] else "")
+    out.append(f"  cache backing {cache}{mode}")
     if cfg["chunk_transforms"]:
         out.append(f"  chunk_transforms {', '.join(cfg['chunk_transforms'])} (slot assembles)")
     if cfg["batch_transforms"]:

--- a/tests/test_cache_concurrency.py
+++ b/tests/test_cache_concurrency.py
@@ -1,0 +1,402 @@
+"""Cross-process arbitration of a shared ``cache_dir`` (#42, part 1).
+
+Two processes pointed at one cache directory is the obvious thing to do -- and until
+this module's contract landed it silently corrupted data. The re-admission window is
+the sharp edge: a reader holds a chunk's mapping while a writer re-allocates the same
+chunk, and ``open_memmap(mode="w+")`` truncates the file *under the reader*. Right
+shape, right dtype, wrong numbers; throughput and smoke tests all pass.
+
+The tests here are deliberately multi-process. A same-process test cannot see the bug
+(one pool arbitrates itself with its own lock), and the fix -- atomic replace plus an
+advisory ``flock`` -- is only meaningful across process boundaries.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+from insitubatch import obstore_store, open_geometries
+from insitubatch.pool import _TMP_SUFFIX, ChunkPool
+
+# Maps the chunk's .npy, reports its hash, waits for a line on stdin, reports it again.
+# The second hash is read back through the SAME mapping -- which is the whole point.
+_READER = """
+import hashlib, sys
+import numpy as np
+a = np.lib.format.open_memmap(sys.argv[1], mode="r")
+print(hashlib.sha256(a.tobytes()).hexdigest(), flush=True)
+sys.stdin.readline()
+print(hashlib.sha256(a.tobytes()).hexdigest(), flush=True)
+"""
+
+
+# Opens a writing pool over the cache dir and parks, holding the exclusive lock, until it
+# is killed. A subprocess is the point: `flock` is per open file description, and only a
+# real process death can demonstrate that the kernel -- not us -- releases it.
+_HOLDER = """
+import sys
+from insitubatch import obstore_store, open_geometries
+from insitubatch.pool import ChunkPool
+cache, url = sys.argv[1], sys.argv[2]
+pool = ChunkPool(open_geometries(obstore_store(url), variables=["t2m"]),
+                 backing_dir=cache, persist=True)
+print("locked", flush=True)
+sys.stdin.readline()
+"""
+
+
+def _geoms(url, var="t2m"):
+    return open_geometries(obstore_store(url), variables=[var])
+
+
+def _fill(pool, geom, var, cid, src):
+    """Admit + deliver every stored tile of one outer chunk, then wait for READY."""
+    owner = pool.new_owner()
+    assert pool.try_admit(var, cid, owner)
+    spc = geom.sample_chunk_size
+    for coord in geom.inner_coords():
+        pool.deliver_tile(var, cid, coord, src[cid * spc : (cid + 1) * spc])
+    pool.wait_ready(var, cid, owner)
+    return owner
+
+
+def _warm(url, cache, srcs, var="t2m", cids=(0,)):
+    """Populate a persist cache over ``cache`` and close it, leaving the files behind."""
+    geoms = _geoms(url, var)
+    pool = ChunkPool(geoms, backing_dir=cache, persist=True)
+    for cid in cids:
+        _fill(pool, geoms[var], var, cid, srcs[var])
+    pool.close()
+    return geoms
+
+
+def _hash(path):
+    return hashlib.sha256(np.lib.format.open_memmap(path, mode="r").tobytes()).hexdigest()
+
+
+def test_readmission_does_not_corrupt_another_process_mapping(write_zarr, tmp_path):
+    """The bug: re-admitting a chunk another process has mapped must not truncate it.
+
+    POSIX keeps the old inode alive for anyone holding it, so replacing the directory
+    entry (write a temp file, ``rename``) is safe where ``open_memmap(mode="w+")`` --
+    which truncates in place -- is not. The reader here takes no lock at all: it is a
+    bare mapping, so this stays a test of the *file* mechanics rather than of the
+    arbitration layered on top.
+    """
+    url, srcs = write_zarr()
+    cache = tmp_path / "cache"
+    geoms = _warm(url, cache, srcs)
+    npy = cache / "t2m__0.npy"
+    expected = _hash(npy)
+
+    reader = subprocess.Popen(
+        [sys.executable, "-c", _READER, str(npy)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert reader.stdout.readline().strip() == expected, "reader mapped the wrong bytes"
+        # A miss on a chunk whose .npy is on disk is reachable: an evicted (demoted)
+        # entry whose revive is declined by a full budget, or -- until the lock landed --
+        # any second process with persist=False sharing the dir. try_admit IS that
+        # re-admission; going through it directly keeps the test on the mechanic.
+        pool = ChunkPool(geoms, backing_dir=cache, persist=True)
+        owner = pool.new_owner()
+        assert pool.try_admit("t2m", 0, owner)
+        reader.stdin.write("go\n")
+        reader.stdin.flush()
+        after = reader.stdout.readline().strip()
+        pool.close()
+    finally:
+        reader.stdin.close()
+        reader.wait(timeout=30)
+    assert after == expected, "re-admission truncated a mapping another process was holding"
+
+
+def test_second_writer_fails_fast_with_guidance(write_zarr, tmp_path):
+    """Two writers on one cache_dir is an error, not a warning -- and the error has to be
+    actionable: who holds it, what to do either way, and the two commands that answer
+    "who?". Silent corruption is what this replaces, so a vague message would waste it."""
+    url, srcs = write_zarr()
+    cache = tmp_path / "cache"
+    geoms = _geoms(url)
+    first = ChunkPool(geoms, backing_dir=cache, persist=True)
+    try:
+        with pytest.raises(RuntimeError) as exc:
+            ChunkPool(geoms, backing_dir=cache, persist=True)
+    finally:
+        first.close()
+    msg = str(exc.value)
+    assert "already open for writing" in msg
+    assert f"PID {os.getpid()}" in msg  # the holder, read back from the lockfile
+    assert "readonly_cache=True" in msg  # what to do if two jobs on one cache was intended
+    assert "separate cache_dirs" in msg  # ...and if it was not
+    assert "fuser" in msg and "lsof" in msg
+    assert "Do NOT delete the lockfile" in msg
+    # Released with the pool, so the next run gets it.
+    ChunkPool(geoms, backing_dir=cache, persist=True).close()
+
+
+def test_the_lock_keys_on_cache_dir_not_on_persist(write_zarr, tmp_path):
+    """A correction to #42 as filed: scoping the lock to persist mode leaves the hole open.
+
+    ``_alloc`` writes ``{array}__{cid}.npy`` whenever a backing dir is set, so two
+    processes sharing a spill dir with ``persist=False`` collide on identical filenames
+    just as surely as two persist runs do."""
+    url, _ = write_zarr()
+    cache = tmp_path / "spill"
+    geoms = _geoms(url)
+    first = ChunkPool(geoms, backing_dir=cache)  # persist=False: ephemeral spill
+    try:
+        with pytest.raises(RuntimeError, match="already open for writing"):
+            ChunkPool(geoms, backing_dir=cache)
+    finally:
+        first.close()
+
+
+def test_a_reader_and_a_writer_do_not_coexist(write_zarr, tmp_path):
+    """``readonly_cache`` takes the lock shared, so it cannot open a cache being warmed --
+    which is the honest answer: a cache still being written is not complete, and
+    completeness is the whole contract of the flag."""
+    url, srcs = write_zarr()
+    cache = tmp_path / "cache"
+    geoms = _warm(url, cache, srcs)
+    writer = ChunkPool(geoms, backing_dir=cache, persist=True)
+    try:
+        with pytest.raises(RuntimeError, match="being written right now"):
+            ChunkPool(geoms, backing_dir=cache, readonly_cache=True)
+    finally:
+        writer.close()
+
+
+def test_many_readers_coexist(write_zarr, tmp_path):
+    """The workload the single-writer rule is shaped around: one job warms a cache, several
+    score against it at once. Shared locks do not exclude each other."""
+    url, srcs = write_zarr()
+    cache = tmp_path / "cache"
+    geoms = _warm(url, cache, srcs)
+    readers = [ChunkPool(geoms, backing_dir=cache, readonly_cache=True) for _ in range(3)]
+    try:
+        for reader in readers:
+            assert reader.pin_if_ready("t2m", 0, reader.new_owner()), "a warm entry must revive"
+        # ...and a writer is still excluded while any of them is open.
+        with pytest.raises(RuntimeError, match="already open for writing"):
+            ChunkPool(geoms, backing_dir=cache, persist=True)
+    finally:
+        for reader in readers:
+            reader.close()
+    ChunkPool(geoms, backing_dir=cache, persist=True).close()  # ...and allowed once they go
+
+
+def test_readonly_miss_raises_and_names_the_chunk(write_zarr, tmp_path):
+    """A miss in read-only mode is the contract turning out to be false. Raising is what
+    makes ``readonly_cache`` mean "this cache is complete for what I am about to read"
+    rather than "quietly re-fetch whatever is missing"."""
+    url, srcs = write_zarr()
+    cache = tmp_path / "cache"
+    geoms = _warm(url, cache, srcs, cids=(0,))  # only chunk 0 is warm
+    reader = ChunkPool(geoms, backing_dir=cache, readonly_cache=True)
+    try:
+        owner = reader.new_owner()
+        assert reader.try_admit("t2m", 0, owner), "the warm chunk is served"
+        with pytest.raises(RuntimeError) as exc:
+            reader.try_admit("t2m", 1, owner)
+    finally:
+        reader.close()
+    msg = str(exc.value)
+    assert "chunk 1 of 't2m'" in msg  # names what was missing
+    assert str(cache) in msg
+    assert "split, sample_range or transform set" in msg  # ...and the usual cause
+
+
+def test_readonly_cache_never_writes(write_zarr, tmp_path):
+    """A read-only opener must leave the directory byte-identical: no new .npy, no log
+    entry, no header. Otherwise "read-only" is a name, not a property."""
+    url, srcs = write_zarr()
+    cache = tmp_path / "cache"
+    geoms = _warm(url, cache, srcs)
+    before = {f.name: f.stat().st_mtime_ns for f in cache.iterdir() if f.name != ".insitu.lock"}
+    log_before = (cache / "insitu_cache.jsonl").read_bytes()
+
+    reader = ChunkPool(geoms, backing_dir=cache, readonly_cache=True)
+    assert reader.pin_if_ready("t2m", 0, reader.new_owner())
+    reader.close()
+
+    after = {f.name: f.stat().st_mtime_ns for f in cache.iterdir() if f.name != ".insitu.lock"}
+    assert after == before, "readonly_cache modified the cache directory"
+    assert (cache / "insitu_cache.jsonl").read_bytes() == log_before
+
+
+def test_readonly_cache_rejects_reset_stale_cache(write_zarr, tmp_path):
+    """The two flags contradict each other: a read-only opener may not delete files another
+    process may be reading. Rejected at construction rather than silently ignored."""
+    url, srcs = write_zarr()
+    cache = tmp_path / "cache"
+    geoms = _warm(url, cache, srcs)
+    with pytest.raises(ValueError, match="contradict"):
+        ChunkPool(geoms, backing_dir=cache, readonly_cache=True, reset_stale_cache=True)
+
+
+def test_readonly_cache_requires_a_cache_dir(write_zarr, tmp_path):
+    """...and requires the directory to already exist: a read-only opener reads a cache
+    another run warmed, it never creates one."""
+    url, _ = write_zarr()
+    geoms = _geoms(url)
+    with pytest.raises(ValueError, match="requires cache_dir"):
+        ChunkPool(geoms, readonly_cache=True)
+    with pytest.raises(ValueError, match="does not exist"):
+        ChunkPool(geoms, backing_dir=tmp_path / "never-warmed", readonly_cache=True)
+
+
+def test_stale_tmp_files_are_swept(write_zarr, tmp_path):
+    """A writer killed between `open_memmap` and `rename` leaves a temp file. The next
+    writer to hold the exclusive lock sweeps them -- which is the only moment it is safe,
+    since holding LOCK_EX is what proves no other writer has one in flight."""
+    url, srcs = write_zarr()
+    cache = tmp_path / "cache"
+    geoms = _warm(url, cache, srcs)
+    litter = cache / f"t2m__3.npy.99999{_TMP_SUFFIX}"
+    litter.write_bytes(b"partial")
+    keep = cache / "t2m__0.npy"
+
+    pool = ChunkPool(geoms, backing_dir=cache, persist=True)
+    pool.close()
+    assert not litter.exists(), "a crashed writer's temp file must be swept"
+    assert keep.exists(), "the sweep must not touch real cache entries"
+
+    # A read-only opener never sweeps: it does not hold the exclusive lock, so it cannot
+    # know whether a live writer is mid-rename.
+    litter.write_bytes(b"partial")
+    reader = ChunkPool(geoms, backing_dir=cache, readonly_cache=True)
+    reader.close()
+    assert litter.exists(), "readonly_cache must not delete anything"
+
+
+def test_a_sigkilled_holders_lock_is_immediately_reacquirable(write_zarr, tmp_path):
+    """There is no such thing as a stale ``flock``: the kernel releases it when the process
+    dies, ``SIGKILL`` included. Pinned into CI rather than left as something verified once
+    by hand, because the docs promise it and it is the first thing a user will doubt."""
+    url, srcs = write_zarr()
+    cache = tmp_path / "cache"
+    geoms = _warm(url, cache, srcs)
+    holder = subprocess.Popen(
+        [sys.executable, "-c", _HOLDER, str(cache), url],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert holder.stdout.readline().strip() == "locked"
+        with pytest.raises(RuntimeError, match="already open for writing"):
+            ChunkPool(geoms, backing_dir=cache, persist=True)
+        holder.kill()
+        holder.wait(timeout=30)
+    finally:
+        holder.stdin.close()
+    lockfile = cache / ".insitu.lock"
+    assert lockfile.exists(), "the lockfile outlives the holder -- it is the inode, not the lock"
+    assert str(holder.pid) in lockfile.read_text(), "...still naming the dead PID"
+    ChunkPool(geoms, backing_dir=cache, persist=True).close()  # ...and yet immediately free
+
+
+def test_end_to_end_readonly_cache_serves_a_warm_cache(write_zarr, tmp_path):
+    """The workload the whole feature is for: one run warms a cache, a second reads it
+    without writing and gets byte-identical batches -- fetching nothing."""
+    from insitubatch import split_by_chunk
+    from insitubatch.source import InSituDataset
+
+    url, _ = write_zarr(n=80, spc=8)
+    geom = open_geometries(obstore_store(url))["t2m"]
+    manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
+    cache = str(tmp_path / "cache")
+
+    def make(**kw):
+        return InSituDataset(
+            obstore_store(url),
+            manifest,
+            batch_size=4,
+            block_chunks=4,
+            shuffle=False,
+            cache_dir=cache,
+            cache_budget_bytes=10_000_000,
+            **kw,
+        )
+
+    warm = make(persist=True)
+    try:
+        warm.set_epoch(0)
+        expected = np.concatenate([b.arrays["t2m"] for b in warm.train])
+    finally:
+        warm.close()
+
+    reader = make(readonly_cache=True)
+    try:
+        reader.set_epoch(0)
+        got = np.concatenate([b.arrays["t2m"] for b in reader.train])
+    finally:
+        reader.close()
+    np.testing.assert_array_equal(got, expected)
+    assert reader.cache_misses == 0, "a read-only run must fetch nothing"
+    assert reader.cache_hits > 0
+
+
+def test_a_network_filesystem_warns_that_it_cannot_be_arbitrated(write_zarr, tmp_path, caplog):
+    """NFS is where the lock may be emulated per client, so two hosts can both hold it.
+    We cannot fix that, so we must say it -- this is the one configuration where two
+    writers still corrupt each other."""
+    url, _ = write_zarr()
+    monkey = pytest.MonkeyPatch()
+    monkey.setattr("insitubatch.pool._filesystem_type", lambda _p: "nfs4")
+    try:
+        with caplog.at_level("WARNING", logger="insitubatch.pool"):
+            ChunkPool(_geoms(url), backing_dir=tmp_path / "cache").close()
+    finally:
+        monkey.undo()
+    msg = caplog.text
+    assert "nfs4" in msg and "unarbitrated" in msg
+    assert "silently corrupt" in msg
+
+
+def test_filesystem_type_reads_the_real_mount_table(tmp_path):
+    """Longest-prefix match on /proc/self/mountinfo, on the resolved path. ``/proc`` is the
+    one mount every Linux box has that differs from its parent, so it is the check that
+    proves the match is by mount point rather than by luck."""
+    if not os.path.exists("/proc/self/mountinfo"):
+        pytest.skip("no /proc: not Linux")  # macOS/Windows -> None, by design
+    from insitubatch.pool import _filesystem_type
+
+    assert _filesystem_type("/proc") == "proc"
+    assert _filesystem_type("/proc/self") == "proc"
+    assert _filesystem_type(tmp_path) not in (None, "proc")
+
+
+def test_log_entries_append_regardless_of_file_position(write_zarr, tmp_path):
+    """Manifest entries go out as one ``os.write`` on an ``O_APPEND`` fd, so the seek to the
+    end and the write are a single kernel operation and a sub-PIPE_BUF entry can never
+    interleave with another writer's. Seeking the fd to the start proves it: with an
+    ordinary handle the next entry would overwrite the header.
+
+    The lock already gives us a single writer. This keeps the *format* robust independently
+    of it -- which is what makes a log written on an unarbitrated platform readable."""
+    url, srcs = write_zarr()
+    cache = tmp_path / "cache"
+    geoms = _geoms(url)
+    pool = ChunkPool(geoms, backing_dir=cache, persist=True)
+    try:
+        _fill(pool, geoms["t2m"], "t2m", 0, srcs["t2m"])
+        os.lseek(pool._log_fd, 0, os.SEEK_SET)  # a writer that ignored O_APPEND would clobber
+        _fill(pool, geoms["t2m"], "t2m", 1, srcs["t2m"])
+    finally:
+        pool.close()
+    lines = (cache / "insitu_cache.jsonl").read_text().splitlines()
+    assert len(lines) == 3, "header + one entry per completed chunk, none overwritten"
+    assert "format_version" in lines[0]
+    assert [json.loads(x)["chunk_index"] for x in lines[1:]] == [0, 1]

--- a/tests/test_cache_concurrency.py
+++ b/tests/test_cache_concurrency.py
@@ -506,3 +506,38 @@ def test_deleting_a_cached_file_does_not_disturb_a_held_mapping(write_zarr, tmp_
         reader.stdin.close()
         reader.wait(timeout=30)
     assert after == expected, "unlinking the file corrupted a mapping already held on it"
+
+
+def test_a_slot_file_is_named_by_where_it_landed_not_where_it_was_written(write_zarr, tmp_path):
+    """The rename leaves the two consumers of a slot's path with a name that no longer
+    exists unless it is corrected.
+
+    ``_alloc`` opens the mapping on ``<name>.<pid>.insitu-tmp`` and renames it to
+    ``<name>``. ``_record_completed`` names the manifest entry from that path and ``_free``
+    unlinks through it, so if the temp name survived, persist would log an entry that cannot
+    be reopened and spill would leak every file it was supposed to remove. Both failures are
+    silent -- a leaked spill file is just disk, and a bad log entry reads as a cold cache --
+    which is why this is asserted directly rather than left to the two tests that would
+    happen to catch it."""
+    url, srcs = write_zarr()
+    cache = tmp_path / "cache"
+    geoms = _geoms(url)
+
+    # persist: the recorded entry must be the bare landed name, and reopenable.
+    pool = ChunkPool(geoms, backing_dir=cache, persist=True)
+    _fill(pool, geoms["t2m"], "t2m", 0, srcs["t2m"])
+    assert pool._persisted[("t2m", 0)] == "t2m__0.npy"
+    assert not list(cache.glob(f"*{_TMP_SUFFIX}")), "the temp name must not survive the rename"
+    logged = json.loads((cache / "insitu_cache.jsonl").read_text().splitlines()[1])["file"]
+    assert logged == "t2m__0.npy"
+    np.lib.format.open_memmap(cache / logged, mode="r")  # the log entry actually opens
+    pool.close()
+    assert (cache / "t2m__0.npy").exists(), "persist must keep the landed file"
+
+    # spill: _free unlinks through the same path, so the landed file must go.
+    spill = tmp_path / "spill"
+    pool = ChunkPool(geoms, backing_dir=spill)
+    _fill(pool, geoms["t2m"], "t2m", 0, srcs["t2m"])
+    assert (spill / "t2m__0.npy").exists()
+    pool.close()
+    assert not list(spill.glob("*.npy")), "spill leaked the file it meant to unlink"

--- a/tests/test_cache_concurrency.py
+++ b/tests/test_cache_concurrency.py
@@ -1,14 +1,14 @@
 """Cross-process arbitration of a shared ``cache_dir`` (#42, part 1).
 
-Two processes pointed at one cache directory is the obvious thing to do -- and until
-this module's contract landed it silently corrupted data. The re-admission window is
-the sharp edge: a reader holds a chunk's mapping while a writer re-allocates the same
-chunk, and ``open_memmap(mode="w+")`` truncates the file *under the reader*. Right
-shape, right dtype, wrong numbers; throughput and smoke tests all pass.
+Two processes pointed at one cache directory is the obvious thing to do, and unarbitrated
+it corrupts data silently. The re-admission window is the sharp edge: a reader holds a
+chunk's mapping while a writer re-allocates the same chunk, and ``open_memmap(mode="w+")``
+truncates the file *under the reader*. Right shape, right dtype, wrong numbers; throughput
+and smoke tests all pass.
 
-The tests here are deliberately multi-process. A same-process test cannot see the bug
-(one pool arbitrates itself with its own lock), and the fix -- atomic replace plus an
-advisory ``flock`` -- is only meaningful across process boundaries.
+The tests here are deliberately multi-process. A same-process pool arbitrates itself with
+its own lock, so nothing below is observable within one, and neither half of the
+contract -- atomic replace, and an advisory ``flock`` -- means anything until there are two.
 """
 
 from __future__ import annotations
@@ -96,7 +96,7 @@ def _hash(path):
 
 
 def test_readmission_does_not_corrupt_another_process_mapping(write_zarr, tmp_path):
-    """The bug: re-admitting a chunk another process has mapped must not truncate it.
+    """Re-admitting a chunk another process has mapped must not truncate it.
 
     POSIX keeps the old inode alive for anyone holding it, so replacing the directory
     entry (write a temp file, ``rename``) is safe where ``open_memmap(mode="w+")`` --
@@ -118,10 +118,10 @@ def test_readmission_does_not_corrupt_another_process_mapping(write_zarr, tmp_pa
     )
     try:
         assert reader.stdout.readline().strip() == expected, "reader mapped the wrong bytes"
-        # A miss on a chunk whose .npy is on disk is reachable: an evicted (demoted)
-        # entry whose revive is declined by a full budget, or -- until the lock landed --
-        # any second process with persist=False sharing the dir. try_admit IS that
-        # re-admission; going through it directly keeps the test on the mechanic.
+        # A miss on a chunk whose .npy is on disk is reachable: an evicted (demoted) entry
+        # whose revive a full budget declines, or -- where no lock can be taken -- any second
+        # process with persist=False sharing the dir. try_admit IS that re-admission; going
+        # through it directly keeps the test on the mechanic.
         pool = ChunkPool(geoms, backing_dir=cache, persist=True)
         owner = pool.new_owner()
         assert pool.try_admit("t2m", 0, owner)
@@ -138,7 +138,8 @@ def test_readmission_does_not_corrupt_another_process_mapping(write_zarr, tmp_pa
 def test_second_writer_fails_fast_with_guidance(write_zarr, tmp_path):
     """Two writers on one cache_dir is an error, not a warning -- and the error has to be
     actionable: who holds it, what to do either way, and the two commands that answer
-    "who?". Silent corruption is what this replaces, so a vague message would waste it."""
+    "who?". The alternative outcome is silent corruption, so a vague message wastes the
+    one chance to say so."""
     url, srcs = write_zarr()
     cache = tmp_path / "cache"
     geoms = _geoms(url)

--- a/tests/test_cache_concurrency.py
+++ b/tests/test_cache_concurrency.py
@@ -52,6 +52,20 @@ sys.stdin.readline()
 """
 
 
+# Opens a *read-only* pool and parks, holding the shared lock, until it is killed.
+_SHARED_HOLDER = """
+import sys
+from insitubatch import obstore_store, open_geometries
+from insitubatch.pool import ChunkPool
+cache, url = sys.argv[1], sys.argv[2]
+pool = ChunkPool(open_geometries(obstore_store(url), variables=["t2m"]),
+                 backing_dir=cache, readonly_cache=True)
+assert pool.pin_if_ready("t2m", 0, pool.new_owner())
+print("reading", flush=True)
+sys.stdin.readline()
+"""
+
+
 def _geoms(url, var="t2m"):
     return open_geometries(obstore_store(url), variables=[var])
 
@@ -400,3 +414,95 @@ def test_log_entries_append_regardless_of_file_position(write_zarr, tmp_path):
     assert len(lines) == 3, "header + one entry per completed chunk, none overwritten"
     assert "format_version" in lines[0]
     assert [json.loads(x)["chunk_index"] for x in lines[1:]] == [0, 1]
+
+
+def test_the_lock_outlives_every_mapping_the_pool_holds(write_zarr, tmp_path, monkeypatch):
+    """The lock must be released *last*, after the final mmap is closed.
+
+    Otherwise ``close()`` opens a window where this process still has cache files mapped
+    while another process is already free to take the write lock and replace them. Atomic
+    replace means that window cannot corrupt data -- POSIX keeps our inode alive -- but the
+    invariant the arbitration rests on is "hold the lock for as long as you hold a mapping",
+    and a fix that leans on the other layer to cover it is a fix that stops working the day
+    the other layer changes."""
+    url, srcs = write_zarr()
+    cache = tmp_path / "cache"
+    geoms = _warm(url, cache, srcs)
+    pool = ChunkPool(geoms, backing_dir=cache, persist=True)
+    assert pool.pin_if_ready("t2m", 0, pool.new_owner()), "need a live mapping to close"
+
+    held: list[bool] = []
+    real_free = ChunkPool._free
+    monkeypatch.setattr(
+        ChunkPool,
+        "_free",
+        lambda self, slot, *, keep_file: (
+            held.append(self._lock_fd is not None),
+            real_free(self, slot, keep_file=keep_file),
+        )[1],
+    )
+    pool.close()
+    assert held, "the pool freed no mapping -- the test proves nothing"
+    assert all(held), "close() released the cache lock while mappings were still open"
+
+
+def test_a_writer_cannot_start_while_another_process_is_reading(write_zarr, tmp_path):
+    """The question the single-writer rule has to answer: what happens to active readers
+    when a writer starts overwriting? Nothing -- because the writer never starts.
+
+    A reader holds ``LOCK_SH``, which excludes ``LOCK_EX``, so the writer is refused at
+    construction, before it can allocate, evict, or reset anything. Cross-process on
+    purpose: the in-process case (``test_a_reader_and_a_writer_do_not_coexist``) proves the
+    same thing, but a real reader in another process is the case people actually run."""
+    url, srcs = write_zarr()
+    cache = tmp_path / "cache"
+    geoms = _warm(url, cache, srcs)
+    reader = subprocess.Popen(
+        [sys.executable, "-c", _SHARED_HOLDER, str(cache), url],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert reader.stdout.readline().strip() == "reading"
+        with pytest.raises(RuntimeError, match="already open for writing"):
+            ChunkPool(geoms, backing_dir=cache, persist=True)
+        # A second reader is still fine -- readers do not exclude each other.
+        ChunkPool(geoms, backing_dir=cache, readonly_cache=True).close()
+    finally:
+        reader.stdin.close()
+        reader.wait(timeout=30)
+    ChunkPool(geoms, backing_dir=cache, persist=True).close()  # free once the reader exits
+
+
+def test_deleting_a_cached_file_does_not_disturb_a_held_mapping(write_zarr, tmp_path):
+    """Invalidation is deletion (``reset_stale_cache``), and deletion is safe for a reader
+    that already holds the mapping: POSIX keeps the inode alive until the last reference
+    goes. So even if the lock were bypassed -- a network filesystem, a platform without
+    advisory locking, a user with ``rm`` -- an active reader keeps reading real data. What
+    it can lose is a *future* open, which is a miss, never wrong numbers.
+
+    This is the second layer, tested on its own so we know it is load-bearing rather than
+    merely implied by the lock."""
+    url, srcs = write_zarr()
+    cache = tmp_path / "cache"
+    _warm(url, cache, srcs)
+    npy = cache / "t2m__0.npy"
+    expected = _hash(npy)
+
+    reader = subprocess.Popen(
+        [sys.executable, "-c", _READER, str(npy)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert reader.stdout.readline().strip() == expected
+        npy.unlink()  # what a stale-cache reset does to every entry it listed
+        reader.stdin.write("go\n")
+        reader.stdin.flush()
+        after = reader.stdout.readline().strip()
+    finally:
+        reader.stdin.close()
+        reader.wait(timeout=30)
+    assert after == expected, "unlinking the file corrupted a mapping already held on it"

--- a/tests/test_chunked_slots.py
+++ b/tests/test_chunked_slots.py
@@ -226,6 +226,7 @@ def test_persist_round_trips_the_data(tmp_path):
 
     cold = _fill(url, geoms, backing_dir=cache, persist=True)
     np.testing.assert_array_equal(read(cold), src)
+    cold.close()  # run 1 ends here: one writer at a time holds the cache dir's lock
 
     warm = ChunkPool(geoms, backing_dir=cache, persist=True)
     owner = warm.new_owner()
@@ -246,7 +247,7 @@ def test_a_version_2_cache_is_rejected_not_misread(tmp_path):
     url, _ = _store(tmp_path, (2, 8, 8), (1, 4, 4), name="p5.zarr")
     geoms = open_geometries(obstore_store(url))
     cache = tmp_path / "c5"
-    _fill(url, geoms, backing_dir=cache, persist=True)
+    _fill(url, geoms, backing_dir=cache, persist=True).close()  # run 1 ends; lock released
 
     log = next(cache.glob("*.log"), None) or next(cache.glob("*.jsonl"), None)
     assert log is not None, f"no cache log found in {sorted(cache.iterdir())}"

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -15,6 +15,7 @@ import asyncio
 import itertools
 import json
 import logging
+import os
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 
@@ -499,6 +500,18 @@ def test_pool_persist_requires_cache_dir(tiled_store):
         ChunkPool(geoms, persist=True)
 
 
+def _die(pool):
+    """Simulate the process being *killed* (spot preempt / OOM / SIGKILL).
+
+    The kernel closes its fds -- releasing the cache dir's ``flock``, which is held on
+    behalf of the open file description and so can never go stale -- while nothing in
+    ``close()`` runs: no orderly teardown, no manifest rewrite. What survives on disk is
+    exactly what was appended as each chunk completed, which is the contract under test.
+    """
+    os.close(pool._lock_fd)
+    pool._lock_fd = None
+
+
 def _fill_chunk(pool, var, cid, geom, tiles, owner):
     pool.try_admit(var, cid, owner)
     for inner in geom.inner_coords():
@@ -560,6 +573,7 @@ def test_pool_persist_crash_recovery_without_close(tiled_store, tmp_path):
         _fill_chunk(pool, "single_inner", cid, geom, tiles, owner)
     log = (backing / "insitu_cache.jsonl").read_text().splitlines()
     assert len(log) == geom.n_chunks + 1  # header + one entry per completed chunk
+    _die(pool)
 
     # Run 2: same dir, fresh pool -> every chunk a ready hit despite the missing close().
     pool2 = ChunkPool(geoms, backing_dir=backing, persist=True)
@@ -590,7 +604,7 @@ def test_pool_persist_partial_iteration_recovers_completed_subset(tiled_store, t
     owner = pool.new_owner()
     # only chunk 0 completes before the "crash"
     _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)
-    # no close()
+    _die(pool)  # no close()
 
     pool2 = ChunkPool(geoms, backing_dir=backing, persist=True)
     owner = pool2.new_owner()
@@ -650,7 +664,7 @@ def test_pool_close_is_idempotent(tiled_store, tmp_path):
     owner = pool.new_owner()
     _fill_chunk(pool, "single_inner", 0, geom, tiles, owner)
     pool.close()
-    assert pool._log is None  # handle released
+    assert pool._log_fd is None  # log handle released
     pool.close()  # idempotent -- no double-close error on the file handle or slots
 
 


### PR DESCRIPTION
## Summary

Part 1 of #42 — the arbitration half. It does **not** touch the manifest, so it fixes the
silent corruption without invalidating anybody's cache. Part 2 (per-variable cache identity)
still needs the format bump and is unchanged; the issue stays open for it.

Two processes pointed at one `cache_dir` — the obvious thing to do, and what the
supply-chain audit on [NVIDIA/earth2studio#962](https://github.com/NVIDIA/earth2studio/pull/962)
found `InSituForecastFeed` inviting — could corrupt each other with nothing to show for it.
The window is re-admission after eviction: B revives a cached chunk and holds its mapping,
A misses the same chunk and re-admits it, and `open_memmap(mode="w+")` truncates the file
*under B*, which then reads zero pages as data. Right shape, right dtype, wrong numbers.

**The fix, in two independent layers.**

1. **`_alloc` replaces instead of truncating.** A slot file is written under a temp name and
   `rename`d into place; POSIX keeps the old inode alive for anyone holding it, so a reader's
   mapping stays intact. This closes the corruption window *on its own*, with no locking
   involved. A writer killed between the two leaves a temp file, swept by the next writer to
   hold the exclusive lock (the only moment it is safe).
2. **An advisory `flock` on the cache dir**, held for the pool's lifetime. Exclusive to
   write, so a second writer fails fast with a message naming the holder, what to do in
   either case, and the two commands that answer "who?". Non-blocking on purpose: contention
   is a configuration fact to resolve, not a queue to join.

**The lock keys on `cache_dir` being set, not on `persist` — a correction to the issue as
filed.** `_alloc` writes `{array}__{cid}.npy` whenever a backing dir is set, so two processes
sharing a spill dir with `persist=False` collide on identical filenames just as surely;
scoping the lock to persist mode would have left that hole open. Test:
`test_the_lock_keys_on_cache_dir_not_on_persist`.

**New `readonly_cache=True`** (`InSituDataset` and `ChunkPool`) is the workload this is
shaped around — one job warms a cache, several score against it. Shared lock, so many
coexist and none coexists with a writer; writes nothing; and **a miss raises**, naming the
array and chunk. That is what makes it a contract (*this cache is complete for what I am
about to read*) rather than a slow path that silently re-fetches whatever the warming run's
split or transforms left out. `reset_stale_cache` is rejected in this mode.

Also: manifest entries now go out as a single `os.write` on an `O_APPEND` fd (sub-`PIPE_BUF`
appends are atomic under POSIX), so the *format* is robust independently of the lock —
which is what keeps a log written on an unarbitrated platform readable.

**What is still unarbitrated, said plainly where the user meets it.** A network `cache_dir`
(`flock` may be emulated per client, so two hosts can each believe they hold it) and a
platform with no POSIX locking. Both warn at construction saying that this is the one
configuration where two writers can still corrupt each other. Detection is not a fix. That
forced the project's first **platform-support statement** (README, contributing,
classifiers): Linux supported and the only thing CI proves; macOS expected to work but
untested; Windows untested and unarbitrated — *untested*, not *unsupported*.

Two things the docs now have to say, because they are the first things anyone will get
wrong: there is **no such thing as a stale `flock`** (the kernel releases it on process
death, `SIGKILL` and spot preemption included), so there is no cleanup procedure; and
**deleting the lockfile is actively harmful** — it releases nothing and makes the next two
processes lock *different inodes*, reintroducing exactly the corruption the check prevents.

### Two deviations from the agreed plan, both deliberate

- **`bench/run.py` did not get `--readonly-cache`.** Its `--cache-dir` is a per-config
  scratch *root*, not a shared cache, and nothing in the bench sets `persist=True` — so the
  flag could only ever error. Making it usable means adding persist to `Cfg`, which lands a
  new column in the JSONL results schema for a knob no benchmark measures. Benchmarking the
  cross-run cache is its own piece of work. The other three CLIs got `--persist` **and**
  `--readonly-cache`: `--readonly-cache` alone would have been equally dead there, since no
  example could warm a cache for it to read.
- **`examples/advection/data.py` was left alone.** It has a `--cache-dir` too, but it was not
  in the agreed list, and the arbitration protects it regardless — the lock is on the
  directory, not on a flag.

## For reviewers

Worth a second look:

- **`_alloc`'s `filename` fix-up.** After `tmp.replace(path)` the memmap still records the
  name it was opened under, so `_alloc` corrects `backing.filename`. `_record_completed`
  names the cache entry through it and `_free` unlinks through it; both would otherwise chase
  a temp path that no longer exists. `test_pool_spill_unlinks_without_persist` covers the
  second.
- **Releasing the lock when the constructor raises.** A stale cache raises inside
  `__init__`, after the lock is taken, and `__del__` cannot clean that up — `close()` reads
  attributes a half-built pool does not have, and its own suppression would swallow the
  error, leaving the directory locked until the process exits. Handled explicitly.
- **The two in-process "crash" simulations** in `test_pool.py` now call a `_die(pool)` helper
  that closes the lock fd without running `close()`. That is what process death actually
  does (the kernel drops the fds; nothing in `close()` runs), and the tests' contract — only
  what was appended at completion survives — is unchanged.
- `readonly_cache` deliberately does **not** require `persist=True`: it implies the same
  cross-run identity internally, so `persist=True, readonly_cache=True` and `readonly_cache=True`
  alone behave identically, and forgetting the pair cannot produce a confusing all-misses run.

Confident in: the failure mode itself (reproduced by a subprocess test that fails on `main`),
and that nothing changes for a single-process run.

### Active readers while a writer invalidates the cache

Asked in review, and worth stating as a contract rather than leaving to inference.

**It cannot happen on the arbitrated path.** Invalidation — `reset_stale_cache` deleting
every entry, or a run re-admitting chunks it evicted — is work a *writer* does, and `LOCK_SH`
excludes `LOCK_EX`, so a writer cannot open the directory while any reader holds it. The
exclusion lands at construction, before the writer can allocate, evict or delete anything.
Now tested cross-process in both directions
(`test_a_writer_cannot_start_while_another_process_is_reading`), not just in-process.

**And the layer underneath does not depend on that** — which is what matters on a network
`cache_dir` or a platform without advisory locking. A reader holding a chunk's mapping keeps
reading real data whether the file is *replaced* (new content goes to a new inode) or
*deleted* (POSIX keeps the inode alive until the last reference goes). So the worst a
bypassed lock can do to an active reader is cost it a **future** open — a miss, which
`readonly_cache` turns into a loud error — never wrong numbers in a batch that looks fine.
Pinned by `test_deleting_a_cached_file_does_not_disturb_a_held_mapping`.

**Checking that turned up a real defect in this PR, now fixed** (`732acc9`): `close()`
released the lock *before* freeing the slots, leaving a window where another process could
take the write lock while this one still had cache files mapped. Atomic replace meant the
window could not corrupt data, but the invariant the arbitration rests on is "hold the lock
for as long as you hold a mapping" — and a fix that leans on the other layer to cover it is
one that stops working the day the other layer changes. The lock is now released last, and
`test_the_lock_outlives_every_mapping_the_pool_holds` fails on the previous ordering.

### Verified by running the CLIs, not just `--help`

- **`examples/wb2_dataloader.py`** — `--persist` warmed 6 chunks; `--readonly-cache` over it
  reported `chunks 6/6 hit (100%)` with `inflight peak 0/32`, i.e. it fetched nothing. Against
  a deliberately incomplete cache (entries removed from the log and disk) it raised through
  the prefetch producer onto the main thread with the intended message: *"chunk 5 of 't2m' is
  not in the cache … The usual cause is that the run that warmed it used a different split,
  sample_range or transform set."*
- **Real two-process contention, through the CLI.** Writer A held the cache for 12 s
  (`--train-step-ms 4000`); writer B on the same `--cache-dir` failed at construction with the
  contention error naming A's live PID and host. The two commands that error prints were then
  run against that lockfile and both named the same PID — `fuser -v` → `dstuebe 54294 F....
  python3`, `lsof` → `10uW` (write lock held). After A exited, a `--readonly-cache` run over
  the same directory succeeded immediately: no stale lock, no cleanup step.
- **`examples/fit_scaler.py`** — `--persist` then `--readonly-cache`; both complete, the
  read-only pass serving every chunk.
- **`bench/run.py`** (unchanged, but `cache=resident` puts a `cache_dir` under the new lock) —
  a local sweep runs clean, including `--repeats 2`, since each repeat already gets its own
  scratch subdirectory.
- **`examples/advection/train_torch.py`** (unchanged; also takes `--cache-dir`) — full run
  green, and the model-free check passes: *persistence RMSE 0.884*, which is the one signal
  that would catch a cache returning different bytes.
- **`examples/wb2_arraylake.py` could not be run here** — `arraylake` is not installed in this
  environment and the local config carries no token. Argparse accepts both new flags (it gets
  as far as the `arraylake` import before failing), and `main()`'s `run(...)` call was bound
  against the real signature to catch a kwarg-name typo that mypy cannot see through an
  untyped argparse `Namespace`. **It deserves a run by someone with credentials.**

One incidental, unrelated finding: `train_torch --n-steps 24` fails with `ValueError: need at
least one array to concatenate` (too few chunks leaves a split empty). It reproduces *without*
`--cache-dir`, so it is pre-existing and untouched here.

**One small behavior change worth knowing:** a spill (`persist=False`) `cache_dir` used to be
left empty on close. It now retains the `.insitu.lock` file — deliberately, since that inode
*is* the lock, and removing it is what the docs tell users never to do.

## Author attestation

- [x] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

*(Left unchecked deliberately — that box is the human author's to tick.)*

## Checklist

- [x] Tests added or updated — `tests/test_cache_concurrency.py` (18 tests). The bug test came
      first and is a real subprocess: a child maps a chunk, the parent re-admits it, and the
      child must still read real data. It fails on `main`
      (`assert '38723a2e…' == '64cddc0c…'`). Also covered: second writer raises with the
      guidance, reader+writer excluded, many readers coexist, a readonly miss raises naming the
      chunk, readonly writes nothing, readonly rejects `reset_stale_cache`, `.tmp` litter swept
      (and *not* swept by a reader), `O_APPEND` entries survive a seek to 0, a `SIGKILL`ed
      holder's lock is immediately re-acquirable, and the end-to-end warm-then-read flow through
      `InSituDataset`.
- [x] `uv run ruff check src tests bench examples`, `uv run mypy src bench examples` and
      `uv run pytest -q` are green locally (416 passed, 6 skipped)
- [x] Docstrings and API docs for any new or changed public surface (`cache_dir` /
      `readonly_cache` on both `InSituDataset` and `ChunkPool`)
- [x] User-facing behavior documented in `docs/*.md` — `docs/tuning.md`, "Sharing a
      `cache_dir` between processes"; platform support in `docs/contributing.md` and the README
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] No load-bearing invariant is broken — no framework, no per-sample Python, no dask, no
      reshard; the hot path is unchanged (the lock is taken once, at construction)
- [x] Touches `ChunkPool` → free-threaded (3.13t) run passes: `364 passed, 29 skipped`
      with `PYTHON_GIL=0` and the GIL confirmed off
- No performance claim is made. `_alloc` gains one `rename` per chunk *file creation* (not per
  tile, not per batch), and construction gains one `open`+`flock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iQ36j3rLYeh4R5uzmB52j


