### PR TITLE
ci: give the free-threaded job its own uv cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
   # Free-threaded 3.13t: the real test of the pool's lock-free disjoint scatter +
   # lock-published readiness. torch/bench have no free-threaded wheels yet, so this
   # job is core-deps-only (the torch tests skip via importorskip).
+  #
+  # numcodecs publishes no cp313t wheel, so it compiles from sdist -- ~6 min, which is the
+  # whole job and the workflow's critical path. The uv cache holds that build; see the
+  # cache-suffix note below for what makes it reachable.
   test-freethreaded:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -97,6 +101,14 @@ jobs:
       - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
+          # This job needs a cache key of its own. setup-uv derives the key from the lock
+          # files and the *runner's* interpreter, so every job in this workflow computes the
+          # same one -- and `uv cache prune --ci`, which runs before the save, keeps only
+          # wheels built from source. The 3.12 jobs build nothing (everything has a wheel),
+          # so whichever finishes first stores an ~12 KB cache under the shared key and the
+          # rest, this one included, are refused as duplicates. The suffix separates it, so
+          # the numcodecs/pyyaml/librt builds below are stored once and restored after.
+          cache-suffix: freethreaded
       - run: uv sync --python 3.13t
       # Fail loudly if the GIL is actually still on -- otherwise the run below is a
       # no-op masquerading as a free-threading test.


### PR DESCRIPTION
## Summary

`test-freethreaded` takes **6m40s**; every other job in the workflow finishes inside 90s, so it
is the whole critical path. `uv sync --python 3.13t` is 6m09s of it, and `numcodecs` alone is
**6m06s** — it publishes no `cp313t` wheel (0.16.5 is current), so 3.13t compiles it from sdist.

Caching was already enabled, and already *hitting*. The restored cache was **12 KB**:

```
Cache hit for: setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-3.12.3-pruned-418c9ad…
Cache Size: ~0 MB (12691 B)
```

setup-uv derives its key from the lock files and the **runner's** interpreter, so all seven jobs
in this workflow compute the same one — and `uv cache prune --ci`, which runs before the save,
keeps only wheels built from source. The 3.12 jobs build nothing (everything they install has a
wheel), so whichever finishes first stores a near-empty cache under the shared key, and every
later save — this job's included — is refused as a duplicate. `gh cache list` is the proof: every
cache in the repo is 11–13 KB.

```
12691  refs/heads/main       setup-uv-2-…-pruned-418c9ad…
12759  refs/pull/51/merge    setup-uv-2-…-pruned-418c9ad…   <- same key, different ref
10996  refs/heads/main       setup-uv-2-…-pruned-a873fc6…
```

`cache-suffix: freethreaded` separates the key, which is the case setup-uv documents the input
for. One line, plus the comment explaining why it cannot be dropped.

**Expected effect:** this PR's first run still pays the build, but *saves* it. The second run
should restore instead — I'll post both numbers before asking for review, rather than claiming a
speed-up I haven't measured.

Once on `main`, PR runs read main's cache, so the saving applies to every PR.

## For reviewers

I checked whether the build is avoidable before reaching for a cache: `numcodecs`, `librt`,
`google-crc32c`, `pyyaml` and `ast-serialize` all publish **zero** `cp313t` wheels today, so the
README's "numcodecs has no free-threaded wheel yet, so it compiles from sdist" is still accurate
and there is no version bump that removes the work.

I deliberately did **not** add suffixes to the other six jobs. They build nothing from source, so
their pruned caches are genuinely empty and sharing one key costs only a redundant save attempt.
Keeping their *downloaded* wheels instead (`prune-cache: false`) would mean caching torch and TF —
hundreds of MB against the repo's 10 GB budget, plausibly slower to restore than to re-download.

## Author attestation

- [ ] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

*(Left unchecked deliberately — that box is the human author's to tick.)*

## Checklist

- [x] User-facing behavior documented — n/a; CI-only, no src/tests/docs change
- [x] No load-bearing invariant is broken
- Not applicable: tests (no code change), CHANGELOG (no user-visible change — say the word if you
  want CI work recorded there anyway)
- Performance claim: CI wall-clock only, measured from this repo's own run
  [33828894804](https://github.com/emfdavid/insitubatch/actions/runs/33828894804) — step timings
  and cache sizes quoted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iQ36j3rLYeh4R5uzmB52j
