### PR TITLE
feat: applies() -- per-variable transform scope, and cache identity per array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,24 @@
   lock proves there is no second writer. A format-3 cache is still rejected whole: a log we
   cannot parse says nothing about any individual array.
 
+- **A re-fitted `StandardScaler` could reopen a persisted cache as a *hit*, serving the old
+  normalization.** Without cloudpickle the fingerprint falls back to hashing a transform's
+  source plus its `repr` — and numpy summarizes any array over 1000 elements in `repr`, so
+  per-gridpoint `mean`/`std` repr identically whatever their values. Re-fit the scaler, reopen
+  the cache, and every chunk revives with the previous statistics: no error, no miss, wrong
+  numbers, and nothing in the run that would tell you. The hole is now documented where it
+  bites — on the scaler itself, in the fingerprint section and on the tuning page — and
+  `StandardScaler` takes a `cache_key` you bump per fit (it is a `slots=True` dataclass, so
+  setting the attribute from outside was not even possible). Installing `insitubatch[cache]`
+  remains the stronger fix: cloudpickle hashes the values, not their summary.
+
+- **Documented: two labels backed by one array cannot have different chunk transforms.** Scope
+  is per zarr array *path*, so `t2m_now` / `t2m_next` — one decoded chunk read at two sample
+  offsets — share one pipeline. That is the de-duplication the pool exists for rather than an
+  omission (two pipelines would mean two transformed copies of the same bytes under one cache
+  key), but it was nowhere on the page a reader learns about aliasing. Per-label work belongs
+  in a `batch_transform`.
+
 - **A `chunk_transform` that disagrees with its own declared output shape now raises instead of
   silently truncating.** Everything downstream of assembly — the byte budget, `gather`'s tile
   placement, the revive structural check — is sized from the transform's declared `output_inner`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## Unreleased
 
+- **`applies(...)` scopes a `chunk_transform` to named variables — and the in-body name test
+  it replaces was silently truncating data.** `chunk_transforms` is one list run on every
+  variable, so the convention was for a transform to check `chunk.read.array` and no-op on
+  the rest. `output_geometry` cannot see a test inside a function body: it folded **every**
+  transform's declared `output_inner` into **every** variable's geometry. So a regrid scoped
+  by an `if` to `t2m` also made the engine believe `u10` was regridded — `u10` was gathered
+  as a truncated prefix of itself, and its cache entry could never revive, because the file
+  on disk no longer matched the declared geometry. Nothing raised. Nothing in this tree was
+  affected (all four gating sites — `kelvin_to_celsius`, Hubble's `SCI`, SDSS's `flux`, and
+  `StandardScaler`'s implicit `KeyError` — are shape-preserving, and the one shipped
+  reshaping transform is ungated), but it is what a user's next regrid would have hit.
+
+  Scope is now declared at the call site, where the engine can read it:
+  `applies(["2m_temperature"], kelvin_to_celsius)`. "Subtract 273.15" is a fact about
+  Kelvin; "`2m_temperature` is in Kelvin" is a fact about your store — and the old pattern
+  welded them together, which is why one unit conversion had to enumerate two archives'
+  naming conventions and silently skipped a third. A bare transform still applies to
+  everything. A name matching no array raises at construction, a scoped `StandardScaler` is
+  checked against its own stats dict there too, and off-scope arrays now skip the call
+  entirely rather than paying a no-op pass. The four in-body gates are retired from the
+  examples and docs.
+
+- **Editing one variable's transform no longer invalidates the whole cache (manifest format
+  4).** The fingerprint hashed the entire `chunk_transforms` list once and stamped that on
+  every array's entries, so changing a transform that only touched `t2m` marked `u10` and
+  `v10` stale as well — byte-identical chunks the user then had to `reset_stale_cache` and
+  re-decode, on an NVMe cache that may have taken hours to warm. Each entry now carries the
+  hash of the transforms scoped to *its own* array. The staleness error names which arrays,
+  and `reset_stale_cache=True` deletes only their files.
+
+  Three consequences of staleness becoming a partial answer, each of which used to be a
+  wipe: an array with no entries is **cold, not stale**, so adding a variable is not a cache
+  reset; an array a run does not read keeps its entries and files, so two configurations can
+  share one `cache_dir`; and narrowing a scope invalidates the variable that *left* it and
+  not the one that stayed (a transform is hashed without its scope, deliberately). The log
+  is compacted — temp file, then `rename` — whenever a load drops entries, so a reset is not
+  re-read and re-rejected on every subsequent open; that is safe because part 1's exclusive
+  lock proves there is no second writer. A format-3 cache is still rejected whole: a log we
+  cannot parse says nothing about any individual array.
+
 - **A `chunk_transform` that disagrees with its own declared output shape now raises instead of
   silently truncating.** Everything downstream of assembly — the byte budget, `gather`'s tile
   placement, the revive structural check — is sized from the transform's declared `output_inner`,

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -403,6 +403,44 @@ The shape above wasn't the first cut. The pivots that got here, and the roads no
   collapsed into the `ChunkPool`: one byte-budgeted object that is the assembly buffer when
   small and the cache when large ("don't evict"). One machinery, and no copy between a buffer
   and a cache.
+- **Cache identity per entry, not a header map.** The cross-run manifest
+  (`insitu_cache.jsonl`) is append-only: line 1 is the header, every later line is one
+  completed chunk written as a single `O_APPEND` write, and nothing ever seeks back. When
+  format 4 made cache identity **per array**, the tidy-looking place for it was the header —
+  one `{array: pipeline_hash}` map, instead of the same 16 hex chars repeated on every entry.
+  It does not survive the second run:
+
+  ```text
+  {"format_version": 4}                                   <- written once, on a cold start
+  {"array": "2m_temperature", "chunk_index": 0, "file": "t2m-0.npy", "pipeline": "a1b2c3d4e5f60718"}
+  {"array": "2m_temperature", "chunk_index": 1, "file": "t2m-1.npy", "pipeline": "a1b2c3d4e5f60718"}
+                                                          <- run 1 ends here (or is preempted)
+
+     run 2 opens the same cache_dir with u10 added to the manifest, and reads it for the
+     first time. Its pipeline hash has to be recorded somewhere:
+
+  {"array": "10m_u_component_of_wind", "chunk_index": 0, "file": "u10-0.npy", "pipeline": "9f8e7d6c5b4a3928"}
+                                                          <- ...on the entry, it just appends
+  ```
+
+  With the hash on the entry, run 2's first `u10` line carries its own identity and no
+  earlier byte moves. With a header map, `u10`'s hash belongs on line 1 — written on the cold
+  start, now sitting behind every entry appended since, and longer than the text it replaces —
+  so recording it means rewriting the whole file — and rewriting it *safely*, since
+  `readonly_cache` openers hold the directory lock shared and read that same log whole, so an
+  in-place rewrite can be read torn. The only safe form is the one `_compact` already uses
+  (temp file, then `rename`), which is fine where it is used — rare, exclusive-locked, and
+  already an invalidation the run is paying for — and wrong on the ordinary path of a run
+  touching a variable it has not seen before. The chosen form costs ~30 duplicated bytes per
+  line, which is what the 64-bit truncation of the hash trades against.
+
+  Two consequences worth naming, because they are the reason the per-array split is useful at
+  all: an array with **no entries** is *cold*, not stale (adding a variable is not a wipe), and
+  an array a run **does not read** is left alone entirely, so two configurations can share one
+  `cache_dir`. Scope is deliberately kept **out** of a transform's own token for the mirror-image
+  reason: scope already decides which transforms enter an array's hash, so folding it in as well
+  would invalidate the variable that *stayed* in scope every time another one left it.
+
 - **Transforms staged by cost, not per-sample.** torch's per-`__getitem__` transform redoes
   work for every reused sample. We split preprocessing into a per-chunk `chunk_transform`
   (deterministic, per-variable, applied *before* shuffle so it is cached), a per-batch
@@ -959,8 +997,8 @@ measurements live in [docs/benchmarks.md](docs/benchmarks.md).
   incrementally as each chunk lands — so a killed process leaves a usable cache and the
   next run re-decodes only what had not finished. A new pool over the same dir revives
   entries as ready hits, so decode-once amortizes across *runs* (relaunched jobs, sweeps,
-  several processes on one box). Invalidation is a chunk-transform fingerprint in the log
-  header; a stale cache **raises by default** (`reset_stale_cache=True` opts into GC +
+  several processes on one box). Invalidation is a chunk-transform fingerprint stamped on every
+  entry; a stale cache **raises by default** (`reset_stale_cache=True` opts into GC +
   rebuild), while corruption or tampering always raises. Reshaping transforms (`Regrid`,
   dtype recast) are cacheable on every tier via `output_inner`. Closed decisions: the store
   URL is **not** in the key (session stores have no round-trippable URL, so `cache_dir`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -725,6 +725,16 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   the corruption. **What remains open** is named where the user meets it: a network
   `cache_dir` (`flock` may be emulated per client) and a platform with no POSIX locking are
   still unarbitrated, and both warn at construction saying so. Detection is not a fix.
+- **Aliased labels share one chunk pipeline.** `chunk_transform` scope (`applies`) is per
+  zarr array *path*, so two labels backed by the same array — `t2m_now` / `t2m_next`, or any
+  two dict entries pointing at one path — cannot be given different chunk-stage transforms.
+  This one is a *consequence*, not an omission: aliases are one decoded, transformed chunk
+  read at two sample offsets, which is the de-duplication the pool exists for, and two
+  pipelines over it would mean two transformed copies of the same bytes and two cache entries
+  under one key — resharding by transform. The workaround is exact rather than grudging: a
+  difference the labels can see is a difference the assembled batch can see, so it belongs in
+  a `batch_transform` (uncached, which is the price). Documented in
+  `docs/architecture.md`; no plan to lift it.
 - **Per-array assembly.** A variable no transform touches could stay on the tiled fast path
   instead of assembling into one contiguous array at completion. It does not, because
   `assembles` is a single bool the scheduler reads to decide *where* delivery runs; making

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -687,16 +687,11 @@ Things wrong or missing in *our* code today, with the reasoning that sets their 
   the corruption. **What remains open** is named where the user meets it: a network
   `cache_dir` (`flock` may be emulated per client) and a platform with no POSIX locking are
   still unarbitrated, and both warn at construction saying so. Detection is not a fix.
-- **Cache invalidation is whole-pipeline, not per-variable.** `chunk_transforms` is one list
-  applied to every variable (each transform self-gates by name and no-ops on the rest), and
-  the fingerprint hashes the **whole list once** → a single `pipeline_hash` on every array's
-  entries. Editing a transform that only affects `t2m` therefore invalidates the *whole*
-  cache (`u10`/`v10` too, whose chunks are byte-identical) — and with the raise-on-stale
-  default the user must `reset_stale_cache` and re-decode everything. Fix: assign transforms
-  per variable (or derive, per array, the subset that touches it) and fingerprint **per
-  array**, which also drops the wasted no-op passes. Open design question: how a transform
-  declares which variables it applies to (explicit mapping vs today's name-gating
-  convention). Documented as a limitation in `docs/architecture.md`.
+- **Per-array assembly.** A variable no transform touches could stay on the tiled fast path
+  instead of assembling into one contiguous array at completion. It does not, because
+  `assembles` is a single bool the scheduler reads to decide *where* delivery runs; making
+  it per path also moves `_tile_grid`, `_charge` and gather's `tile_geom`. Now that scope is
+  declared (`applies`), the information is available — the work is the plumbing.
 - **Windowed + shuffle holds the whole split resident.** Shuffle spills a windowed chunk's
   reads into arbitrary blocks, so residency is bounded by the split rather than the block;
   the same applies to a non-uniformly chunked variable (geometry rung 4). The tighter bound
@@ -970,8 +965,12 @@ measurements live in [docs/benchmarks.md](docs/benchmarks.md).
   dtype recast) are cacheable on every tier via `output_inner`. Closed decisions: the store
   URL is **not** in the key (session stores have no round-trippable URL, so `cache_dir`
   *is* the dataset identity); `chunk_index` is the *global* zarr index so subsets and
-  splits share entries; the log needs no compaction. See Known limitations for the
-  per-variable fingerprint gap.
+  splits share entries. Cache identity is **per array** (manifest format 4): each entry
+  carries the hash of the transforms scoped to *its* array, so editing one variable's
+  transform leaves the others valid, an array with no entries is *cold* rather than stale,
+  and an array a run does not read keeps its files — two configurations may share a
+  `cache_dir`. The log is compacted (temp file + rename) when a load drops entries, which
+  the one-writer lock makes safe.
 - **M-W — windowed / multi-offset sampling** ✅ the forecasting unlock and the prerequisite
   for M4. Design, scope decision and as-built deviations are in the geometry-ladder section;
   validated by `examples/advection/` across torch, JAX and TF.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -588,7 +588,8 @@ read → decode ─►[chunk_transform]─► buffer → gather ─►[batch_tra
    thread pool, **before** shuffle/gather. Amortized over every sample that draws
    from the chunk. Home for per-element, sample-order-independent ops: **scaling /
    normalization, unit conversion, dtype cast, chunk-local regrid.** Sees one
-   variable, one chunk (`chunk.read.array` gives the variable).
+   variable, one chunk. Restrict it to particular variables with `applies` — see
+   [Scoping a transform to variables](#scoping-a-transform-to-variables).
 2. **`batch_transform(Batch) -> Batch`** — per-batch, after gather. For ops that
    need the assembled batch: **cross-variable derived fields, channel stacking,
    per-sample random augmentation/crops, collation to model layout.**
@@ -609,6 +610,43 @@ Runnable side-by-side example:
 [`examples/transforms.py`](https://github.com/emfdavid/insitubatch/blob/main/examples/transforms.py)
 — a Kelvin→Celsius `chunk_transform` (one variable, cached) and a cross-variable windspeed
 `batch_transform` (needs the assembled batch, uncached).
+
+### Scoping a transform to variables
+
+`chunk_transforms` is one ordered list and a bare transform runs on **every** variable. To
+restrict one, wrap it at the call site with `applies`:
+
+```python
+from insitubatch import applies
+
+InSituDataset(..., chunk_transforms=[
+    applies(["2m_temperature"], kelvin_to_celsius),   # this variable only
+    Coarsen(2),                                       # every variable
+])
+```
+
+The names are zarr array **paths** (what `chunk.read.array` carries), not dict labels —
+two labels may alias one array (`t2m_now` / `t2m_next`), and the cache is keyed by path. A
+name matching no array raises at construction.
+
+**Do not gate inside the transform.** An `if chunk.read.array == "t2m"` in the body is
+invisible to the engine, and that is not a style point — it is a correctness bug for any
+reshaping transform. `output_geometry` folds every transform's declared `output_inner` into
+**every** variable's geometry; it cannot see a name test in a function body. A transform
+that halves `t2m` and no-ops on `u10` therefore makes the engine believe `u10` is halved
+too, and `u10` is gathered as a truncated prefix of itself, its cache file permanently
+unable to revive — with nothing raised. Right shape, right dtype, wrong numbers.
+
+The division of labour: "subtract 273.15" is a fact about Kelvin, "`2m_temperature` is in
+Kelvin" is a fact about your store. A transform may be *parameterized* by variable — a
+fitted `StandardScaler`'s statistics legitimately are, and it validates a declared scope
+against its own stats dict — but it must not decide whether it runs. Configuration inside,
+control flow outside. sklearn's `ColumnTransformer`, NVTabular's `cols >> Op()` and
+xarray's subset-then-`map` all place the selector the same way.
+
+Scope also buys two smaller things: the engine skips the call for arrays outside it (the
+no-op passes are gone), and cache invalidation becomes per array — see
+[the cache fingerprint](#cross-run-persistence).
 
 ### Standard scaler — pre-fit GLOBAL stats (not per-chunk)
 
@@ -875,11 +913,13 @@ ds = InSituDataset(store, manifest, cache_dir="/mnt/nvme/era5/v3",
 
 Two guards keep a reopened cache honest:
 
-1. a **chunk-transform fingerprint** in the log header — change your `chunk_transforms`
-   (or bump the log format) and the cache is **stale**. A stale cache is almost never
-   what you intended, so by default it **raises** at construction rather than silently
+1. a **chunk-transform fingerprint** stamped on every log entry, over the transforms
+   scoped to *that array* — change your `chunk_transforms` (or bump the log format) and
+   the arrays they affect are **stale**. A stale cache is almost never what you intended,
+   so by default it **raises** at construction, naming which arrays, rather than silently
    rebuilding or serving stale data. Pass `reset_stale_cache=True` to opt into deleting
-   the old files and rebuilding cold (or delete the `cache_dir` yourself); and
+   just those arrays' files and rebuilding them cold (or delete the `cache_dir`
+   yourself); and
 2. a per-entry **shape/dtype check** on revive — a chunk whose stored geometry no
    longer matches the current array is a **miss** (re-fetch + overwrite), never an error.
 
@@ -893,19 +933,27 @@ and referenced globals, so a changed closed-over constant invalidates), or a
 best-effort source hash (catches an edited body but not a changed closure/global — it
 warns once so the weaker guarantee is visible).
 
-> **Limitation — the fingerprint is per-*pipeline*, not per-variable (invalidation is
-> all-or-nothing).** `chunk_transforms` is a single ordered list applied to **every**
-> variable; a transform that only concerns one field self-gates by name and no-ops on the
-> rest (e.g. `kelvin_to_celsius` acts on `t2m`, returns `u10`/`v10` untouched). But the
-> fingerprint hashes the **whole list once** and stamps that single `pipeline_hash` on
-> every array's cache entries. So editing a transform that logically affects only `t2m`
-> marks the **entire** cache stale — `u10`/`v10` included — even though their cached chunks
-> are byte-identical (the edited transform no-oped on them); with the default you must then
-> `reset_stale_cache=True` and re-decode everything. The engine also runs every transform
-> on every chunk (the no-op passes are wasted work, though cheap for a name-gated early
-> return). A per-variable transform assignment + per-array fingerprint would scope
-> invalidation (and application) to just the affected arrays — see the roadmap in
-> [DESIGN.md](https://github.com/emfdavid/insitubatch/blob/main/DESIGN.md).
+**The fingerprint is per *array*, over the transforms scoped to it.** `chunk_transforms`
+is one ordered list, but a transform restricted with `applies` contributes only to the
+arrays it names, so each array's entries carry their own 16-hex `pipeline` hash. Editing a
+transform scoped to `t2m` marks `t2m` stale and leaves `u10`/`v10` — whose bytes did not
+change — valid. Staleness is a partial answer now, which changes three behaviours worth
+knowing:
+
+- the error **names which arrays** are stale, and `reset_stale_cache=True` deletes exactly
+  those arrays' `.npy` files, not the directory;
+- an array with **no entries** is *cold*, not stale — adding a variable to a configuration
+  is not a cache wipe;
+- an array **this run does not read** is left entirely alone, entries and files, so two
+  configurations can share one `cache_dir`.
+
+Scope does *not* enter a transform's own token: narrowing `applies(["t2m", "u10"], f)` to
+`applies(["t2m"], f)` invalidates `u10` (it lost a transform) and leaves `t2m` valid (its
+pipeline is unchanged). The log is compacted — written to a temp name and renamed — when a
+load drops entries, which is safe because one writer holds the `cache_dir` lock.
+
+Only the manifest **format** is still all-or-nothing: a log we cannot parse tells us
+nothing about any individual array, so an older format resets the whole cache.
 
 **Observability.** `dataset.cache_hits` / `cache_misses` give per-epoch counts; a plain
 miss is silent, but `persist=True` serving **zero** hits while the cache was

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -629,6 +629,15 @@ The names are zarr array **paths** (what `chunk.read.array` carries), not dict l
 two labels may alias one array (`t2m_now` / `t2m_next`), and the cache is keyed by path. A
 name matching no array raises at construction.
 
+**Limitation: aliased labels share one chunk pipeline.** Because scope is per array path,
+two labels backed by the same array cannot be given *different* `chunk_transforms` — there
+is no way to express "scale `t2m_now` but not `t2m_next`" at the chunk stage. This is the
+de-duplication the pool exists for: aliases are one decoded, transformed chunk read at two
+sample offsets, and two pipelines over it would mean two transformed copies of the same
+bytes and two cache entries under one key. Per-label work belongs in a `batch_transform`,
+which sees the assembled batch and each label separately (uncached, which is the honest
+price). The same holds for any two labels pointing at one path, aliased or not.
+
 **Do not gate inside the transform.** An `if chunk.read.array == "t2m"` in the body is
 invisible to the engine, and that is not a style point — it is a correctness bug for any
 reshaping transform. `output_geometry` folds every transform's declared `output_inner` into
@@ -644,8 +653,8 @@ against its own stats dict — but it must not decide whether it runs. Configura
 control flow outside. sklearn's `ColumnTransformer`, NVTabular's `cols >> Op()` and
 xarray's subset-then-`map` all place the selector the same way.
 
-Scope also buys two smaller things: the engine skips the call for arrays outside it (the
-no-op passes are gone), and cache invalidation becomes per array — see
+Scope also buys two smaller things: the engine skips the call entirely for arrays outside
+it, and cache invalidation is per array — see
 [the cache fingerprint](#cross-run-persistence).
 
 ### Standard scaler — pre-fit GLOBAL stats (not per-chunk)
@@ -669,6 +678,15 @@ Pre-fit the stats however you like and pass them in. The recommended way is to f
 — covered next — which also warms the cache. `StandardScaler` above is then the
 *chunk*-stage applier, for when you want the normalization cached with the decoded
 chunk; the fit pass and the apply stage are independent.
+
+!!! warning "A re-fitted scaler needs a `cache_key` (or cloudpickle)"
+
+    Stats large enough for numpy to summarize in `repr` — anything over 1000 elements, so
+    per-gridpoint mean/std — are invisible to the best-effort source fingerprint, and a
+    re-fit reopens a persisted cache as a **hit** carrying the old normalization. Install
+    `insitubatch[cache]`, or pass `StandardScaler(..., cache_key=...)` with a stats version
+    you bump on every fit. See [the fingerprint](#cross-run-persistence). Fitting at the *batch* stage
+    (below) sidesteps this entirely: the cache then holds raw chunks.
 
 **Alternative: fit at the *batch* stage with community tooling, warming the cache.**
 Standardization is elementwise, so per-chunk and per-batch are identical — which means
@@ -935,11 +953,21 @@ and referenced globals, so a changed closed-over constant invalidates), or a
 best-effort source hash (catches an edited body but not a changed closure/global — it
 warns once so the weaker guarantee is visible).
 
+**The source fallback is blind to large statistics.** It folds a class-based transform's
+`repr` in so instance config still counts, but numpy *summarizes* an array over 1000
+elements in `repr` — `array([0., 1., 2., ..., 1997., 1998., 1999.])` — so two transforms
+carrying different per-gridpoint arrays repr identically and hash the same. Re-fit a
+`StandardScaler` over a `(721, 1440)` grid, reopen a persisted cache without cloudpickle,
+and every chunk revives as a hit, normalized with the *old* statistics: no error, no miss,
+wrong numbers. Install `insitubatch[cache]` (cloudpickle hashes the values), or set
+pass `StandardScaler(..., cache_key="<stats version>")`, whenever a transform's identity
+lives in an array rather than in its source.
+
 **The fingerprint is per *array*, over the transforms scoped to it.** `chunk_transforms`
 is one ordered list, but a transform restricted with `applies` contributes only to the
 arrays it names, so each array's entries carry their own 16-hex `pipeline` hash. Editing a
 transform scoped to `t2m` marks `t2m` stale and leaves `u10`/`v10` — whose bytes did not
-change — valid. Staleness is a partial answer now, which changes three behaviours worth
+change — valid. Staleness is therefore a *partial* answer, with three behaviours worth
 knowing:
 
 - the error **names which arrays** are stale, and `reset_stale_cache=True` deletes exactly
@@ -947,7 +975,9 @@ knowing:
 - an array with **no entries** is *cold*, not stale — adding a variable to a configuration
   is not a cache wipe;
 - an array **this run does not read** is left entirely alone, entries and files, so two
-  configurations can share one `cache_dir`.
+  configurations can share one `cache_dir`. Dropping a variable is not an edit to it: a
+  feature-importance or ablation sweep can run variable subsets over one warm cache all day,
+  and every array it omits is still there, valid, when a later run asks for it.
 
 Scope does *not* enter a transform's own token: narrowing `applies(["t2m", "u10"], f)` to
 `applies(["t2m"], f)` invalidates `u10` (it lost a transform) and leaves `t2m` valid (its

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -914,7 +914,9 @@ ds = InSituDataset(store, manifest, cache_dir="/mnt/nvme/era5/v3",
 Two guards keep a reopened cache honest:
 
 1. a **chunk-transform fingerprint** stamped on every log entry, over the transforms
-   scoped to *that array* — change your `chunk_transforms` (or bump the log format) and
+   scoped to *that array* (identity is carried on the entry, not in the header; the
+   [design record](https://github.com/emfdavid/insitubatch/blob/main/DESIGN.md#design-evolution--alternatives)
+   has the why) — change your `chunk_transforms` (or bump the log format) and
    the arrays they affect are **stale**. A stale cache is almost never what you intended,
    so by default it **raises** at construction, naming which arrays, rather than silently
    rebuilding or serving stale data. Pass `reset_stale_cache=True` to opt into deleting

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -246,9 +246,27 @@ Two cases that are deliberately *not* stale:
   can widen a configuration without a wipe.
 - **Reading a subset.** An array this run does not open is left alone entirely — entries
   and files. Two configurations can share one `cache_dir`, each warming its own arrays.
+  This is what makes an **ablation / feature-importance sweep** cheap: drop a variable from
+  the run and its cached chunks are neither validated nor deleted, so the run that puts it
+  back reads it warm. Dropping a variable is not an edit to it.
 
-Narrowing a scope invalidates the variable that *left* it, and only that one: the transform
-itself is hashed without its scope, so the variables that stayed hash identically.
+Narrowing a scope is different, and it *is* stale: a variable that leaves
+`applies([...], scale)` while the run still reads it has cached chunks holding scaled bytes
+that the new configuration must not serve, so its files are deleted and re-decoded. Only that
+one variable — the transform is hashed without its scope, so the variables that stayed hash
+identically.
+
+Put the two together and the rule is: **a variable is invalidated when the pipeline over it
+changes, not when your configuration stops mentioning it.**
+
+!!! warning "Re-fitted statistics may not invalidate"
+
+    Without cloudpickle (`insitubatch[cache]`) the fingerprint falls back to hashing a
+    transform's source plus its `repr`, and numpy summarizes any array over 1000 elements in
+    `repr`. A `StandardScaler` holding per-gridpoint `mean`/`std` therefore hashes the same
+    after a re-fit, and the cache reopens as a **hit** carrying the old normalization. Install
+    the extra, or pass `StandardScaler(..., cache_key=...)` with a version you bump on every
+    fit.
 
 A load that drops entries rewrites the log (to a temp name, then a rename), so a reset is
 not re-read and re-rejected on every subsequent open. That is safe only because one writer

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -231,6 +231,29 @@ There is no such thing as a stale lock, and so no cleanup procedure. The kernel 
 when the process dies — `SIGKILL`, OOM and spot preemption included. If you are seeing the
 error, that process is alive.
 
+### What a transform edit invalidates
+
+Cache identity is **per array**: each manifest entry carries the hash of the
+`chunk_transforms` scoped to *its* array (see
+[`applies`](architecture.md#scoping-a-transform-to-variables)). Editing a transform scoped
+to `2m_temperature` therefore raises naming `['2m_temperature']`, and
+`reset_stale_cache=True` deletes just that array's chunk files — `10m_u_component_of_wind`
+and the rest keep theirs, because their bytes did not change.
+
+Two cases that are deliberately *not* stale:
+
+- **Adding a variable.** An array with no entries yet is a cold start for that array. You
+  can widen a configuration without a wipe.
+- **Reading a subset.** An array this run does not open is left alone entirely — entries
+  and files. Two configurations can share one `cache_dir`, each warming its own arrays.
+
+Narrowing a scope invalidates the variable that *left* it, and only that one: the transform
+itself is hashed without its scope, so the variables that stayed hash identically.
+
+A load that drops entries rewrites the log (to a temp name, then a rename), so a reset is
+not re-read and re-rejected on every subsequent open. That is safe only because one writer
+holds the lock above.
+
 ### Put `cache_dir` on local NVMe, not NFS
 
 The cache is an mmap tier, so this is what it is built for. Over a network filesystem it

--- a/examples/fit_scaler.py
+++ b/examples/fit_scaler.py
@@ -16,6 +16,12 @@ Why this over a chunk-stage scaler:
     change the scaler (or sweep normalizations) without re-decoding.
   * **Composes correctly** — the fit pass runs the dataset's own `chunk_transforms`
     (e.g. a regrid), so the scaler is fit on exactly what training will see.
+  * **No cache identity to keep in sync** — a chunk-stage scaler is part of the cache
+    fingerprint, and without cloudpickle the fallback cannot see re-fitted statistics
+    (numpy summarizes a large array's `repr`), so a re-fit can reopen a persisted cache
+    as a *hit* carrying the old numbers. Here the cache holds raw chunks and the question
+    never arises. If you do scale at the chunk stage, give
+    `insitubatch.StandardScaler` a `cache_key` and bump it on every fit.
 
     uv run python -m examples.fit_scaler                 # synthetic file://
     uv run python -m examples.fit_scaler --wb2           # public WeatherBench2 ERA5

--- a/examples/hubble/data.py
+++ b/examples/hubble/data.py
@@ -178,9 +178,12 @@ def clean_normalize(chunk: DecodedChunk) -> DecodedChunk:
     the per-frame median and divide by a MAD-based scale, then clip -- so MSE denoising is
     well-conditioned. Per-(variable, chunk), deterministic, pure numpy: the cacheable chunk
     stage, and it releases the GIL on the decode pool.
+
+    No variable gate, in the body or at the call site: this dataset opens ``SCI`` and nothing
+    else, so an unscoped transform already applies to exactly the right array. Scope a
+    transform with ``insitubatch.applies`` when the dataset has variables it must not touch --
+    never with an ``if`` inside the transform, which the engine cannot see.
     """
-    if chunk.read.array != SCI_VAR:
-        return chunk
     x = np.nan_to_num(chunk.data.astype(np.float32), nan=0.0, posinf=0.0, neginf=0.0)
     med = np.median(x, axis=(1, 2), keepdims=True)
     mad = np.median(np.abs(x - med), axis=(1, 2), keepdims=True)

--- a/examples/sdss/data.py
+++ b/examples/sdss/data.py
@@ -388,9 +388,12 @@ def normalize(chunk: DecodedChunk) -> DecodedChunk:
     divide by a MAD-based scale, then clip -- so a reconstruction MSE is well-conditioned across
     fibers. Per-(variable, chunk), deterministic, pure numpy: the cacheable chunk stage, and it
     releases the GIL on the decode pool.
+
+    No variable gate, in the body or at the call site: this dataset opens ``flux`` and nothing
+    else, so an unscoped transform already applies to exactly the right array. Scope a
+    transform with ``insitubatch.applies`` when the dataset has variables it must not touch --
+    never with an ``if`` inside the transform, which the engine cannot see.
     """
-    if chunk.read.array != FLUX_VAR:
-        return chunk
     x = np.nan_to_num(chunk.data.astype(np.float32), nan=0.0, posinf=0.0, neginf=0.0)
     med = np.median(x, axis=1, keepdims=True)
     mad = np.median(np.abs(x - med), axis=1, keepdims=True)

--- a/examples/transforms.py
+++ b/examples/transforms.py
@@ -34,7 +34,13 @@ from dataclasses import dataclass
 import numpy as np
 import zarr
 
-from insitubatch import ensure_local_dir, obstore_store, open_geometries, split_by_chunk
+from insitubatch import (
+    applies,
+    ensure_local_dir,
+    obstore_store,
+    open_geometries,
+    split_by_chunk,
+)
 from insitubatch.source import InSituDataset
 from insitubatch.types import ArrayGeometry, Batch, DecodedChunk
 
@@ -64,17 +70,17 @@ def build_store(tmp: str, *, n: int = 64, lat: int = 16, lon: int = 32, spc: int
     return url
 
 
-# Temperature fields this K->C transform understands: the synthetic ``t2m`` here and the public
-# WeatherBench2 ERA5 name (``2m_temperature``), so the same callable works against real cloud data.
-TEMPERATURE_VARS = ("t2m", "2m_temperature")
-
-
 def kelvin_to_celsius(chunk: DecodedChunk) -> DecodedChunk:
-    """A chunk_transform: convert 2 m temperature from Kelvin to Celsius, vectorized.
+    """A chunk_transform: convert temperature from Kelvin to Celsius, vectorized.
 
-    Gated on the variable name, because a chunk_transform is called once per (variable,
-    chunk) and should only touch the field it understands (leaves u10/v10 untouched). It is
-    per-variable, per-chunk, deterministic and elementwise -- the textbook cacheable chunk
+    It knows nothing about any store -- no variable names appear in it. "Subtract 273.15" is a
+    fact about Kelvin; "``t2m`` is in Kelvin" is a fact about *your* archive, and the call site
+    declares it with ``applies(["t2m"], kelvin_to_celsius)``. Scoping in the body instead
+    would hide it from the engine, which folds a reshaping transform's declared output into
+    every variable's geometry -- and it makes one callable enumerate every archive's naming
+    convention (``t2m``, ``2m_temperature``, ...), silently skipping the next one.
+
+    Per-variable, per-chunk, deterministic and elementwise -- the textbook cacheable chunk
     stage -- and pure vectorized numpy, so it releases the GIL on the decode pool.
 
     Check it against one chunk of your real store before training (geometry, cacheability, and
@@ -83,8 +89,7 @@ def kelvin_to_celsius(chunk: DecodedChunk) -> DecodedChunk:
         insitubatch-check-transform <URL> --var 2m_temperature \\
             --transform examples/transforms.py:kelvin_to_celsius --skip-signature
     """
-    if chunk.read.array in TEMPERATURE_VARS:
-        chunk.data = chunk.data - 273.15
+    chunk.data = chunk.data - 273.15
     return chunk
 
 
@@ -144,8 +149,11 @@ def run_demo(
         manifest = split_by_chunk(geoms["t2m"], fractions=(0.8, 0.1, 0.1))
         source_inner = geoms["t2m"].inner_shape
 
-        # Two chunk stages: K->C (shape-preserving) then a reshaping Coarsen (halves the grid).
-        # The cache slot is sized at the *coarsened* shape via Coarsen.output_inner.
+        # Two chunk stages: K->C on t2m alone (u10/v10 are not temperatures), then a
+        # reshaping Coarsen on every variable. The cache slot is sized at the *coarsened*
+        # shape via Coarsen.output_inner. `applies` is what keeps those two facts separate:
+        # without it the engine would believe u10 and v10 were K->C'd as well, and -- worse,
+        # because it is silent -- fold Coarsen's output shape into variables it never saw.
         ds = InSituDataset(
             store,
             manifest,
@@ -153,7 +161,7 @@ def run_demo(
             batch_size=batch_size,
             block_chunks=block_chunks,
             shuffle=False,
-            chunk_transforms=[kelvin_to_celsius, Coarsen(factor=2)],
+            chunk_transforms=[applies(["t2m"], kelvin_to_celsius), Coarsen(factor=2)],
             batch_transforms=[add_windspeed],
         )
 

--- a/src/insitubatch/__init__.py
+++ b/src/insitubatch/__init__.py
@@ -39,6 +39,7 @@ from .transforms import (
     BatchTransform,
     ChunkTransform,
     StandardScaler,
+    applies,
 )
 from .types import ArrayGeometry, Batch, ChunkRead, DecodedChunk, SplitName, StoredChunkRead
 
@@ -69,6 +70,7 @@ __all__ = [
     "SplitName",
     "StandardScaler",
     "StoredChunkRead",
+    "applies",
     "arraylake_store",
     "as_tf_dataset",
     "as_torch",

--- a/src/insitubatch/check_transform.py
+++ b/src/insitubatch/check_transform.py
@@ -31,7 +31,6 @@ import os
 import statistics
 import sys
 import time
-from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -41,9 +40,8 @@ from zarr.abc.store import Store
 
 from .pool import output_geometry
 from .store import obstore_store, open_geometries
+from .transforms import ChunkTransform, transform_scope
 from .types import ArrayGeometry, ChunkRead, DecodedChunk
-
-ChunkTransform = Callable[[DecodedChunk], DecodedChunk]
 
 
 def load_transform(target: str) -> ChunkTransform:
@@ -235,6 +233,20 @@ def main(argv: list[str] | None = None) -> int:
         f"  chunk {a.chunk:<5}: {n_samples} samples -> source shape "
         f"{geom.slot_shape(a.chunk)} = {src_mb:.1f} MB decoded"
     )
+
+    # A scoped transform (`applies`) that does not name this variable would never run in the
+    # engine, so running it here would report on something training will not do. Say which
+    # variables it covers rather than printing a misleading PASS.
+    scope = transform_scope(fn)
+    if scope is not None and geom.path not in scope:
+        print(
+            f"\nFAIL: this transform is scoped with applies({sorted(scope)}), which does not "
+            f"include {geom.path!r}. The engine would skip it for this variable entirely. "
+            f"Re-run with --var one of {sorted(scope)}."
+        )
+        return 1
+    if scope is not None:
+        print(f"  scope       : applies to {sorted(scope)}")
 
     base = read_chunk(store, a.var, a.chunk, geom)
     in_shape, in_dtype = base.data.shape, base.data.dtype

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -291,6 +291,10 @@ def _transform_token(fn: ChunkTransform) -> str:
     the object's memory address, so the token would be unstable across runs (a spurious
     cache miss on every reopen). A stable, non-default ``__repr__`` (dataclasses, partials)
     is folded in so instance config still affects the token; the address-bearing default is not.
+    That has one sharp edge: numpy **summarizes** an array over 1000 elements in ``repr``, so a
+    transform holding large statistics (a :class:`~insitubatch.transforms.StandardScaler` with
+    per-gridpoint mean/std) can repr -- and therefore hash -- identically after a re-fit. Give
+    such a transform an explicit ``cache_key``, or install cloudpickle, which hashes the values.
 
     An :func:`~insitubatch.transforms.applies` wrapper is stripped first: the token covers
     *what* a transform does, never *which arrays it runs on*. Narrowing a scope therefore
@@ -490,21 +494,21 @@ class ChunkPool:
 
     _MANIFEST_NAME = "insitu_cache.jsonl"
     _MANIFEST_FORMAT = 4
-    """Bumped to 4: cache identity is **per array**, carried on each entry.
+    """The on-disk contract of the manifest, and cache identity is **per array**.
 
     An entry is ``{array, chunk_index, file, pipeline}``, where ``pipeline`` is the hash of
-    the chunk_transforms scoped to *that array* -- so editing a transform that only touches
-    ``t2m`` no longer invalidates ``u10`` and ``v10``, whose bytes did not change. The header
-    line carries ``{format_version}`` and nothing else; identity rides on the entry, which is
-    what lets a run append an array it is seeing for the first time without touching a byte
-    written by an earlier one. (The header-map alternative, and why it was rejected, are in
-    DESIGN.md under "Design evolution & alternatives".)
+    the chunk_transforms scoped to *that array* -- so editing a transform that touches only
+    ``t2m`` leaves ``u10`` and ``v10`` valid, their bytes being unchanged. The header line
+    carries ``{format_version}`` and nothing else; identity rides on the entry, which is what
+    lets a run append an array it is seeing for the first time without touching a byte written
+    by an earlier one. (The header-map alternative, and why it was rejected, are in DESIGN.md
+    under "Design evolution & alternatives".)
 
-    Format 3 made a persisted chunk **tile-major** -- a ``.npy`` holds ``(n_tiles,
+    The ``file`` a persisted chunk names is **tile-major**: the ``.npy`` holds ``(n_tiles,
     *tile_shape)``, each stored tile contiguous in :meth:`ArrayGeometry.inner_index` order,
-    rather than one assembled ``slot_shape`` array. That layout is unchanged in 4.
+    not one assembled ``slot_shape`` array.
 
-    A log at any earlier version is rejected whole (:meth:`_reset_stale_format`): we cannot
+    A log at any other version is rejected whole (:meth:`_reset_stale_format`): we cannot
     read its entries' meaning, so we cannot judge any array in it valid."""
 
     def __init__(
@@ -633,8 +637,11 @@ class ChunkPool:
                 logger.warning(
                     "persist: cloudpickle not installed and a chunk_transform has no "
                     "cache_key -> cache invalidation on transform changes is best-effort "
-                    "(source only; closure/global changes may not invalidate). Install "
-                    "`insitubatch[cache]` or set a `cache_key` attribute for a stronger guarantee."
+                    "(source text only; a changed closure or global may not invalidate, and "
+                    "neither may re-fitted statistics: numpy summarizes an array over 1000 "
+                    "elements in repr, so large per-gridpoint mean/std can hash identically to "
+                    "the values they replaced). Install `insitubatch[cache]` or set a "
+                    "`cache_key` attribute for a stronger guarantee."
                 )
             try:
                 self._load_log()
@@ -1545,9 +1552,8 @@ class ChunkPool:
             self._cv.notify_all()
 
     def _apply_transforms(self, array: str, chunk_index: int, data: np.ndarray) -> np.ndarray:
-        """Run the transforms scoped to this array, in order. Off-scope transforms are not
-        called at all -- the no-op pass over a variable a transform does not understand is
-        gone, and so is any chance of it acting on one it was not given."""
+        """Run the transforms scoped to this array, in order. A transform outside its scope
+        is not called at all: it never sees a variable it was not given."""
         pipeline = self._transforms_by_path[array]
         if not pipeline:
             return data

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -292,11 +292,10 @@ def _transform_token(fn: ChunkTransform) -> str:
     cache miss on every reopen). A stable, non-default ``__repr__`` (dataclasses, partials)
     is folded in so instance config still affects the token; the address-bearing default is not.
 
-    An :func:`~insitubatch.transforms.applies` wrapper is stripped first, for two reasons: it
-    is a frozen dataclass whose ``repr`` would otherwise dominate the source-path hash, and --
-    deliberately -- scope must **not** enter the token. Scope already decides which transforms
-    enter an array's hash; folding it in as well would invalidate the variable that *stayed*
-    in scope every time another one left it.
+    An :func:`~insitubatch.transforms.applies` wrapper is stripped first: the token covers
+    *what* a transform does, never *which arrays it runs on*. Narrowing a scope therefore
+    invalidates the variable that left it and leaves the ones that stayed hashing identically.
+    (Rationale for that split: DESIGN.md, "Design evolution & alternatives".)
     """
     fn = unwrap_transform(fn)
     key = getattr(fn, "cache_key", None)
@@ -324,11 +323,10 @@ def _transform_token(fn: ChunkTransform) -> str:
 def _pipeline_hash(transforms: Sequence[ChunkTransform]) -> str:
     """The cache identity of one array's pipeline: 16 hex chars over its transforms' tokens.
 
-    Stamped on every manifest entry (not once in the header), because the log is append-only:
-    a header map could not absorb an array this run reads for the first time without
-    rewriting it. Truncated to 64 bits -- a collision means serving a chunk transformed by a
-    *different* pipeline, and at the scale of one directory's worth of pipeline edits that is
-    not a risk worth 32 more bytes per line.
+    Stamped on every manifest entry (see :attr:`ChunkPool._MANIFEST_FORMAT`). Truncated to
+    64 bits -- a collision means serving a chunk transformed by a *different* pipeline, and
+    at the scale of one directory's worth of pipeline edits that is not a risk worth 32 more
+    bytes per line.
 
     An empty pipeline (no transform applies to this array) hashes like any other, so a
     variable that leaves every scope invalidates exactly once and then stays valid."""
@@ -497,8 +495,10 @@ class ChunkPool:
     An entry is ``{array, chunk_index, file, pipeline}``, where ``pipeline`` is the hash of
     the chunk_transforms scoped to *that array* -- so editing a transform that only touches
     ``t2m`` no longer invalidates ``u10`` and ``v10``, whose bytes did not change. The header
-    is just ``{format_version}``: a map there could not absorb an array a later run reads for
-    the first time, because the log is append-only.
+    line carries ``{format_version}`` and nothing else; identity rides on the entry, which is
+    what lets a run append an array it is seeing for the first time without touching a byte
+    written by an earlier one. (The header-map alternative, and why it was rejected, are in
+    DESIGN.md under "Design evolution & alternatives".)
 
     Format 3 made a persisted chunk **tile-major** -- a ``.npy`` holds ``(n_tiles,
     *tile_shape)``, each stored tile contiguous in :meth:`ArrayGeometry.inner_index` order,

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -76,7 +76,7 @@ import sys
 import threading
 import time
 from collections import OrderedDict
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Collection, Iterator, Sequence
 from dataclasses import dataclass, replace
 from enum import Enum
 from pathlib import Path
@@ -85,6 +85,7 @@ from typing import cast
 import numpy as np
 
 from .buffers import BatchBuffers, BufferStats, HostAllocator
+from .transforms import ChunkTransform, transform_scope, unwrap_transform
 from .types import ArrayGeometry, Batch, ChunkRead, DecodedChunk
 
 try:  # optional: stronger transform fingerprint (closures + globals). `--extra cache`.
@@ -98,8 +99,6 @@ except ImportError:  # pragma: no cover - Windows; warned about at pool construc
     fcntl = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
-
-ChunkTransform = Callable[[DecodedChunk], DecodedChunk]
 
 
 #: Suffix of the private file a slot is written to before it is renamed into place
@@ -184,8 +183,35 @@ def _safe(name: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "_", name)
 
 
+def transforms_for(path: str, transforms: Sequence[ChunkTransform]) -> tuple[ChunkTransform, ...]:
+    """The subset of the pipeline that applies to one array, in order.
+
+    A transform wrapped in :func:`~insitubatch.transforms.applies` runs only for the arrays
+    it names; a bare one runs for all of them. This is the single place scope is resolved --
+    geometry, the cache fingerprint and the call itself all read it, so they cannot drift.
+    """
+    return tuple(t for t in transforms if (s := transform_scope(t)) is None or path in s)
+
+
+def validate_scopes(transforms: Sequence[ChunkTransform], paths: Collection[str]) -> None:
+    """Reject a scope naming an array this dataset does not have.
+
+    A misspelled name would otherwise apply to nothing, silently: the scaler that quietly
+    stops scaling. Raised at construction, before any cache directory, lockfile or fetch."""
+    known = set(paths)
+    for t in transforms:
+        scope = transform_scope(t)
+        if scope is not None and (unknown := sorted(scope - known)):
+            raise ValueError(
+                f"applies({sorted(scope)}, {getattr(unwrap_transform(t), '__name__', t)}) "
+                f"names {unknown}, which are not arrays in this dataset. Known arrays: "
+                f"{sorted(known)}. Scope is matched against the zarr array *path* (what "
+                "chunk.read.array carries), not the dict label you gave the variable."
+            )
+
+
 def output_geometry(geom: ArrayGeometry, transforms: Sequence[ChunkTransform]) -> ArrayGeometry:
-    """The geometry a chunk has *after* the chunk_transform pipeline.
+    """The geometry a chunk of ``geom`` has *after* the chunk_transform pipeline.
 
     A reshaping transform (regrid / dtype recast) declares ``output_inner(geom) ->
     (inner_shape, dtype)``; the pipeline folds them so each transform sees the geometry
@@ -194,7 +220,12 @@ def output_geometry(geom: ArrayGeometry, transforms: Sequence[ChunkTransform]) -
     transform can neither move nor reshape it (the sample-geometry invariant). A transform
     without ``output_inner`` is identity; with none reshaping, the source geometry returns
     unchanged. Output ``chunks`` are set to the inner shape (the cache slot is one assembled
-    buffer, never inner-tiled), keeping the geometry self-consistent."""
+    buffer, never inner-tiled), keeping the geometry self-consistent.
+
+    Folding is **per array**: only the transforms scoped to ``geom.path`` contribute. Folding
+    all of them into every variable is what made a transform scoped to ``t2m`` truncate
+    ``u10`` -- gather read a prefix of the real data and the entry could never revive, with
+    nothing raised (#42)."""
 
     def rebuild(inner_shape: tuple[int, ...], dt: np.dtype) -> ArrayGeometry:
         # Reinsert the (whole, single-chunk) sample dim at its physical axis so the
@@ -205,7 +236,7 @@ def output_geometry(geom: ArrayGeometry, transforms: Sequence[ChunkTransform]) -
         return replace(geom, shape=shape, chunks=chunks, dtype=dt)
 
     inner, dt = geom.inner_shape, geom.dtype
-    for t in transforms:
+    for t in transforms_for(geom.path, transforms):
         declare = getattr(t, "output_inner", None)
         if declare is None:
             continue
@@ -260,7 +291,14 @@ def _transform_token(fn: ChunkTransform) -> str:
     the object's memory address, so the token would be unstable across runs (a spurious
     cache miss on every reopen). A stable, non-default ``__repr__`` (dataclasses, partials)
     is folded in so instance config still affects the token; the address-bearing default is not.
+
+    An :func:`~insitubatch.transforms.applies` wrapper is stripped first, for two reasons: it
+    is a frozen dataclass whose ``repr`` would otherwise dominate the source-path hash, and --
+    deliberately -- scope must **not** enter the token. Scope already decides which transforms
+    enter an array's hash; folding it in as well would invalidate the variable that *stayed*
+    in scope every time another one left it.
     """
+    fn = unwrap_transform(fn)
     key = getattr(fn, "cache_key", None)
     if key is not None:
         return f"key:{key}"
@@ -281,6 +319,22 @@ def _transform_token(fn: ChunkTransform) -> str:
         repr(fn) if not inspect.isroutine(fn) and type(fn).__repr__ is not object.__repr__ else ""
     )
     return "src:" + hashlib.sha256(f"{name}\n{src}\n{config}".encode()).hexdigest()
+
+
+def _pipeline_hash(transforms: Sequence[ChunkTransform]) -> str:
+    """The cache identity of one array's pipeline: 16 hex chars over its transforms' tokens.
+
+    Stamped on every manifest entry (not once in the header), because the log is append-only:
+    a header map could not absorb an array this run reads for the first time without
+    rewriting it. Truncated to 64 bits -- a collision means serving a chunk transformed by a
+    *different* pipeline, and at the scale of one directory's worth of pipeline edits that is
+    not a risk worth 32 more bytes per line.
+
+    An empty pipeline (no transform applies to this array) hashes like any other, so a
+    variable that leaves every scope invalidates exactly once and then stays valid."""
+    return hashlib.sha256("\n".join(_transform_token(t) for t in transforms).encode()).hexdigest()[
+        :16
+    ]
 
 
 def _has_weak_token(transforms: Sequence[ChunkTransform]) -> bool:
@@ -437,14 +491,21 @@ class ChunkPool:
     """
 
     _MANIFEST_NAME = "insitu_cache.jsonl"
-    _MANIFEST_FORMAT = 3
-    """Bumped to 3: a persisted chunk is now stored **tile-major**.
+    _MANIFEST_FORMAT = 4
+    """Bumped to 4: cache identity is **per array**, carried on each entry.
 
-    A ``.npy`` holds ``(n_tiles, *tile_shape)`` -- each stored tile contiguous, in
-    :meth:`ArrayGeometry.inner_index` order -- rather than one assembled
-    ``slot_shape`` array. File count per chunk is unchanged. A version-2 cache is
-    structurally unreadable under the new layout, so the header check rejects the whole
-    log and refetches rather than misreading it as data."""
+    An entry is ``{array, chunk_index, file, pipeline}``, where ``pipeline`` is the hash of
+    the chunk_transforms scoped to *that array* -- so editing a transform that only touches
+    ``t2m`` no longer invalidates ``u10`` and ``v10``, whose bytes did not change. The header
+    is just ``{format_version}``: a map there could not absorb an array a later run reads for
+    the first time, because the log is append-only.
+
+    Format 3 made a persisted chunk **tile-major** -- a ``.npy`` holds ``(n_tiles,
+    *tile_shape)``, each stored tile contiguous in :meth:`ArrayGeometry.inner_index` order,
+    rather than one assembled ``slot_shape`` array. That layout is unchanged in 4.
+
+    A log at any earlier version is rejected whole (:meth:`_reset_stale_format`): we cannot
+    read its entries' meaning, so we cannot judge any array in it valid."""
 
     def __init__(
         self,
@@ -463,6 +524,15 @@ class ChunkPool:
         # representative geometry per path suffices for slot sizing (aliases share shape).
         self._by_path = {g.path: g for g in geometries.values()}
         self._chunk_transforms = tuple(chunk_transforms)
+        # Scope first: a name that matches no array is a user error, and the fastest place to
+        # say so is before any geometry is derived from it (and before a cache dir or lockfile
+        # exists to clean up).
+        validate_scopes(self._chunk_transforms, self._by_path)
+        # The pipeline each array actually runs -- the single resolution of scope, read by
+        # geometry, by the fingerprint and by `_apply_transforms`.
+        self._transforms_by_path = {
+            p: transforms_for(p, self._chunk_transforms) for p in self._by_path
+        }
         # Output geometry after the chunk_transform pipeline. A reshaping transform (regrid /
         # dtype recast) makes the cached chunk differ from the source, so everything
         # *downstream of assembly* -- slot sizing, the cache budget, gather, the revive
@@ -548,16 +618,17 @@ class ChunkPool:
         # completion is one os.write() -- no per-chunk open(). None in heap/spill mode, and in
         # readonly_cache mode, which reads the log and never appends to it.
         self._log_fd: int | None = None
-        # Fingerprint of the chunk_transform pipeline (only chunk_transforms are baked into
-        # cached chunks; batch_transforms run post-cache). A run whose fingerprint differs
-        # from the manifest's discards the cache (changed transforms -> stale). batch
-        # transforms and the store identity are out of scope (the cache_dir path is the
-        # dataset identity -- see the class docstring).
-        self._pipeline_fp = ""
+        # Fingerprint of the chunk_transform pipeline, **per array** (only chunk_transforms are
+        # baked into cached chunks; batch_transforms run post-cache). An array whose
+        # fingerprint differs from the one stamped on its manifest entries is stale; the rest
+        # of the cache is untouched. Batch transforms and the store identity are out of scope
+        # (the cache_dir path is the dataset identity -- see the class docstring).
+        self._pipeline_fp: dict[str, str] = {}
         if self._persistent:
-            self._pipeline_fp = hashlib.sha256(
-                "\n".join(_transform_token(t) for t in self._chunk_transforms).encode()
-            ).hexdigest()
+            self._pipeline_fp = {
+                path: _pipeline_hash(pipeline)
+                for path, pipeline in self._transforms_by_path.items()
+            }
             if _has_weak_token(self._chunk_transforms):
                 logger.warning(
                     "persist: cloudpickle not installed and a chunk_transform has no "
@@ -1474,11 +1545,15 @@ class ChunkPool:
             self._cv.notify_all()
 
     def _apply_transforms(self, array: str, chunk_index: int, data: np.ndarray) -> np.ndarray:
-        if not self._chunk_transforms:
+        """Run the transforms scoped to this array, in order. Off-scope transforms are not
+        called at all -- the no-op pass over a variable a transform does not understand is
+        gone, and so is any chance of it acting on one it was not given."""
+        pipeline = self._transforms_by_path[array]
+        if not pipeline:
             return data
         offset = chunk_index * self._by_path[array].sample_chunk_size
         chunk = DecodedChunk(read=ChunkRead(array, chunk_index), data=data, sample_offset=offset)
-        for transform in self._chunk_transforms:  # vectorized numpy -> GIL released
+        for transform in pipeline:  # vectorized numpy -> GIL released
             chunk = transform(chunk)
         return chunk.data
 
@@ -1630,8 +1705,16 @@ class ChunkPool:
             self._recorded.add(key)
 
     def _append_entry(self, array: str, chunk_index: int, fname: str) -> None:  # under the lock
-        """Append one completed-entry line to the open log."""
-        self._write_line({"array": array, "chunk_index": chunk_index, "file": fname})
+        """Append one completed-entry line to the open log, stamped with **this array's**
+        pipeline hash -- so a later run can tell which arrays a transform edit invalidated."""
+        self._write_line(
+            {
+                "array": array,
+                "chunk_index": chunk_index,
+                "file": fname,
+                "pipeline": self._pipeline_fp[array],
+            }
+        )
 
     def _write_line(self, record: dict[str, object]) -> None:
         """Append one JSON record as a **single** ``os.write`` on an ``O_APPEND`` fd.
@@ -1669,17 +1752,25 @@ class ChunkPool:
         fresh = not path.exists()
         self._log_fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
         if fresh:
-            self._write_line(
-                {"format_version": self._MANIFEST_FORMAT, "pipeline_hash": self._pipeline_fp}
-            )
+            self._write_line({"format_version": self._MANIFEST_FORMAT})
 
     def _load_log(self) -> None:
         """Populate the persisted-entry registry from a prior run's append-only log, if any.
 
-        No log is a cold start (silent -- the expected first run). A log whose header ``format``
-        or ``pipeline_hash`` differs from this run is a **stale** cache: by default that *raises*
-        (a stale cache is almost never what the user intended), or -- with ``reset_stale_cache``
-        -- it deletes the listed files + the log and rebuilds (see :meth:`_reset_stale`).
+        No log is a cold start (silent -- the expected first run). Staleness is decided **per
+        array** (#42): an entry carries the pipeline hash of the array it belongs to, and an
+        array whose hash differs from this run's is stale on its own, leaving every other
+        array's entries valid. Two consequences worth stating, because they are what makes the
+        partial answer usable:
+
+        - an array with **no entries** is *cold*, not stale -- adding a variable to a
+          configuration must not invalidate the cache;
+        - an array this run does **not read** is left completely alone (entries and files), so
+          two configurations can share one ``cache_dir``.
+
+        A stale array raises by default, naming which arrays and why; ``reset_stale_cache``
+        instead deletes exactly those arrays' files. Only the log *format* is still all-or-
+        nothing -- a format we cannot parse tells us nothing about any individual array.
 
         Corruption always raises, regardless of the flag: an unreadable header, a malformed
         *interior* entry, or a ``file`` that is not a bare filename (an absolute or ``..`` path
@@ -1694,25 +1785,54 @@ class ChunkPool:
         if not lines:
             return  # header not yet flushed (a crash before the first write) -- treat as cold
         try:
-            header = json.loads(lines[0])
-            fmt, fp = header["format_version"], header["pipeline_hash"]
+            fmt = json.loads(lines[0])["format_version"]
         except (json.JSONDecodeError, TypeError, KeyError) as exc:
             raise ValueError(
                 f"persist: cache log {path} has an unreadable header ({exc}); this is corruption "
                 f"or tampering, not a stale cache -- delete {self._dir} to reset."
             ) from exc
         entry_lines = lines[1:]
-        if fmt != self._MANIFEST_FORMAT or fp != self._pipeline_fp:
-            why = "log format" if fmt != self._MANIFEST_FORMAT else "chunk_transform fingerprint"
-            self._reset_stale(path, entry_lines, why)
+        if fmt != self._MANIFEST_FORMAT:
+            # The one whole-cache case left: a log we cannot parse says nothing about any
+            # individual array, so there is no subset to keep.
+            self._reset_stale_format(path, entry_lines)
             return
+        records, torn = self._parse_entries(path, entry_lines)
+        stale = {
+            r["array"]
+            for r in records
+            if r["array"] in self._pipeline_fp and r["pipeline"] != self._pipeline_fp[r["array"]]
+        }
+        survivors = records
+        if stale:
+            survivors = self._drop_stale_arrays(records, stale)
+        for rec in survivors:
+            key = (str(rec["array"]), int(rec["chunk_index"]))
+            self._persisted[key] = str(rec["file"])
+            self._recorded.add(key)
+        # Compact only when something was actually dropped. Rewriting an unchanged log every
+        # open would be pure write traffic, and it is exactly the sort of churn a user watching
+        # an NVMe cache would have to explain to themselves.
+        if not self._readonly and (len(survivors) != len(records) or torn):
+            self._compact(path, survivors)
+        self.manifest_entries = sum(1 for a, _ in self._persisted if a in self._by_path)
+
+    def _parse_entries(self, path: Path, entry_lines: list[str]) -> tuple[list[dict], bool]:
+        """Validate every entry line; return the records and whether a torn tail was dropped.
+
+        Records for arrays this run does not read are parsed and kept like any other: they are
+        another configuration's entries in a shared directory, and dropping them on the floor
+        would delete that run's cache the next time we compact.
+        """
+        records: list[dict] = []
         for i, line in enumerate(entry_lines):
             try:
                 rec = json.loads(line)
-                array, chunk_index, fname = rec["array"], int(rec["chunk_index"]), rec["file"]
+                array, chunk_index = str(rec["array"]), int(rec["chunk_index"])
+                fname, pipeline = str(rec["file"]), str(rec["pipeline"])
             except (json.JSONDecodeError, TypeError, KeyError, ValueError) as exc:
                 if i == len(entry_lines) - 1:
-                    break  # torn tail: the crash landed mid-append on the last line -- drop it
+                    return records, True  # torn tail: the crash landed mid-append -- drop it
                 raise ValueError(
                     f"persist: cache log {path} has a malformed entry on line {i + 2} ({exc}); "
                     f"this is corruption or tampering, not a stale cache -- delete {self._dir} "
@@ -1723,24 +1843,86 @@ class ChunkPool:
                     f"persist: cache log {path} entry file {fname!r} is not a bare filename "
                     f"(possible path-traversal tampering); delete {self._dir} to reset."
                 )
-            key = (array, chunk_index)
-            self._persisted[key] = fname
-            self._recorded.add(key)
-        self.manifest_entries = len(self._persisted)
+            records.append(
+                {"array": array, "chunk_index": chunk_index, "file": fname, "pipeline": pipeline}
+            )
+        return records, False
 
-    def _reset_stale(self, path: Path, entry_lines: list[str], why: str) -> None:
-        """A stale cache: raise by default, or (``reset_stale_cache``) GC + rebuild.
+    def _drop_stale_arrays(self, records: list[dict], stale: set[str]) -> list[dict]:
+        """Raise, or (``reset_stale_cache``) GC exactly the stale arrays' files.
 
-        The GC deletes exactly the ``.npy`` files this stale log named -- each re-checked as a
-        bare filename before ``unlink`` (a tampered path is never removed) -- then the log
-        itself. Precise: only files we recorded writing; crash-orphans are already in the log.
+        Precise on both axes: only the arrays whose pipeline changed, and only the ``.npy``
+        files this log named for them (each re-checked as a bare filename before ``unlink``, so
+        a tampered path is never removed). Everything else -- other arrays, other
+        configurations sharing this directory -- is untouched.
+        """
+        assert self._dir is not None
+        if self._readonly:
+            raise ValueError(
+                f"readonly_cache: the cache at {self._dir} is stale for {sorted(stale)} (their "
+                "chunk_transform pipeline changed since it was written). A read-only opener "
+                "may not reset it -- run the writer that warms this cache with the transforms "
+                "you are asking for, or point at the cache that matches them."
+            )
+        if not self._reset_stale_cache:
+            raise ValueError(
+                f"persist: cache at {self._dir} is stale for {sorted(stale)}: the "
+                "chunk_transform pipeline scoped to those arrays changed since they were "
+                "written. Every other array in this cache is still valid. This is not "
+                "corruption -- pass reset_stale_cache=True to delete and rebuild just those "
+                "arrays, or point at a different cache_dir."
+            )
+        survivors = []
+        for rec in records:
+            if rec["array"] not in stale:
+                survivors.append(rec)
+            else:
+                with contextlib.suppress(FileNotFoundError):
+                    os.unlink(self._dir / str(rec["file"]))
+        logger.info(
+            "persist: cache at %s reset for %s (chunk_transform pipeline changed); %d entr(ies) "
+            "for other arrays kept.",
+            self._dir,
+            sorted(stale),
+            len(survivors),
+        )
+        return survivors
+
+    def _compact(self, path: Path, survivors: list[dict]) -> None:
+        """Rewrite the log with only the surviving entries, atomically.
+
+        Written to a temp name and ``rename``d over the log, which POSIX makes atomic: a crash
+        leaves either the old log or the new one, never a half-truncated one. Without
+        compaction a partial reset would re-read (and re-reject) the same stale entries on
+        every subsequent open, and the log would grow without bound across resets.
+
+        Safe only because part 1 of #42 made this an exclusive-writer path: we hold the
+        ``cache_dir`` lock, so no other process is appending to the file we are replacing.
+        The temp name carries ``_TMP_SUFFIX``, so a crash between write and rename leaves a
+        file the next lock holder's :meth:`_sweep_tmp` clears -- the same treatment a
+        half-written chunk file gets.
+        """
+        tmp = path.with_name(f"{path.name}.{os.getpid()}{_TMP_SUFFIX}")
+        body = [json.dumps({"format_version": self._MANIFEST_FORMAT})]
+        body += [json.dumps(rec) for rec in survivors]
+        tmp.write_text("\n".join(body) + "\n")
+        tmp.replace(path)
+
+    def _reset_stale_format(self, path: Path, entry_lines: list[str]) -> None:
+        """A log written by an incompatible manifest format: raise by default, or GC + rebuild.
+
+        Unlike a stale *pipeline* this is whole-cache. We cannot read the entries' meaning, so
+        we cannot decide any array is still valid -- and the ``.npy`` layout itself may have
+        changed (format 3 made chunks tile-major). The GC deletes exactly the files this log
+        named, each re-checked as a bare filename before ``unlink``, then the log.
         """
         assert self._dir is not None
         if not self._reset_stale_cache:
             raise ValueError(
-                f"persist: cache at {self._dir} is stale ({why} changed since it was written). "
-                "This is not corruption -- pass reset_stale_cache=True to delete and rebuild it, "
-                f"or remove {self._dir} yourself."
+                f"persist: cache at {self._dir} is stale (it was written by a different cache "
+                f"log format, which changes the on-disk layout, so none of it can be reused). "
+                "This is not corruption -- pass reset_stale_cache=True to delete and rebuild "
+                f"it, or remove {self._dir} yourself."
             )
         for line in entry_lines:
             try:
@@ -1752,7 +1934,7 @@ class ChunkPool:
                     os.unlink(self._dir / fname)
         with contextlib.suppress(FileNotFoundError):
             os.unlink(path)
-        logger.info("persist: stale cache at %s (%s changed) reset; rebuilding.", self._dir, why)
+        logger.info("persist: stale cache at %s (log format changed) reset; rebuilding.", self._dir)
 
     def close(self) -> None:
         """Free every remaining slot; release the log handle and the cache lock. Persist keeps

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -32,21 +32,22 @@ import logging
 import queue
 import threading
 import time
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Iterator, Sequence
 from typing import TextIO
 
 import numpy as np
 from zarr.abc.store import Store
 
 from .buffers import HostAllocator
-from .pool import ChunkPool, output_geometry
+from .pool import ChunkPool, output_geometry, validate_scopes
 from .runtime import Depths, PassStats, StatsCollector, format_pass
 from .scheduler import Scheduler, SchedulerConfig
 from .shuffle import block_shuffled_order, sequential_order
 from .split import SplitManifest, valid_anchor_range
 from .store import close_store, open_geometries
 from .summary import DatasetReport, describe, print_summary, working_set_bytes
-from .types import ArrayGeometry, Batch, DecodedChunk, SplitName, StoredChunkRead
+from .transforms import BatchTransform, ChunkTransform
+from .types import ArrayGeometry, Batch, SplitName, StoredChunkRead
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +105,11 @@ class InSituDataset:
     - ``chunk_transforms`` -- ``(DecodedChunk) -> DecodedChunk``, run per chunk *before*
       shuffle, seeing **one variable**. The cacheable home for elementwise, per-variable,
       deterministic work (scaling, unit conversion, dtype cast); amortized over every sample
-      in the chunk and reused across epochs.
+      in the chunk and reused across epochs. Restrict one to particular variables with
+      :func:`~insitubatch.transforms.applies` -- ``applies(["2m_temperature"], k_to_c)`` --
+      rather than testing ``chunk.read.array`` inside the transform: a name test in the body
+      is invisible to the engine, which would fold a reshaping transform's declared output
+      into *every* variable's geometry and truncate the ones it does not touch.
     - ``batch_transforms`` -- ``(Batch) -> Batch``, run per assembled batch, seeing **all
       variables** aligned on the sample axis. For cross-variable derived fields and
       per-sample random augmentation; runs after the cache, so it is **never cached**.
@@ -140,8 +145,8 @@ class InSituDataset:
         readonly_cache: bool = False,
         reset_stale_cache: bool = False,
         on_bad_chunk: str = "raise",
-        chunk_transforms: Sequence[Callable[[DecodedChunk], DecodedChunk]] = (),
-        batch_transforms: Sequence[Callable[[Batch], Batch]] = (),
+        chunk_transforms: Sequence[ChunkTransform] = (),
+        batch_transforms: Sequence[BatchTransform] = (),
     ) -> None:
         self.store = store
         self.geometries = geometries if geometries is not None else open_geometries(store)
@@ -194,6 +199,10 @@ class InSituDataset:
         self.prefetch_depth = max(int(prefetch_depth), 1)
         self.chunk_transforms = tuple(chunk_transforms)
         self.batch_transforms = tuple(batch_transforms)
+        # A transform scoped with `applies` to an array this dataset does not have is a
+        # user error, and every geometry below is derived from the scopes -- so check them
+        # first, before a wrong shape can propagate into a report or a cache slot.
+        validate_scopes(self.chunk_transforms, {g.path for g in self.geometries.values()})
         # Geometry each variable presents *after* the chunk_transform pipeline (regrid / dtype
         # recast). What the consumer and the framework adapters see, and what sizes the cache.
         self._out_geometries = {

--- a/src/insitubatch/summary.py
+++ b/src/insitubatch/summary.py
@@ -27,6 +27,7 @@ import numpy as np
 from .pool import slot_charge_bytes
 from .shuffle import shuffle_quality
 from .split import SplitManifest
+from .transforms import transform_scope, unwrap_transform
 from .types import ArrayGeometry, SplitName
 
 if TYPE_CHECKING:  # pragma: no cover - typing only, keeps summary importable from source
@@ -405,7 +406,14 @@ def describe(ds: InSituDataset, *, iterations: int = 1) -> DatasetReport:
 
 
 def _name(fn: object) -> str:
-    return getattr(fn, "__name__", type(fn).__name__)
+    """A transform's display name, with its scope when it has one.
+
+    ``kelvin_to_celsius[2m_temperature]`` -- the report exists to say what a configuration
+    will do, and "which variables does this transform touch" is now part of that."""
+    scope = transform_scope(fn) if callable(fn) else None
+    base = unwrap_transform(fn) if scope is not None else fn  # type: ignore[arg-type]
+    label = getattr(base, "__name__", type(base).__name__)
+    return label if scope is None else f"{label}[{','.join(sorted(scope))}]"
 
 
 def _bytes(n: int) -> str:

--- a/src/insitubatch/summary.py
+++ b/src/insitubatch/summary.py
@@ -409,7 +409,7 @@ def _name(fn: object) -> str:
     """A transform's display name, with its scope when it has one.
 
     ``kelvin_to_celsius[2m_temperature]`` -- the report exists to say what a configuration
-    will do, and "which variables does this transform touch" is now part of that."""
+    will do, and that includes which variables each transform touches."""
     scope = transform_scope(fn) if callable(fn) else None
     base = unwrap_transform(fn) if scope is not None else fn  # type: ignore[arg-type]
     label = getattr(base, "__name__", type(base).__name__)

--- a/src/insitubatch/transforms.py
+++ b/src/insitubatch/transforms.py
@@ -110,7 +110,7 @@ def applies(arrays: Sequence[str], transform: ChunkTransform) -> ChunkTransform:
 
         InSituDataset(..., chunk_transforms=[
             applies(["2m_temperature"], kelvin_to_celsius),
-            Coarsen(2),                    # bare = every array, as before
+            Coarsen(2),                    # bare = every array
         ])
 
     Declaring scope here rather than with an ``if chunk.read.array == ...`` inside the
@@ -118,13 +118,17 @@ def applies(arrays: Sequence[str], transform: ChunkTransform) -> ChunkTransform:
     folds a reshaping transform's ``output_inner`` into *every* array's declared geometry.
     The unaffected arrays are then gathered as truncated prefixes of themselves and can
     never revive from cache -- with no exception raised. Scope also enters the cache
-    fingerprint per array, so editing one variable's transform no longer invalidates the
-    rest.
+    fingerprint per array, so editing one variable's transform leaves the rest valid.
+
+    Scope is matched against the zarr array **path**. Two labels that alias one array
+    (``t2m_now`` / ``t2m_next``) therefore share one chunk pipeline; per-label work belongs in
+    a ``batch_transform``.
 
     A transform may be *parameterized* by variable (a fitted scaler's statistics
     legitimately are) but must not decide whether it runs. If it can validate a declared
     scope -- :class:`StandardScaler` checks the names against its own stats dict -- it
-    defines ``validate_scope(arrays)`` and this calls it now, not in a decode thread.
+    defines ``validate_scope(arrays)``, which this calls at construction rather than leaving
+    it to fail in a decode thread.
     """
     if isinstance(arrays, str):
         raise TypeError(
@@ -175,11 +179,24 @@ class StandardScaler:
     (which also warms the cache) and scale at the *batch* stage -- see
     ``examples/fit_scaler.py``; this class is the *chunk*-stage applier for when you
     want the normalization cached with the decoded chunk.
+
+    **Give a re-fitted scaler a new ``cache_key`` if you persist the cache without
+    cloudpickle.** The fallback fingerprint hashes this class's source plus its ``repr``, and
+    numpy summarizes an array over 1000 elements in ``repr`` -- so per-gridpoint statistics
+    (say ``(721, 1440)``) repr identically whatever their values, and a re-fit reopens a
+    persisted cache as a *hit*, serving chunks normalized with the old numbers. Any of three
+    closes the hole: install ``insitubatch[cache]`` (cloudpickle hashes the values), pass
+    ``cache_key="<stats version>"`` and bump it on every fit, or keep stats small enough to
+    repr in full.
     """
 
     mean: dict[str, np.ndarray]
     std: dict[str, np.ndarray]
     eps: float = 1e-8
+    cache_key: str | None = None
+    """The identity this scaler declares to the cache fingerprint, and the only one that is
+    exact: the fallback hashes ``repr``, which numpy summarizes for large statistics. ``None``
+    (the default) leaves identity to the fingerprint's own resolution."""
 
     def __call__(self, chunk: DecodedChunk) -> DecodedChunk:
         m = self.mean[chunk.read.array]

--- a/src/insitubatch/transforms.py
+++ b/src/insitubatch/transforms.py
@@ -12,10 +12,15 @@ stages; ``device_transform`` lives in the framework adapters (M2/M3).
 
 Rule of thumb: per-variable + per-chunk + deterministic -> chunk stage;
 cross-variable or per-sample-random -> batch stage; cross-chunk -> not supported.
+
+**Scope is declared at the call site**, with :func:`applies` -- never by a name test inside
+the transform's body. "Subtract 273.15" is a fact about Kelvin; "``2m_temperature`` is in
+Kelvin" is a fact about *your store*, and only the call site knows it.
 """
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol, runtime_checkable
@@ -29,7 +34,7 @@ from .types import ArrayGeometry, Batch, DecodedChunk
 class ChunkTransform(Protocol):
     """Per-chunk transform applied before shuffle/gather (cacheable)."""
 
-    def __call__(self, chunk: DecodedChunk) -> DecodedChunk: ...
+    def __call__(self, chunk: DecodedChunk, /) -> DecodedChunk: ...
 
 
 @runtime_checkable
@@ -60,7 +65,100 @@ class ReshapingChunkTransform(ChunkTransform, Protocol):
 class BatchTransform(Protocol):
     """Per-batch transform applied after gather (not cached)."""
 
-    def __call__(self, batch: Batch) -> Batch: ...
+    def __call__(self, batch: Batch, /) -> Batch: ...
+
+
+# -- scope: which arrays a chunk_transform applies to ------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _Scoped:
+    """One chunk_transform, restricted to a set of array paths. Built by :func:`applies`.
+
+    The engine reads ``arrays`` directly: it skips the call for an array outside the scope,
+    and -- the part a name test in ``__call__`` cannot provide -- it excludes the transform
+    from those arrays' *declared output geometry* and from their *cache fingerprint*.
+    """
+
+    arrays: frozenset[str]
+    transform: ChunkTransform
+
+    def __call__(self, chunk: DecodedChunk) -> DecodedChunk:
+        return self.transform(chunk)
+
+
+@dataclass(frozen=True, slots=True)
+class _ScopedReshaping(_Scoped):
+    """A scoped :class:`ReshapingChunkTransform`.
+
+    ``output_inner`` exists as a *separate class* rather than a delegating method on
+    :class:`_Scoped`, because the engine detects a reshaping transform by
+    ``hasattr(t, "output_inner")``: a wrapper that always defined it would make every
+    shape-preserving transform claim to reshape.
+    """
+
+    def output_inner(self, geom: ArrayGeometry) -> tuple[tuple[int, ...], np.dtype]:
+        return self.transform.output_inner(geom)  # type: ignore[attr-defined]
+
+
+def applies(arrays: Sequence[str], transform: ChunkTransform) -> ChunkTransform:
+    """Restrict a ``chunk_transform`` to the named arrays; every other array passes through.
+
+    ``arrays`` are zarr array **paths** (what ``open_geometries`` keys on, and what
+    ``chunk.read.array`` carries) -- not dict labels, since two labels may alias one array
+    (``t2m_now`` / ``t2m_next``). Unknown names raise at dataset construction::
+
+        InSituDataset(..., chunk_transforms=[
+            applies(["2m_temperature"], kelvin_to_celsius),
+            Coarsen(2),                    # bare = every array, as before
+        ])
+
+    Declaring scope here rather than with an ``if chunk.read.array == ...`` inside the
+    transform is not a style preference: an in-body gate is invisible to the engine, which
+    folds a reshaping transform's ``output_inner`` into *every* array's declared geometry.
+    The unaffected arrays are then gathered as truncated prefixes of themselves and can
+    never revive from cache -- with no exception raised. Scope also enters the cache
+    fingerprint per array, so editing one variable's transform no longer invalidates the
+    rest.
+
+    A transform may be *parameterized* by variable (a fitted scaler's statistics
+    legitimately are) but must not decide whether it runs. If it can validate a declared
+    scope -- :class:`StandardScaler` checks the names against its own stats dict -- it
+    defines ``validate_scope(arrays)`` and this calls it now, not in a decode thread.
+    """
+    if isinstance(arrays, str):
+        raise TypeError(
+            f"applies() takes a sequence of array names, not the bare string {arrays!r} -- "
+            f'a string would scope to its characters. Write applies(["{arrays}"], ...).'
+        )
+    scope = frozenset(arrays)
+    if not scope:
+        raise ValueError(
+            "applies() was given an empty scope, so the transform would never run. Drop it "
+            "from chunk_transforms instead, or name the arrays it applies to."
+        )
+    check = getattr(transform, "validate_scope", None)
+    if check is not None:
+        check(scope)
+    if hasattr(transform, "output_inner"):
+        return _ScopedReshaping(scope, transform)
+    return _Scoped(scope, transform)
+
+
+def transform_scope(transform: ChunkTransform) -> frozenset[str] | None:
+    """The array paths ``transform`` is restricted to, or ``None`` for "every array"."""
+    return transform.arrays if isinstance(transform, _Scoped) else None
+
+
+def unwrap_transform(transform: ChunkTransform) -> ChunkTransform:
+    """The user's own callable, with any :func:`applies` wrapper removed.
+
+    The cache fingerprint hashes *this*, never the wrapper: scope already selects which
+    transforms enter an array's hash, so folding it into the token as well would invalidate
+    the variable that **stayed** in scope every time another one left it."""
+    while isinstance(transform, _Scoped):
+        transform = transform.transform
+    return transform
 
 
 @dataclass(slots=True)
@@ -88,6 +186,20 @@ class StandardScaler:
         s = self.std[chunk.read.array]
         chunk.data = (chunk.data - m) / (s + self.eps)
         return chunk
+
+    def validate_scope(self, arrays: frozenset[str]) -> None:
+        """Reject a scope this scaler has no statistics for (called by :func:`applies`).
+
+        ``applies(["u10"], scaler_fitted_on_t2m)`` would otherwise ``KeyError`` inside a
+        decode thread, one chunk into training. The stats dict may be *wider* than the
+        scope -- one fitted scaler shared by several scoped uses is normal."""
+        missing = sorted(arrays - (self.mean.keys() | self.std.keys()))
+        if missing:
+            raise ValueError(
+                f"StandardScaler has no mean/std for {missing}; it was fitted for "
+                f"{sorted(self.mean.keys() & self.std.keys())}. Fit those variables, or "
+                "scope this scaler to the ones it knows."
+            )
 
     def save(self, path: str | Path) -> None:
         flat = {f"{k}.mean": v for k, v in self.mean.items()}

--- a/tests/test_chunked_slots.py
+++ b/tests/test_chunked_slots.py
@@ -257,7 +257,7 @@ def test_a_version_2_cache_is_rejected_not_misread(tmp_path):
     log.write_text("\n".join([json.dumps(header), *lines[1:]]) + "\n")
 
     # Loud by design: a stale cache is a user decision, not something to silently discard.
-    with pytest.raises(ValueError, match="stale .log format changed"):
+    with pytest.raises(ValueError, match="stale .*log format"):
         ChunkPool(geoms, backing_dir=cache, persist=True)
 
     # ...and with consent it resets and refetches rather than reinterpreting v2 bytes.

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,0 +1,162 @@
+"""Unit tests for the cross-run cache fingerprint: ``_transform_token`` per transform and
+``_pipeline_hash`` per array.
+
+The round-trip behaviour these underpin -- a reopened pool hitting or raising -- is covered
+in ``test_pool.py`` (``cache_key`` precedence, cloudpickle vs source, an edited body) and
+``test_transform_scope.py`` (which arrays a transform edit invalidates). What is pinned here
+is the hash itself, because every one of these properties is a claim the docstrings make and
+a silent wrong-data bug if it stops holding.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+from insitubatch.pool import _pipeline_hash, _transform_token, transforms_for
+from insitubatch.transforms import StandardScaler, applies
+
+
+@pytest.fixture
+def source_path(monkeypatch):
+    """Force the best-effort source hash -- the fallback when cloudpickle is absent."""
+    monkeypatch.setattr("insitubatch.pool.cloudpickle", None)
+
+
+def scale(chunk):
+    chunk.data = chunk.data * 2.0
+    return chunk
+
+
+def shift(chunk):
+    chunk.data = chunk.data + 1.0
+    return chunk
+
+
+@dataclass
+class Coarsen:
+    """A configured, class-based transform with a stable dataclass repr."""
+
+    factor: int = 2
+
+    def __call__(self, chunk):
+        return chunk
+
+
+class Plain:
+    """A callable instance with the *default* repr -- the one carrying a memory address."""
+
+    def __call__(self, chunk):
+        return chunk
+
+
+# -- one transform's token --------------------------------------------------
+
+
+def test_cache_key_outranks_everything(source_path):
+    """The declared key is the whole token: nothing about the body or config can override it."""
+
+    def declared(chunk):
+        return chunk
+
+    declared.cache_key = "v1"
+    assert _transform_token(declared) == "key:v1"
+
+
+def test_scope_is_not_in_the_token():
+    """`applies` is stripped before hashing. Two scopes of one transform are one identity --
+    which is what lets narrowing a scope invalidate the variable that left and no other."""
+    bare = _transform_token(scale)
+    assert _transform_token(applies(["a"], scale)) == bare
+    assert _transform_token(applies(["b", "c"], scale)) == bare
+
+
+def test_a_callable_instance_hashes_by_class_not_by_address(source_path):
+    """Two separately constructed instances must hash alike, or every reopen is a spurious
+    miss: the default ``repr`` embeds an address that differs per object and per process."""
+    assert _transform_token(Plain()) == _transform_token(Plain())
+
+
+def test_instance_config_still_reaches_the_token(source_path):
+    """A stable dataclass repr is folded in, so a reconfigured transform is a different one."""
+    assert _transform_token(Coarsen(2)) == _transform_token(Coarsen(2))
+    assert _transform_token(Coarsen(2)) != _transform_token(Coarsen(3))
+
+
+def test_the_hashing_method_is_encoded_in_the_token(monkeypatch):
+    """Toggling cloudpickle re-computes rather than falsely matching: the two methods cannot
+    collide, because the token carries which one produced it."""
+    pytest.importorskip("cloudpickle")
+    pickled = _transform_token(scale)
+    monkeypatch.setattr("insitubatch.pool.cloudpickle", None)
+    sourced = _transform_token(scale)
+    assert pickled.startswith("pickle:") and sourced.startswith("src:")
+    assert pickled != sourced
+
+
+def test_large_statistics_are_invisible_to_the_source_fallback(source_path):
+    """A documented hole, pinned so it cannot widen unnoticed (docs/architecture.md).
+
+    numpy summarizes an array over 1000 elements in ``repr``, so a re-fitted scaler carrying
+    per-gridpoint stats hashes identically to the values it replaced -- a persisted cache
+    reopens as a hit, serving the old normalization. An explicit ``cache_key`` closes it.
+    """
+    old = np.arange(2000.0)
+    new = old.copy()
+    new[500] = 999.0
+    ones = {"a": np.ones(1)}
+    assert repr(old) == repr(new), "numpy stopped summarizing -- re-check the docs claim"
+    assert _transform_token(StandardScaler({"a": old}, ones)) == _transform_token(
+        StandardScaler({"a": new}, ones)
+    )
+    assert _transform_token(
+        StandardScaler({"a": old}, ones, cache_key="fit-1")
+    ) != _transform_token(StandardScaler({"a": new}, ones, cache_key="fit-2"))
+
+
+def test_cloudpickle_sees_the_statistics_the_repr_hides():
+    """The recommended fix works: cloudpickle hashes the values, not their summary."""
+    pytest.importorskip("cloudpickle")
+    old = np.arange(2000.0)
+    new = old.copy()
+    new[500] = 999.0
+    ones = {"a": np.ones(1)}
+    assert _transform_token(StandardScaler({"a": old}, ones)) != _transform_token(
+        StandardScaler({"a": new}, ones)
+    )
+
+
+# -- one array's pipeline hash ----------------------------------------------
+
+
+def test_pipeline_hash_is_ordered():
+    """Composition is not commutative, so the identity of the pipeline must not be either."""
+    assert _pipeline_hash([scale, shift]) != _pipeline_hash([shift, scale])
+
+
+def test_pipeline_hash_is_stable_and_fixed_width():
+    """16 hex chars, deterministic -- the manifest's ``pipeline`` field is compared verbatim."""
+    once = _pipeline_hash([scale])
+    assert once == _pipeline_hash([scale])
+    assert len(once) == 16 and len(_pipeline_hash([])) == 16
+
+
+def test_an_empty_pipeline_is_an_identity_like_any_other():
+    """An array no transform touches hashes to a stable value distinct from any pipeline's:
+    it invalidates once when it leaves every scope, then stays valid across reopens."""
+    assert _pipeline_hash([]) == _pipeline_hash([])
+    assert _pipeline_hash([]) != _pipeline_hash([scale])
+
+
+def test_scope_reaches_the_hash_through_membership_not_the_token():
+    """The two halves together, through the one function that resolves scope: membership
+    decides *which* transforms enter an array's hash, and each token is scope-free. Narrowing
+    a scope therefore changes the hash of the array that left it, and of no other."""
+    wide = [applies(["a", "b"], scale), shift]
+    narrow = [applies(["a"], scale), shift]
+    assert _pipeline_hash(transforms_for("a", wide)) == _pipeline_hash(
+        transforms_for("a", narrow)
+    ), "a kept the same transforms -- its cached bytes are still valid"
+    assert _pipeline_hash(transforms_for("b", wide)) != _pipeline_hash(
+        transforms_for("b", narrow)
+    ), "b lost one -- its cached bytes were transformed by a pipeline no longer configured"

--- a/tests/test_transform_scope.py
+++ b/tests/test_transform_scope.py
@@ -1,0 +1,442 @@
+"""Per-variable transform scope (``applies``) and per-array cache identity (#42, part 2).
+
+Two properties, one mechanism. Scoping a ``chunk_transform`` at the call site rather than
+inside its body makes the scope **visible to the engine**, which fixes two things a name
+gate in ``__call__`` cannot:
+
+- **Geometry.** ``output_geometry`` folds every transform's ``output_inner`` into every
+  variable. With an in-body gate a transform that halves ``a`` also makes the engine believe
+  ``b`` is halved -- ``b`` is then gathered truncated and can never revive from cache. No
+  exception is raised: right shape, right dtype, wrong numbers.
+- **Cache identity.** The manifest stamped one fingerprint of the *whole* pipeline on every
+  array's entries, so editing ``t2m``'s transform invalidated ``u10`` and ``v10`` too, whose
+  bytes had not changed. The hash is now per array, over the transforms that apply *to it*.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import numpy as np
+import pytest
+import zarr
+from test_pool import _decode_tiles, _fill_chunk  # shared tiled-store helpers (pytest rootdir)
+
+from insitubatch import (
+    StandardScaler,
+    applies,
+    ensure_local_dir,
+    obstore_store,
+    open_geometries,
+    split_by_chunk,
+)
+from insitubatch.pool import _TMP_SUFFIX, ChunkPool, output_geometry
+from insitubatch.source import InSituDataset
+from insitubatch.types import ArrayGeometry
+
+SHAPE = (4, 8)
+VARS = ("a", "b", "c")
+
+
+@pytest.fixture
+def three_vars(tmp_path):
+    """Three same-shaped single-tile arrays; return (url, {var: source})."""
+    url = f"file://{tmp_path}/three.zarr"
+    ensure_local_dir(url)
+    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
+    srcs = {}
+    for i, var in enumerate(VARS):
+        arr = group.create_array(var, shape=SHAPE, chunks=(2, 8), dtype="f4")
+        arr[:] = np.arange(int(np.prod(SHAPE)), dtype="f4").reshape(SHAPE) + i * 100
+        srcs[var] = np.asarray(arr[:])
+    return url, srcs
+
+
+class HalveLastAxis:
+    """A reshaping transform: block-mean pairs on the last inner axis, ``(n, 8) -> (n, 4)``."""
+
+    def __call__(self, chunk):
+        chunk.data = chunk.data.reshape(chunk.data.shape[0], -1, 2).mean(axis=-1)
+        return chunk
+
+    def output_inner(self, geom: ArrayGeometry) -> tuple[tuple[int, ...], np.dtype]:
+        return (geom.inner_shape[0] // 2,), geom.dtype
+
+
+def _geoms(url, variables=VARS):
+    return open_geometries(obstore_store(url), variables=list(variables))
+
+
+def _gather_all(pool, var, geom, tiles, owner):
+    _fill_chunk(pool, var, 0, geom, tiles, owner)
+    spc = geom.sample_chunk_size
+    rows = np.array([[0, w] for w in range(spc)], dtype=np.int64)
+    return pool.gather(rows, [var], spc).arrays[var]
+
+
+# -- geometry: the correctness half -----------------------------------------
+
+
+def test_scoped_reshape_does_not_reshape_the_other_variables(three_vars):
+    """The regression the issue reported: a reshaping transform scoped to ``a`` must leave
+    ``b``'s declared geometry alone. Fold it into every variable and ``b`` is gathered as a
+    truncated prefix of itself -- silent, plausible-looking corruption."""
+    url, srcs = three_vars
+    geoms = _geoms(url)
+    scoped = [applies(["a"], HalveLastAxis())]
+    assert output_geometry(geoms["a"], scoped).inner_shape == (4,)
+    assert output_geometry(geoms["b"], scoped).inner_shape == (8,)
+
+    pool = ChunkPool(geoms, chunk_transforms=scoped)
+    owner = pool.new_owner()
+    for var in ("a", "b"):
+        tiles = asyncio.run(_decode_tiles(url, var))
+        got = _gather_all(pool, var, geoms[var], tiles, owner)
+        expect = srcs[var][:2]
+        if var == "a":
+            expect = expect.reshape(2, -1, 2).mean(axis=-1)
+        np.testing.assert_allclose(got, expect)
+    pool.close()
+
+
+def test_scoped_transform_is_not_called_off_scope(three_vars):
+    """Off-scope arrays skip the call entirely -- the wasted no-op pass is gone, and a
+    transform that would raise on a variable it does not understand never sees it."""
+    url, _ = three_vars
+    geoms = _geoms(url)
+    seen = []
+
+    def only_a(chunk):
+        seen.append(chunk.read.array)
+        return chunk
+
+    pool = ChunkPool(geoms, chunk_transforms=[applies(["a"], only_a)])
+    owner = pool.new_owner()
+    for var in ("a", "b"):
+        tiles = asyncio.run(_decode_tiles(url, var))
+        _fill_chunk(pool, var, 0, geoms[var], tiles, owner)
+    assert seen == ["a"]
+    pool.close()
+
+
+def test_unscoped_transform_still_applies_to_every_variable(three_vars):
+    """A bare transform is unchanged from today: every variable, as before."""
+    url, srcs = three_vars
+    geoms = _geoms(url)
+
+    def double(chunk):
+        chunk.data = chunk.data * 2.0
+        return chunk
+
+    pool = ChunkPool(geoms, chunk_transforms=[double])
+    owner = pool.new_owner()
+    for var in ("a", "b"):
+        tiles = asyncio.run(_decode_tiles(url, var))
+        got = _gather_all(pool, var, geoms[var], tiles, owner)
+        np.testing.assert_allclose(got, srcs[var][:2] * 2.0)
+    pool.close()
+
+
+def test_scope_names_an_unknown_array_raises_at_construction(three_vars):
+    """A misspelled variable name is caught before any work -- and before any cache file or
+    lock exists. Silently applying to nothing is how a scaler quietly stops scaling."""
+    url, _ = three_vars
+    geoms = _geoms(url)
+
+    def noop(chunk):
+        return chunk
+
+    with pytest.raises(ValueError, match="t2m.*not.*arrays|unknown"):
+        ChunkPool(geoms, chunk_transforms=[applies(["t2m"], noop)])
+
+
+def test_applies_rejects_a_bare_string(three_vars):
+    """``applies("a", fn)`` would scope to the *characters* of the name. Reject it with the
+    fix in the message rather than accepting a second spelling of the argument."""
+
+    def noop(chunk):
+        return chunk
+
+    with pytest.raises(TypeError, match=r"\[.*\]|sequence"):
+        applies("a", noop)  # type: ignore[arg-type]
+
+
+# -- cache identity: the per-array fingerprint ------------------------------
+
+
+def _persist_pool(geoms, backing, transforms, **kw):
+    return ChunkPool(geoms, backing_dir=backing, persist=True, chunk_transforms=transforms, **kw)
+
+
+def _warm(url, geoms, backing, transforms, variables=VARS, **kw):
+    pool = _persist_pool(geoms, backing, transforms, **kw)
+    owner = pool.new_owner()
+    for var in variables:
+        tiles = asyncio.run(_decode_tiles(url, var))
+        _fill_chunk(pool, var, 0, geoms[var], tiles, owner)
+    pool.close()
+    return pool
+
+
+def test_editing_one_variables_transform_keeps_the_others_entries(three_vars, tmp_path):
+    """The headline. Editing the transform scoped to ``a`` invalidates ``a`` and nothing
+    else: ``b`` and ``c``'s bytes did not change, so their entries stay valid."""
+    url, _ = three_vars
+    geoms = _geoms(url)
+    backing = tmp_path / "cache"
+
+    def scale_a(chunk):
+        chunk.data = chunk.data * 2.0
+        return chunk
+
+    def scale_a_edited(chunk):
+        chunk.data = chunk.data * 3.0
+        return chunk
+
+    _warm(url, geoms, backing, [applies(["a"], scale_a)])
+
+    # Only `a` is stale. Default is still raise -- but the message must name which.
+    with pytest.raises(ValueError, match=r"stale.*'a'|'a'.*stale"):
+        _persist_pool(geoms, backing, [applies(["a"], scale_a_edited)])
+
+    reopened = _persist_pool(
+        geoms, backing, [applies(["a"], scale_a_edited)], reset_stale_cache=True
+    )
+    owner = reopened.new_owner()
+    assert not reopened.pin_if_ready("a", 0, owner), "a's entry must be dropped"
+    assert reopened.pin_if_ready("b", 0, owner), "b's entry must survive"
+    assert reopened.pin_if_ready("c", 0, owner), "c's entry must survive"
+    reopened.close()
+
+
+def test_reset_stale_deletes_only_the_stale_arrays_files(three_vars, tmp_path):
+    """``reset_stale_cache`` is now precise: it unlinks the stale array's ``.npy`` and leaves
+    the others on disk. Wiping the whole directory would throw away work that is still valid."""
+    url, _ = three_vars
+    backing = tmp_path / "cache"
+    geoms = _geoms(url)
+
+    def scale_a(chunk):
+        chunk.data = chunk.data * 2.0
+        return chunk
+
+    def scale_a_edited(chunk):
+        chunk.data = chunk.data * 3.0
+        return chunk
+
+    warm = _warm(url, geoms, backing, [applies(["a"], scale_a)])
+    files = {var: backing / warm._persisted[(var, 0)] for var in VARS}
+    assert all(p.exists() for p in files.values())
+
+    reset = _persist_pool(geoms, backing, [applies(["a"], scale_a_edited)], reset_stale_cache=True)
+    reset.close()
+    assert not files["a"].exists(), "the stale array's file must be GC'd"
+    assert files["b"].exists() and files["c"].exists(), "valid arrays keep their files"
+
+
+def test_a_new_variable_over_an_existing_cache_is_cold_not_stale(three_vars, tmp_path):
+    """An array with **no entries** has nothing to disagree with: it is a cold start for that
+    array, not a stale cache. Raising here would make adding a variable a wipe."""
+    url, _ = three_vars
+    backing = tmp_path / "cache"
+
+    def double(chunk):
+        chunk.data = chunk.data * 2.0
+        return chunk
+
+    _warm(url, _geoms(url, ["a", "b"]), backing, [double], variables=("a", "b"))
+
+    all_three = _geoms(url)
+    pool = _persist_pool(all_three, backing, [double])  # must NOT raise
+    owner = pool.new_owner()
+    assert pool.pin_if_ready("a", 0, owner) and pool.pin_if_ready("b", 0, owner)
+    assert not pool.pin_if_ready("c", 0, owner)  # cold: fetched this run
+    pool.close()
+
+
+def test_an_array_this_run_does_not_read_keeps_its_files(three_vars, tmp_path):
+    """Two configurations may share one cache_dir. A run that reads only ``a`` must not
+    delete -- or forget -- ``b``'s entries just because it cannot check them."""
+    url, _ = three_vars
+    backing = tmp_path / "cache"
+
+    def double(chunk):
+        chunk.data = chunk.data * 2.0
+        return chunk
+
+    warm = _warm(url, _geoms(url), backing, [double])
+    b_file = backing / warm._persisted[("b", 0)]
+
+    only_a = _persist_pool(_geoms(url, ["a"]), backing, [double])
+    only_a.close()
+    assert b_file.exists(), "an untouched array's cache file must survive"
+
+    back = _persist_pool(_geoms(url), backing, [double])
+    owner = back.new_owner()
+    assert back.pin_if_ready("b", 0, owner), "and its manifest entry must survive too"
+    back.close()
+
+
+def test_narrowing_a_scope_invalidates_only_the_variable_that_left(three_vars, tmp_path):
+    """Scope is not folded into a transform's own token: the array that *stays* in scope
+    hashes identically, and only the one that left is stale."""
+    url, _ = three_vars
+    backing = tmp_path / "cache"
+    geoms = _geoms(url)
+
+    def double(chunk):
+        chunk.data = chunk.data * 2.0
+        return chunk
+
+    _warm(url, geoms, backing, [applies(["a", "b"], double)])
+
+    with pytest.raises(ValueError, match=r"'b'") as exc:
+        _persist_pool(geoms, backing, [applies(["a"], double)])
+    assert "'a'" not in str(exc.value), "a's pipeline is unchanged -- it must not be stale"
+
+    narrowed = _persist_pool(geoms, backing, [applies(["a"], double)], reset_stale_cache=True)
+    owner = narrowed.new_owner()
+    assert narrowed.pin_if_ready("a", 0, owner)
+    assert not narrowed.pin_if_ready("b", 0, owner)
+    narrowed.close()
+
+
+def test_stale_reset_compacts_the_log(three_vars, tmp_path):
+    """The log is rewritten on load when entries are dropped -- atomically, via a temp name
+    and a rename. Without compaction the stale entries would be re-read (and re-rejected)
+    on every subsequent open, and the log would grow without bound."""
+    url, _ = three_vars
+    backing = tmp_path / "cache"
+    geoms = _geoms(url)
+    log = backing / "insitu_cache.jsonl"
+
+    def scale_a(chunk):
+        chunk.data = chunk.data * 2.0
+        return chunk
+
+    def scale_a_edited(chunk):
+        chunk.data = chunk.data * 3.0
+        return chunk
+
+    _warm(url, geoms, backing, [applies(["a"], scale_a)])
+    assert len(log.read_text().splitlines()) == 4  # header + 3 entries
+
+    reset = _persist_pool(geoms, backing, [applies(["a"], scale_a_edited)], reset_stale_cache=True)
+    reset.close()
+    lines = log.read_text().splitlines()
+    assert json.loads(lines[0])["format_version"] == 4
+    arrays = [json.loads(line)["array"] for line in lines[1:]]
+    assert sorted(arrays) == ["b", "c"], "the stale entry is gone; the valid ones survive"
+    assert not list(backing.glob("*insitu-tmp")), "compaction must not leave a temp file behind"
+
+    # And the compacted log is what the *next* open reads -- a's entry is not re-rejected.
+    again = _persist_pool(geoms, backing, [applies(["a"], scale_a_edited)])  # no reset flag
+    owner = again.new_owner()
+    assert again.pin_if_ready("b", 0, owner) and not again.pin_if_ready("a", 0, owner)
+    again.close()
+
+
+def test_readonly_cache_cannot_reset_a_stale_array(three_vars, tmp_path):
+    """A read-only opener may not delete files another process may be reading, so a stale
+    array is a hard error there -- with the fix pointed at the run that *writes* the cache."""
+    url, _ = three_vars
+    backing = tmp_path / "cache"
+    geoms = _geoms(url)
+
+    def scale_a(chunk):
+        chunk.data = chunk.data * 2.0
+        return chunk
+
+    def scale_a_edited(chunk):
+        chunk.data = chunk.data * 3.0
+        return chunk
+
+    _warm(url, geoms, backing, [applies(["a"], scale_a)])
+    with pytest.raises(ValueError, match=r"readonly_cache.*stale.*'a'"):
+        ChunkPool(
+            geoms,
+            backing_dir=backing,
+            readonly_cache=True,
+            chunk_transforms=[applies(["a"], scale_a_edited)],
+        )
+
+
+def test_scaler_scope_is_checked_against_its_own_stats(three_vars):
+    """``applies(["b"], scaler_fitted_on_a)`` is caught by :func:`applies` itself, at
+    construction -- not as a ``KeyError`` in a decode thread one chunk into training."""
+    scaler = StandardScaler(mean={"a": np.float64(0.0)}, std={"a": np.float64(1.0)})
+    with pytest.raises(ValueError, match=r"no mean/std for \['b'\]"):
+        applies(["b"], scaler)
+    applies(["a"], scaler)  # the scope it was fitted for is fine
+
+
+def test_applies_rejects_an_empty_scope():
+    """A scope of nothing means the transform never runs; that is a configuration mistake,
+    not a way to disable one."""
+
+    def noop(chunk):
+        return chunk
+
+    with pytest.raises(ValueError, match="empty scope"):
+        applies([], noop)
+
+
+def test_describe_names_each_transforms_scope(three_vars, tmp_path):
+    """The static report says which variables a transform touches -- 'what will this
+    configuration do' is incomplete without it once scope exists."""
+    url, _ = three_vars
+    geoms = _geoms(url)
+
+    def double(chunk):
+        chunk.data = chunk.data * 2.0
+        return chunk
+
+    ds = InSituDataset(
+        obstore_store(url),
+        split_by_chunk(geoms["a"], fractions=(1.0, 0.0, 0.0)),
+        geometries=geoms,
+        batch_size=2,
+        chunk_transforms=[applies(["a", "b"], double)],
+    )
+    assert ds.describe()["config"]["chunk_transforms"] == ("double[a,b]",)
+    ds.close()
+
+
+def test_dataset_rejects_an_unknown_scope_name(three_vars):
+    """The same check on the public surface, before any geometry is derived from the scope."""
+    url, _ = three_vars
+    geoms = _geoms(url)
+
+    def noop(chunk):
+        return chunk
+
+    with pytest.raises(ValueError, match="not arrays in this dataset"):
+        InSituDataset(
+            obstore_store(url),
+            split_by_chunk(geoms["a"], fractions=(1.0, 0.0, 0.0)),
+            geometries=geoms,
+            chunk_transforms=[applies(["nope"], noop)],
+        )
+
+
+def test_a_crashed_compaction_leaves_nothing_behind(three_vars, tmp_path):
+    """Compaction writes a temp file and renames. A crash between the two must not leave
+    litter or a second log: the temp name carries the sweep suffix, so the next writer to
+    hold the cache lock clears it -- the same treatment a half-written chunk file gets."""
+    url, _ = three_vars
+    backing = tmp_path / "cache"
+    geoms = _geoms(url)
+
+    def double(chunk):
+        chunk.data = chunk.data * 2.0
+        return chunk
+
+    _warm(url, geoms, backing, [double])
+    orphan = backing / f"insitu_cache.jsonl.999999{_TMP_SUFFIX}"
+    orphan.write_text('{"format_version": 4}\n')
+
+    pool = _persist_pool(geoms, backing, [double])
+    assert not orphan.exists(), "the next lock holder must sweep an orphaned temp file"
+    assert pool.manifest_entries == 3, "and the real log is untouched"
+    pool.close()

--- a/tests/test_transform_scope.py
+++ b/tests/test_transform_scope.py
@@ -257,7 +257,11 @@ def test_a_new_variable_over_an_existing_cache_is_cold_not_stale(three_vars, tmp
 
 def test_an_array_this_run_does_not_read_keeps_its_files(three_vars, tmp_path):
     """Two configurations may share one cache_dir. A run that reads only ``a`` must not
-    delete -- or forget -- ``b``'s entries just because it cannot check them."""
+    delete -- or forget -- ``b``'s entries just because it cannot check them.
+
+    This is the ablation / feature-importance case: sweeping over variable subsets must not
+    cost a re-decode of the variables each run leaves out. Dropping a variable from a run is
+    not an edit to it."""
     url, _ = three_vars
     backing = tmp_path / "cache"
 
@@ -280,7 +284,13 @@ def test_an_array_this_run_does_not_read_keeps_its_files(three_vars, tmp_path):
 
 def test_narrowing_a_scope_invalidates_only_the_variable_that_left(three_vars, tmp_path):
     """Scope is not folded into a transform's own token: the array that *stays* in scope
-    hashes identically, and only the one that left is stale."""
+    hashes identically, and only the one that left is stale.
+
+    Leaving a scope *is* a real invalidation, not bookkeeping -- ``b``'s cached chunks hold
+    doubled bytes that the narrowed configuration must not serve -- so under
+    ``reset_stale_cache`` its files are deleted and it re-decodes cold (asserted below).
+    Contrast :func:`test_an_array_this_run_does_not_read_keeps_its_files`: an array the run
+    stops *reading* keeps everything."""
     url, _ = three_vars
     backing = tmp_path / "cache"
     geoms = _geoms(url)


### PR DESCRIPTION
## Summary

Part 2 of #42, on top of #51 (writer arbitration) and #52 (the live `_persist` guard).
Follows the plan agreed in [the scoping comment](https://github.com/emfdavid/insitubatch/issues/42#issuecomment-5534685755);
no decisions were re-opened.

**This is a correctness fix before it is a caching one.** Gating a `chunk_transform` with
`if chunk.read.array == ...` inside its body is invisible to `output_geometry`, which folds
every transform's declared `output_inner` into **every** variable's geometry. A regrid gated
to `t2m` therefore made the engine believe `u10` was regridded too: `u10` was gathered as a
truncated prefix of itself, and its cache entry could never revive, because the `.npy` on
disk no longer matched the declared geometry. Nothing raised — right shape, right dtype,
wrong numbers.

Nothing in this tree was corrupt: all four gating sites (`kelvin_to_celsius`, Hubble's `SCI`,
SDSS's `flux`, `StandardScaler`'s implicit `KeyError`) are shape-preserving, and the one
shipped reshaping transform (`Coarsen`) is ungated. The hazard was in what a user writes next.

**Scope is now declared at the call site**, where the engine can read it:

```python
InSituDataset(..., chunk_transforms=[
    applies(["2m_temperature"], kelvin_to_celsius),   # this array only
    Coarsen(2),                                       # every array, as before
])
```

"Subtract 273.15" is a fact about Kelvin; "`2m_temperature` is in Kelvin" is a fact about
your store. The old pattern welded them, which is why one unit conversion had to enumerate
two archives' naming conventions (`TEMPERATURE_VARS`) and silently skipped a third. A
transform may be *parameterized* by variable — a fitted scaler's statistics legitimately are
— but it must not decide whether it runs.

`transforms_for(path, ...)` is the single resolution of scope; geometry, the fingerprint and
`_apply_transforms` all read it, so they cannot drift. Off-scope arrays skip the call
entirely. Unknown names raise at construction (before any cache dir or lockfile exists), and
a scoped `StandardScaler` is validated against its own stats dict there rather than
`KeyError`-ing in a decode thread.

**Manifest format 4: cache identity per array.** Each entry carries the hash of the
transforms scoped to *its own* array — on the entry, not in the header, because the log is
append-only and a header map cannot absorb an array a later run reads for the first time.
Editing `t2m`'s transform no longer invalidates `u10`/`v10`, whose bytes did not change.

Staleness becomes a partial answer, which is the part worth reviewing for semantics:

- the error **names which arrays**; `reset_stale_cache=True` deletes only their files;
- an array with **no entries** is *cold*, not stale — adding a variable is not a wipe;
- an array a run **does not read** keeps its entries and files, so two configurations can
  share one `cache_dir`;
- scope is deliberately **not** folded into a transform's own token, so narrowing a scope
  invalidates the variable that *left* and not the one that stayed;
- the log is compacted (temp file + `rename`, `_TMP_SUFFIX` so a crash is swept) when a load
  drops entries — safe only because #51's exclusive lock proves there is no second writer.

Only the log **format** is still all-or-nothing: a log we cannot parse says nothing about
any individual array.

Also: `ChunkTransform` had three definitions (a Protocol in `transforms.py`, a `Callable`
alias in `pool.py`, another in `check_transform.py`). There is now one — the Protocol, with
its `__call__` made positional-only so a plain function satisfies it whatever it names its
parameter.

Closes #42.

## For reviewers

**The semantics, not the code.** "Which arrays are stale" used to be all-or-nothing and is
now a subset; the error message is what makes that usable, and the three not-stale cases
above are judgement calls worth a second opinion — particularly "an array this run does not
read is left entirely alone", which is what lets two configurations share a directory but
also means we keep entries we cannot validate.

Confident in: the geometry fix (regression test drives the real `ChunkPool` and gathers), the
per-array fingerprint, and that a bare transform behaves exactly as before.

Deferred, as agreed in the issue: **per-path assembly** (a variable no transform touches
could stay on the tiled fast path, but `assembles` is a single bool the scheduler reads to
decide where delivery runs). Recorded in DESIGN.md's known limitations.

## Author attestation

- [ ] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

*(Left unchecked deliberately — this PR was drafted with Claude Code, and the attestation is
the human author's to tick.)*

## Checklist

- [x] Tests added or updated — `tests/test_transform_scope.py`, 17 tests written first: the
      truncation repro, "editing `a`'s transform keeps `b`/`c`", cold-not-stale, an untouched
      array keeps its files, precise GC, scope narrowing, compaction (and a crashed one),
      `readonly_cache` rejection, unknown/empty/bare-string scopes, and the scaler check
- [x] `uv run ruff check src tests bench examples`, `uv run mypy src bench examples` and
      `uv run pytest -q` are green locally (435 passed, 6 skipped; TF run separately)
- [x] Docstrings and API docs for any new or changed public surface (`applies` is in
      `__all__`, so it lands in the generated API reference)
- [x] User-facing behavior documented in `docs/*.md` — a new "Scoping a transform to
      variables" section in `docs/architecture.md`, "What a transform edit invalidates" in
      `docs/tuning.md`, and the old per-pipeline limitation retired in both places + DESIGN.md
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md` (two)
- [x] No load-bearing invariant is broken — transforms stay vectorized numpy, the hot path
      stays O(chunks) (scope is resolved once per path at construction, never per chunk)
- [x] Touches `ChunkPool` → the free-threaded (3.13t) run passes (confirmed in CI)
- [x] No performance claim made

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KnQ6EEXRwRSPKMAzUdgxpn


