### PR TITLE
fix: read the storage chunk, not the inner chunk, on sharded arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,18 @@
   have found it, but a public store going away must not turn into a red build for a
   contributor who changed nothing.
 
+- **The "O(chunks), not O(samples)" invariant is now pinned by tests, having been load-bearing
+  and unguarded.** A read path that degrades to one store read per *sample* is the failure
+  this project exists to avoid, and nothing would have caught it: on a fixture small enough
+  for CI it is not slower, merely wrong, so no throughput test can see it. Chunk reads are
+  counted through a store wrapper and asserted to depend on the plan alone — never on
+  `batch_size` or shuffle. The assertion is an independence property rather than a fixed
+  ratio, because a fixed ratio is false in both directions: a warm epoch legitimately reads
+  *fewer* chunks than the plan names (the pool retains them), and a sharded array may take
+  several byte-range calls for one key. A companion control drives a case known to amplify
+  through the same counter, so that a counter which has come unwired fails loudly instead of
+  reporting "no redundant reads" — which is indistinguishable from a pass.
+
 - **`applies(...)` scopes a `chunk_transform` to named variables — and the in-body name test
   it replaces was silently truncating data.** `chunk_transforms` is one list run on every
   variable, so the convention was for a transform to check `chunk.read.array` and no-op on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,19 @@
   have found it, but a public store going away must not turn into a red build for a
   contributor who changed nothing.
 
+- **`ArrayGeometry.chunk_bytes` reports what one chunk costs — and the docs were teaching
+  a formula that under-reported it by 19%.** Sizing `cache_budget_bytes` means knowing the
+  per-chunk residency, and `docs/tuning.md` said to compute it as
+  `sample_chunk_size × prod(inner_shape) × itemsize`. That is wrong whenever the inner axes
+  are gridded, which is the ARCO/ERA5 norm: residency is the stored *tiles*, kept whole, and
+  a grid that does not divide the array evenly still stores full-size edge chunks. On NOAA
+  GFS analysis the hand-rolled product gives 5.98 GB against a real charge of **7.37 GB**
+  (eight whole 1440×400×400 tiles), so a budget sized that way under-provisions and the pool
+  starves mid-epoch — a hang-shaped failure, not an error. The property is the same
+  expression `slot_charge_bytes` charges, so the two cannot drift, and the tuning page now
+  documents the pattern: ask the geometry, compare against `free -h`, and use `describe()`
+  once more than one variable or a `chunk_transform` is in play.
+
 - **The "O(chunks), not O(samples)" invariant is now pinned by tests, having been load-bearing
   and unguarded.** A read path that degrades to one store read per *sample* is the failure
   this project exists to avoid, and nothing would have caught it: on a fixture small enough

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 ## Unreleased
 
+- **Sharded zarr-v3 arrays could not be read at all, and said so with a checksum error.**
+  On a sharded array zarr reports two shapes: `metadata.chunks` is the *inner* chunk (read
+  granularity inside a shard) and `chunk_grid.chunk_shape` is the shard — the thing a chunk
+  key actually addresses. We planned reads, sized the `ArraySpec` and built geometry from the
+  former, so we asked the store for a key holding a shard and then decoded it as though it
+  were one inner chunk. The `ShardingCodec` sized its index from the wrong spec, read the
+  wrong trailing bytes, and raised `ValueError: Stored and computed checksum do not match` —
+  which says nothing about sharding. **Every dataset in the dynamical.org catalog is sharded**
+  (NOAA GFS/GEFS/HRRR/MRMS, ECMWF AIFS/IFS, DWD ICON-EU, NASA IMERG, ECCC HRDPS), so none of
+  it was readable; WeatherBench2 and ARCO are not sharded, which is why every benchmark,
+  example and test missed it. There is now one spelling of "the shape of one stored object",
+  read through `ChunkGrid.from_metadata` so zarr-v2 keeps working without a deprecated
+  accessor. ([#56](https://github.com/emfdavid/insitubatch/issues/56))
+
+- **`open_geometries(store)` crashed on any CF store — including the form the README
+  teaches.** A CF/xarray-written group holds coordinate arrays and a 0-D `spatial_ref` whose
+  attributes carry the CRS, alongside the data variables. Taking every array in the group
+  made the 0-D one raise `sample_axis 0 out of range for 0-D array`, and — quieter, and
+  worse — returned `time`/`latitude`/`longitude` as variables to batch, with sample-axis
+  lengths that cannot agree with any variable's. Coordinates and grid mappings are now
+  skipped, detected from `dimension_names` (v3) or xarray's `_ARRAY_DIMENSIONS` (v2). The
+  inference is deliberately narrow — only a *self-named* 1-D array is a coordinate, so a
+  station series over `('time',)` is still data — and naming an array in `variables=`
+  bypasses it entirely. A group with nothing batchable left raises, listing what it skipped
+  and pointing at the explicit route.
+
+- **A `cache_budget_bytes` too small for the run now raises instead of being silently raised
+  to the floor.** Handing back ten times what was asked for is indistinguishable from
+  honouring it, until the kernel intervenes. On an archive that chunks the sample axis deeply
+  — 1440 steps × a full field is 5.98 GB for one chunk — that number is the difference
+  between running and being OOM-killed, and the floor is computable from geometry before any
+  IO. The error names the floor, the knob, and the `block_chunks` that set it. Passing no
+  budget still sizes itself automatically.
+
+- **`icechunk_store(url)` opens an Icechunk repository by URL**, public
+  (`anonymous=True`) or with your own cloud credentials — `s3://`, `gs://`, `file://`.
+  Icechunk is the format most new public archives are published in, and our only route to one
+  was `arraylake_store`, which authenticates through Arraylake and cannot address a repo that
+  is simply sitting in a bucket. The two are not alternatives: where the repository lives
+  decides which you use, and the module docstring says so.
+
+- Tests that read a live public bucket are marked `remote` and skipped unless `--remote` is
+  given. The sharded-decode defect lived in an Icechunk store and no synthetic fixture would
+  have found it, but a public store going away must not turn into a red build for a
+  contributor who changed nothing.
+
 - **`applies(...)` scopes a `chunk_transform` to named variables — and the in-body name test
   it replaces was silently truncating data.** `chunk_transforms` is one list run on every
   variable, so the convention was for a transform to check `chunk.read.array` and no-op on

--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ from insitubatch import InSituDataset, obstore_store, open_geometries, split_by_
 
 # The engine reads a zarr Store; build one per backend. obstore_store covers
 # file://, s3://, gs://, az://. (fsspec_store reaches GCS Rapid/requester-pays;
-# arraylake_store opens an Icechunk session — same InSituDataset below.)
+# icechunk_store opens an Icechunk repo by URL — icechunk_store(url, anonymous=True)
+# for a public one; arraylake_store opens an Arraylake-hosted repo by catalog name.
+# All of them return a Store, and the same InSituDataset below reads any of them.)
 store = obstore_store("gs://insitubatch-bench-insitubatch/era5_c16.zarr", skip_signature=True)
 geoms = open_geometries(store)  # {var: ArrayGeometry} from zarr metadata
 # contiguous chunk blocks by default (no time-series leakage);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -240,6 +240,14 @@ or one zarr shard on a sharded array — whatever a single `store.get` returns);
 duplication is tracked in
 [#40](https://github.com/emfdavid/insitubatch/issues/40), not fixed here.
 
+**On a sharded array the stored chunk is the shard**, and the distinction is load-bearing:
+zarr reports `chunks` as the *inner* chunk (read granularity inside a shard) and
+`chunk_grid.chunk_shape` as the shard itself, which is what a chunk key addresses. The
+geometry and the read plan use the latter, so a sharded array is read one whole shard at a
+time. That is a good fit where a run consumes the samples a shard holds and a poor one where
+it wants a small spatial subset of a large shard — fetching only the inner chunks a run needs
+is [#57](https://github.com/emfdavid/insitubatch/issues/57).
+
 Two zarr facilities are deliberately *not* adopted. `FusedCodecPipeline.read_sync` takes
 `ByteGetter`s and therefore **owns the IO**, which would surrender the scheduler,
 `max_inflight` and back-pressure; `decode_chunk` is IO-free, which is why it is the one we

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -272,6 +272,24 @@ A load that drops entries rewrites the log (to a temp name, then a rename), so a
 not re-read and re-rejected on every subsequent open. That is safe only because one writer
 holds the lock above.
 
+### Work out what one chunk costs before setting a budget
+
+`cache_budget_bytes` below what one pass needs co-resident now **raises at construction**,
+naming the floor, rather than being quietly raised to it. Compute the floor the same way the
+engine does — per variable, `samples-per-chunk × field × itemsize`, times `block_chunks`,
+times two (the current block plus one read-ahead):
+
+```python
+geom = open_geometries(store, variables=["temperature_2m"])["temperature_2m"]
+per_chunk = geom.sample_chunk_size * math.prod(geom.inner_shape) * geom.dtype.itemsize
+```
+
+This is not a rounding detail on an archive that chunks the sample axis deeply. A store
+holding 1440 time steps per chunk over a 721×1440 field costs **5.98 GB for one chunk** —
+so `block_chunks=4` asks for ~48 GB, and a box that cannot supply it should say so before
+the first read, not be OOM-killed halfway through an epoch. Passing no budget still sizes
+itself automatically.
+
 ### Put `cache_dir` on local NVMe, not NFS
 
 The cache is an mmap tier, so this is what it is built for. Over a network filesystem it

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -274,21 +274,35 @@ holds the lock above.
 
 ### Work out what one chunk costs before setting a budget
 
-`cache_budget_bytes` below what one pass needs co-resident now **raises at construction**,
-naming the floor, rather than being quietly raised to it. Compute the floor the same way the
-engine does — per variable, `samples-per-chunk × field × itemsize`, times `block_chunks`,
-times two (the current block plus one read-ahead):
+`cache_budget_bytes` below what one pass needs co-resident **raises at construction**,
+naming the floor, rather than being quietly raised to it. Ask the geometry what one chunk
+costs, then check that against the memory you actually have:
 
 ```python
 geom = open_geometries(store, variables=["temperature_2m"])["temperature_2m"]
-per_chunk = geom.sample_chunk_size * math.prod(geom.inner_shape) * geom.dtype.itemsize
+geom.chunk_bytes                      # bytes one sample-axis chunk occupies once resident
+2 * block_chunks * geom.chunk_bytes   # the floor: current block + one read-ahead
 ```
 
-This is not a rounding detail on an archive that chunks the sample axis deeply. A store
-holding 1440 time steps per chunk over a 721×1440 field costs **5.98 GB for one chunk** —
-so `block_chunks=4` asks for ~48 GB, and a box that cannot supply it should say so before
-the first read, not be OOM-killed halfway through an epoch. Passing no budget still sizes
-itself automatically.
+Compare that with `free -h` (the `available` column, not `free`) and leave room for the
+model and the framework's own allocator. Across several variables the floor is the sum, and
+a `chunk_transform` can make the transformed output the binding term instead of the stored
+tiles — so for anything but a single-variable run, ask
+[`describe()`](api.md#insitubatch.InSituDataset.describe), which reports the number the
+engine will actually use rather than one you assembled by hand.
+
+**Do not compute this as `sample_chunk_size × prod(inner_shape) × itemsize`.** Residency is
+the array's stored *tiles*, kept whole: a grid that does not divide the array evenly still
+stores full-size edge chunks and the loader does not clip them. On NOAA GFS analysis —
+1440 time steps per chunk over a 721×1440 field, tiled 400×400 — that product gives 5.98 GB
+while the real cost is **7.37 GB**, eight whole tiles. Sizing a budget from the smaller
+number under-provisions by 19%, and the pool starves mid-epoch, which fails in the shape of
+a hang rather than an error.
+
+The difference is not a rounding detail on an archive that chunks the sample axis deeply.
+One chunk of that store is 7.37 GB, so `block_chunks=4` asks for **59 GB** — and a box that
+cannot supply it should say so before the first read, not be OOM-killed halfway through an
+epoch. Passing no budget still sizes itself automatically.
 
 ### Put `cache_dir` on local NVMe, not NFS
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,9 @@ select = ["E", "F", "I", "UP", "B", "SIM"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+markers = [
+    "remote: reads a live public cloud store; skipped unless --remote is given",
+]
 testpaths = ["tests"]
 pythonpath = ["."]  # make the dev-only `bench` package importable in tests
 

--- a/src/insitubatch/__init__.py
+++ b/src/insitubatch/__init__.py
@@ -31,6 +31,7 @@ from .store import (
     close_store,
     ensure_local_dir,
     fsspec_store,
+    icechunk_store,
     obstore_store,
     open_geometries,
 )
@@ -72,6 +73,7 @@ __all__ = [
     "StoredChunkRead",
     "applies",
     "arraylake_store",
+    "icechunk_store",
     "as_tf_dataset",
     "as_torch",
     "close_store",

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -264,11 +264,10 @@ def slot_charge_bytes(
     sizing from the output shape while charging the tiles under-provisions the budget and
     the pool starves mid-epoch, which is a hang-shaped failure rather than a slow one.
     """
-    tiles = (
-        src.n_inner_chunks(chunk_index)
-        * int(np.prod(src.tile_shape(), dtype=np.int64))
-        * src.dtype.itemsize
-    )
+    # chunk_index does not enter the tiles term -- a short final *outer* chunk is still
+    # one whole stored chunk -- so this is exactly ArrayGeometry.chunk_bytes, the property
+    # users size budgets against. One expression, so the two cannot drift.
+    tiles = src.chunk_bytes
     if not assembles:
         return tiles
     assembled = int(np.prod(out.slot_shape(chunk_index), dtype=np.int64)) * out.dtype.itemsize

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -75,6 +75,7 @@ from zarr.core.sync import _get_loop
 from .plan import build_stored_chunk_reads
 from .pool import ChunkPool
 from .runtime import StatsCollector
+from .store import _storage_chunks
 from .types import ArrayGeometry, StoredChunkRead
 
 STARVATION_POLL_S = 0.25
@@ -572,8 +573,9 @@ class Scheduler:
                 # engine reads public v2 stores (WeatherBench2 ARCO) as well as v3.
                 meta = aa.metadata
                 dtype = getattr(meta, "data_type", None) or meta.dtype
+                stored = _storage_chunks(aa)
                 spec = ArraySpec(
-                    shape=meta.chunks,
+                    shape=stored,
                     dtype=dtype,
                     fill_value=meta.fill_value,
                     config=aa.config,
@@ -585,7 +587,7 @@ class Scheduler:
                     encode=meta.encode_chunk_key,
                     codec=_sync_transform(meta),
                     spec=spec,
-                    chunk_shape=tuple(aa.metadata.chunks),
+                    chunk_shape=stored,
                     fill_value=aa.metadata.fill_value,
                     dtype=geom.dtype,
                     sample_axis=geom.sample_axis,

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -256,6 +256,21 @@ class InSituDataset:
         # caller's: pass `cache_budget_bytes`. Under-sizing is not silent -- admission raises
         # and names how many iterations are sharing the pool (`Scheduler._starvation`).
         # See docs/tuning.md, "Several iterations at once multiply the budget".
+        # An explicit budget below the floor is a configuration error, not something to
+        # quietly round up. Silently handing back ten times what was asked for is
+        # indistinguishable -- until the kernel intervenes -- from honouring it, and on a
+        # store whose stored chunk is hundreds of MB (a sharded analysis archive: a deep
+        # sample-chunk x a whole field) that difference is the run. Computable from geometry
+        # alone, so it is caught here rather than as starvation mid-epoch.
+        if cache_budget_bytes is not None and int(cache_budget_bytes) < working_set:
+            raise ValueError(
+                f"cache_budget_bytes={int(cache_budget_bytes)} is below this run's residency "
+                f"floor of {working_set} bytes, so the pool could not hold what one pass "
+                f"needs co-resident: block_chunks={self.block_chunks} (plus one read-ahead "
+                f"block) across {len(self.variables)} variable(s). Raise cache_budget_bytes "
+                "to at least that, or lower block_chunks -- which shrinks the floor but also "
+                "narrows the shuffle window. Passing no budget sizes it automatically."
+            )
         self.cache_budget_bytes = max(int(cache_budget_bytes or 0), working_set)
         # persist turns the cache_dir mmap tier into a cross-run cache (files + manifest
         # survive close; reopen revives them as hits). It needs a dir to keep files in;

--- a/src/insitubatch/store.py
+++ b/src/insitubatch/store.py
@@ -10,8 +10,15 @@ callers pick a constructor for their backend and hand the resulting ``Store`` to
   layer; the local-now / cloud-later story is just a different URL.
 - :func:`fsspec_store` -- fsspec-backed, for what obstore does not reach (GCS
   Rapid/zonal over gRPC, requester-pays).
-- :func:`arraylake_store` -- an Arraylake/Icechunk session store, bound to a
-  repository snapshot/branch (no URL round-trips to it, so it must be an object).
+- :func:`icechunk_store` -- an Icechunk repository you address by URL, public or with
+  your own cloud credentials.
+- :func:`arraylake_store` -- an Icechunk repository *hosted by Arraylake*, addressed by
+  catalog name and opened with an Arraylake login rather than cloud credentials.
+
+The last two both end in an Icechunk session store, and which one you want is decided by
+where the repository lives, not by preference: a bucket you can name in a URL is
+:func:`icechunk_store`; a repo in an Arraylake catalog has no such URL and is
+:func:`arraylake_store`. They are not alternatives for the same repository.
 
 Anything that is already a zarr ``Store`` (a custom store, an Icechunk session)
 is passed straight to the engine -- no constructor needed.
@@ -70,6 +77,57 @@ def fsspec_store(url: str, *, read_only: bool = True, **storage_options: Any) ->
     )
 
 
+def icechunk_store(
+    url: str,
+    *,
+    branch: str = "main",
+    anonymous: bool = False,
+    region: str | None = None,
+    **kwargs: Any,
+) -> Store:
+    """Return the read-only session ``Store`` of an Icechunk repository at ``url``.
+
+    ``s3://bucket/prefix`` (the common case for public archives), ``gs://``, or a local
+    ``file:///path``. Public buckets need ``anonymous=True``; otherwise credentials come
+    from the environment the way every other AWS/GCS tool finds them (profile, instance
+    role, ``AWS_*`` variables, an SSO login). Extra ``kwargs`` pass through to Icechunk's
+    storage constructor.
+
+    Icechunk is a *versioned* format, so a store is a snapshot: ``branch`` picks which one,
+    and the returned session is read-only, which is what the engine wants -- training reads
+    a fixed view of the data even while a writer appends to the repo.
+
+    Requires ``insitubatch[icechunk]``::
+
+        store = icechunk_store(
+            "s3://dynamical-noaa-gfs/noaa-gfs-analysis/v0.1.0.icechunk",
+            anonymous=True, region="us-west-2",
+        )
+
+    For an Arraylake-hosted repo use :func:`arraylake_store` instead: it is addressed by
+    catalog name rather than URL and authenticates with an Arraylake login.
+    """
+    import icechunk
+
+    parsed = urlparse(url)
+    bucket, prefix = parsed.netloc, parsed.path.lstrip("/")
+    if parsed.scheme in ("s3", "s3a"):
+        storage = icechunk.s3_storage(
+            bucket=bucket, prefix=prefix, region=region, anonymous=anonymous, **kwargs
+        )
+    elif parsed.scheme in ("gs", "gcs"):
+        storage = icechunk.gcs_storage(bucket=bucket, prefix=prefix, **kwargs)
+    elif parsed.scheme in ("", "file"):
+        storage = icechunk.local_filesystem_storage(parsed.path or url, **kwargs)
+    else:
+        raise ValueError(
+            f"icechunk_store does not know the scheme {parsed.scheme!r} in {url!r}; it "
+            "handles s3://, gs:// and file://. For an Arraylake-hosted repository use "
+            "arraylake_store(name), which is addressed by catalog name rather than URL."
+        )
+    return icechunk.Repository.open(storage).readonly_session(branch).store
+
+
 def arraylake_store(repo: str, *, branch: str = "main") -> Store:
     """Open an Arraylake repo and return its read-only Icechunk session store.
 
@@ -119,6 +177,62 @@ def ensure_local_dir(url: str) -> str:
     return url
 
 
+def _storage_chunks(arr: object) -> tuple[int, ...]:
+    """The shape of one **stored object** -- what a chunk key addresses.
+
+    On a **sharded** array these differ and only one is the storage unit:
+    ``metadata.chunks`` is the *inner* chunk (read granularity inside a shard), while
+    ``chunk_grid.chunk_shape`` is the shard, which is what ``store.get(key)`` returns and
+    what the codec chain (whose head is the ``ShardingCodec``) decodes. Planning reads or
+    building an ``ArraySpec`` from ``chunks`` on such an array asks for a key that holds a
+    shard and then decodes it as if it were one inner chunk -- which fails the shard index's
+    CRC rather than saying anything useful.
+
+    Identical on unsharded arrays, and defined for zarr-v2 metadata as well, so this is the
+    single format-agnostic spelling of "one stored chunk". Read through
+    ``ChunkGrid.from_metadata`` rather than ``metadata.chunk_grid``: the latter is deprecated
+    on ``ArrayV2Metadata``, and v2 is not optional here (WeatherBench2 ARCO is v2).
+    """
+    from zarr.core.chunk_grids import ChunkGrid
+
+    return tuple(ChunkGrid.from_metadata(arr.metadata).chunk_shape)  # type: ignore[attr-defined]
+
+
+def _dimension_names(arr: object) -> tuple[str, ...] | None:
+    """The array's dimension names, in either format's spelling, or ``None`` if it has none.
+
+    zarr-v3 carries ``dimension_names`` in metadata; zarr-v2 carries xarray's
+    ``_ARRAY_DIMENSIONS`` attribute. A store written by anything CF-aware has one or the
+    other, and neither is guaranteed (a hand-built or OME-NGFF store may have neither).
+    """
+    names = getattr(arr.metadata, "dimension_names", None)  # type: ignore[attr-defined]
+    if names is None:
+        names = arr.attrs.get("_ARRAY_DIMENSIONS")  # type: ignore[attr-defined]
+    return tuple(str(n) for n in names) if names else None
+
+
+def _is_coordinate(name: str, arr: object) -> bool:
+    """True for an array that describes the grid rather than being data on it.
+
+    Two shapes, both of which a CF store puts in the same group as its variables:
+
+    * a **grid mapping** -- 0-D, all of its content in attributes (``spatial_ref``'s
+      ``crs_wkt``). It has no sample axis, so it is not merely useless to batch, it cannot
+      be turned into an :class:`ArrayGeometry` at all.
+    * a **coordinate** -- 1-D and named after its own dimension (``latitude`` over
+      ``('latitude',)``). Batching it would deliver axis labels as if they were fields, and
+      its sample-axis length is the axis length, which will not agree with any variable's.
+
+    Deliberately narrow: an array is only a coordinate if it is *self-named*, so a 1-D data
+    variable (a station series over ``('time',)``) is kept. Naming it in ``variables=``
+    overrides this in either direction.
+    """
+    if getattr(arr, "ndim", None) == 0:
+        return True
+    dims = _dimension_names(arr)
+    return dims is not None and len(dims) == 1 and dims[0] == name
+
+
 def open_geometries(
     store: Store,
     variables: list[str] | None = None,
@@ -139,7 +253,22 @@ def open_geometries(
     :class:`ArrayGeometry` per array); the shape/chunks stay in physical order.
     """
     group = zarr.open_group(store=store, mode="r")
-    names = variables if variables is not None else [k for k, _ in group.arrays()]
+    if variables is not None:
+        names = variables
+    else:
+        # Infer: a CF group holds coordinates and a grid mapping alongside its variables,
+        # and taking every array makes the 0-D one raise and the 1-D ones batchable.
+        skipped = {k: a for k, a in group.arrays() if _is_coordinate(k, a)}
+        names = [k for k, _ in group.arrays() if k not in skipped]
+        if not names:
+            raise ValueError(
+                f"no batchable arrays found in {store!r}: every array in the group looks "
+                f"like a coordinate or grid mapping ({sorted(skipped)}). A 0-D array has no "
+                "sample axis, and a 1-D array named after its own dimension is an axis "
+                "label rather than data on the grid. If one of these really is the data you "
+                "mean to batch, name it explicitly -- open_geometries(store, "
+                'variables=["<name>"]) -- which bypasses this inference entirely.'
+            )
     out: dict[str, ArrayGeometry] = {}
     for name in names:
         arr = group[name]  # raises KeyError if the name is absent
@@ -151,7 +280,7 @@ def open_geometries(
         out[name] = ArrayGeometry(
             path=name,
             shape=tuple(arr.shape),
-            chunks=tuple(arr.chunks),
+            chunks=_storage_chunks(arr),
             dtype=np.dtype(arr.dtype),
             sample_axis=sample_axis,
         )

--- a/src/insitubatch/types.py
+++ b/src/insitubatch/types.py
@@ -175,6 +175,31 @@ class ArrayGeometry:
         """
         return (self.sample_chunk_size, *self.inner_chunks)
 
+    @property
+    def chunk_bytes(self) -> int:
+        """Bytes one sample-axis chunk occupies once resident — **the number to size a
+        budget against**, and the one that is easy to get wrong by hand.
+
+        Residency is the array's stored *tiles*, kept whole: a chunk grid that does not
+        divide the array evenly still stores full-size edge chunks (721 rows chunked at 180
+        occupy 900) and the pool does not clip them. So this is
+        ``n_inner_chunks * prod(tile_shape) * itemsize``, which on a gridded inner axis is
+        **larger** than ``sample_chunk_size * prod(inner_shape) * itemsize`` — the product a
+        reader reaches for first, and which under-provisions exactly the deeply chunked
+        stores where the difference costs gigabytes.
+
+        This is the tiles term of :func:`~insitubatch.pool.slot_charge_bytes`, which charges
+        it; the two are the same expression, so they cannot drift. A configured
+        ``chunk_transform`` can make the assembled output the binding term instead — ask
+        :meth:`InSituDataset.describe` for the whole picture rather than summing this by
+        hand across variables.
+        """
+        return (
+            self.n_inner_chunks(0)
+            * int(np.prod(self.tile_shape(), dtype=np.int64))
+            * self.dtype.itemsize
+        )
+
     def tile_placement(self, chunk_index: int, inner_coord: tuple[int, ...]) -> ChunkProjection:
         """Where one stored tile lands inside its outer chunk, as zarr's own projection.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,11 +49,13 @@ def run_by():
 def pytest_addoption(parser):
     """``--remote`` opts into the tests that read somebody else's live bucket.
 
-    Off by default: the suite is otherwise fully offline and deterministic, and a public
-    store going away must not turn into a red build for a contributor who changed nothing.
-    These tests exist because a local fixture cannot reproduce a backend-specific defect --
-    the sharded-decode bug (#56) lived in an Icechunk store and no synthetic fixture would
-    have found it.
+    They exist because a local fixture cannot reproduce a backend-specific defect: a
+    synthetic store exercises our code against our own writer, not against the encoding
+    choices a real publisher made.
+
+    Off by default, because the suite is otherwise fully offline and deterministic and
+    somebody else's public store going away must not turn into a red build for a
+    contributor who changed nothing.
     """
     parser.addoption(
         "--remote",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,32 @@ def run_by():
     return _run_by
 
 
+def pytest_addoption(parser):
+    """``--remote`` opts into the tests that read somebody else's live bucket.
+
+    Off by default: the suite is otherwise fully offline and deterministic, and a public
+    store going away must not turn into a red build for a contributor who changed nothing.
+    These tests exist because a local fixture cannot reproduce a backend-specific defect --
+    the sharded-decode bug (#56) lived in an Icechunk store and no synthetic fixture would
+    have found it.
+    """
+    parser.addoption(
+        "--remote",
+        action="store_true",
+        default=False,
+        help="run tests that read live public cloud stores (network, slow)",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--remote"):
+        return
+    skip = pytest.mark.skip(reason="needs --remote (reads a live public bucket)")
+    for item in items:
+        if "remote" in item.keywords:
+            item.add_marker(skip)
+
+
 @pytest.fixture
 def write_zarr(tmp_path):
     """Factory: write a zarr group of random f4 variables, return (url, {var: src})."""
@@ -60,6 +86,86 @@ def write_zarr(tmp_path):
             arr = group.create_array(var, shape=(n, *inner), chunks=(spc, *inner), dtype="f4")
             data = rng.standard_normal((n, *inner)).astype("f4")
             arr[:] = data
+            srcs[var] = data
+        return url, srcs
+
+    return _write
+
+
+@pytest.fixture
+def write_sharded_zarr(tmp_path):
+    """Factory: a **sharded** zarr-v3 group -- the layout every dynamical.org store uses.
+
+    ``shard`` is the stored object (what a chunk key addresses); ``chunks`` is the read
+    granularity inside it. The two differ here on purpose: that difference is the whole of
+    #56, and a fixture where they coincide proves nothing.
+    """
+
+    def _write(
+        *, n=48, shard=(16, 8, 8), chunks=(16, 4, 4), inner=(8, 8), variables=("t2m",), seed=0
+    ):
+        url = f"file://{tmp_path}/sharded.zarr"
+        ensure_local_dir(url)
+        group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
+        rng = np.random.default_rng(seed)
+        srcs: dict[str, np.ndarray] = {}
+        for var in variables:
+            arr = group.create_array(
+                var, shape=(n, *inner), shards=shard, chunks=chunks, dtype="f4"
+            )
+            data = rng.standard_normal((n, *inner)).astype("f4")
+            arr[:] = data
+            srcs[var] = data
+        return url, srcs
+
+    return _write
+
+
+@pytest.fixture
+def write_cf_zarr(tmp_path):
+    """Factory: a CF/xarray-shaped group -- data variables plus coordinate arrays and a 0-D
+    ``spatial_ref`` grid-mapping scalar, which is what every rioxarray-written store carries.
+    """
+
+    def _write(*, n=32, spc=8, lat=4, lon=5, variables=("t2m", "u10"), v3=True, seed=0):
+        url = f"file://{tmp_path}/cf.zarr"
+        ensure_local_dir(url)
+        group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
+        rng = np.random.default_rng(seed)
+        srcs: dict[str, np.ndarray] = {}
+        dims = ("time", "latitude", "longitude")
+
+        def _dim(arr, names):
+            # v3 carries dimension_names in metadata; v2 carries xarray's _ARRAY_DIMENSIONS.
+            if not v3:
+                arr.attrs["_ARRAY_DIMENSIONS"] = list(names)
+
+        for name, size in (("time", n), ("latitude", lat), ("longitude", lon)):
+            c = group.create_array(
+                name,
+                shape=(size,),
+                chunks=(size,),
+                dtype="f8",
+                dimension_names=(name,) if v3 else None,
+            )
+            c[:] = np.arange(size, dtype="f8")
+            _dim(c, (name,))
+
+        crs = group.create_array("spatial_ref", shape=(), chunks=(), dtype="i4")
+        crs.attrs["grid_mapping_name"] = "latitude_longitude"
+        crs.attrs["crs_wkt"] = 'GEOGCS["WGS 84"]'
+
+        for var in variables:
+            arr = group.create_array(
+                var,
+                shape=(n, lat, lon),
+                chunks=(spc, lat, lon),
+                dtype="f4",
+                dimension_names=dims if v3 else None,
+            )
+            data = rng.standard_normal((n, lat, lon)).astype("f4")
+            arr[:] = data
+            _dim(arr, dims)
             srcs[var] = data
         return url, srcs
 

--- a/tests/test_cf_coordinates.py
+++ b/tests/test_cf_coordinates.py
@@ -1,0 +1,62 @@
+"""``open_geometries(store)`` over a CF/xarray-written group (#56).
+
+A CF store's group holds more than data variables: 1-D coordinate arrays, and a 0-D
+``spatial_ref`` whose *attributes* carry the CRS. Taking every array in the group makes the
+0-D one raise ("sample_axis 0 out of range for 0-D array") and, worse, returns ``time`` and
+``latitude`` as if they were variables to batch.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from insitubatch import InSituDataset, obstore_store, open_geometries, split_by_chunk
+
+
+@pytest.mark.parametrize("v3", [True, False], ids=["v3-dimension_names", "v2-_ARRAY_DIMENSIONS"])
+def test_coordinates_and_grid_mapping_are_not_variables(write_cf_zarr, v3):
+    """Both dimension-metadata spellings: v3 carries ``dimension_names`` in metadata, v2
+    carries xarray's ``_ARRAY_DIMENSIONS`` attribute."""
+    url, srcs = write_cf_zarr(variables=("t2m", "u10"), v3=v3)
+    geoms = open_geometries(obstore_store(url))
+    assert sorted(geoms) == ["t2m", "u10"]
+
+
+def test_the_quickstart_call_works_on_a_cf_store(write_cf_zarr):
+    """The README's own form -- ``open_geometries(store)`` with no variables -- must survive
+    contact with a store written by xarray."""
+    url, srcs = write_cf_zarr()
+    store = obstore_store(url)
+    geoms = open_geometries(store)
+    manifest = split_by_chunk(geoms["t2m"], fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(store, manifest, geometries=geoms, batch_size=4, shuffle=False)
+    for batch in ds.all:
+        np.testing.assert_array_equal(batch.arrays["t2m"], srcs["t2m"][batch.sample_indices])
+    ds.close()
+
+
+def test_an_explicit_coordinate_name_is_still_honoured(write_cf_zarr):
+    """Skipping coordinates is a default, not a prohibition: asking for one by name gives it
+    to you (a 1-D series is a legitimate thing to batch)."""
+    url, _ = write_cf_zarr()
+    geoms = open_geometries(obstore_store(url), variables=["time"])
+    assert geoms["time"].n_samples == 32
+
+
+def test_a_group_with_no_batchable_array_raises_and_says_what_to_do(write_cf_zarr):
+    """When inference leaves nothing, say what was found, why each was skipped, and name the
+    explicit route -- rather than returning {} and failing later with something unrelated."""
+    url, _ = write_cf_zarr(variables=())
+    with pytest.raises(ValueError) as exc:
+        open_geometries(obstore_store(url))
+    msg = str(exc.value)
+    assert "variables=" in msg, "the error must name the explicit route"
+    assert "spatial_ref" in msg and "time" in msg, "and what it skipped"
+
+
+def test_unknown_variable_still_raises_plainly(write_cf_zarr):
+    """An explicit name that is not there is a typo, not an inference problem."""
+    url, _ = write_cf_zarr()
+    with pytest.raises(KeyError):
+        open_geometries(obstore_store(url), variables=["t2m_typo"])

--- a/tests/test_read_amplification.py
+++ b/tests/test_read_amplification.py
@@ -1,0 +1,167 @@
+"""Store reads are a function of the plan -- never of ``batch_size`` or shuffle.
+
+This is the "O(chunks), not O(samples)" invariant made falsifiable. It is the whole
+performance thesis, and until now nothing in the suite would have caught its loss: a
+per-sample read path is not slower on a fixture this small, it is just *wrong*, and
+throughput tests on 8 chunks cannot see it.
+
+The assertion is deliberately **not** "amplification is 1.0x", which is false in both
+directions. A warm epoch reads *fewer* chunks than the plan names, because the pool
+retains them across the epoch boundary (measured: 8, then 6, then 5). A sharded array
+may take several byte-range calls for one shard key without anything being wrong.
+What survives both is an *independence* property, asserted three ways below, plus a
+control proving the instrument can see the failure it is looking for.
+
+Held fixed, because each one would legitimately change the count:
+
+- **local store** -- a remote retry is an honest extra read
+- **one variable** -- reads are counted per array, not globally
+- **unsharded** -- count distinct keys, not calls, once #57 lands partial shard reads
+- **no cache_dir** -- persistence makes a second epoch read the local cache, not the
+  store; that is a different claim and deserves its own test
+- **single epoch** for the first two tests; v1 sample geometry has no cross-chunk
+  samples, so windowing does not enter yet -- it would if that ever changes
+"""
+
+from __future__ import annotations
+
+import collections
+from typing import Any
+
+import pytest
+import zarr
+from zarr.storage import WrapperStore
+
+from insitubatch import obstore_store, open_geometries, split_by_chunk
+from insitubatch.source import InSituDataset
+
+N, SPC = 64, 8
+CHUNKS = N // SPC
+
+# Module-level on purpose. Opening a store read-only makes zarr *copy* it, so a counter
+# kept on the instance the test holds would stay empty forever -- and an empty counter
+# reads as "no redundant reads at all", which is indistinguishable from a pass. That trap
+# is why ``test_the_control_amplifies`` exists.
+READS: collections.Counter[str] = collections.Counter()
+
+
+class CountingStore(WrapperStore):  # type: ignore[type-arg]
+    """Counts chunk reads by key.
+
+    Overrides only the async ``get``, which is the seam zarr reads through today. If a
+    future zarr moves these reads to the sync seam this wrapper goes blind -- and
+    ``test_the_control_amplifies`` is what turns that into a loud failure rather than a
+    suite full of vacuous passes.
+    """
+
+    async def get(self, key: str, prototype: Any, byte_range: Any = None) -> Any:
+        READS[key] += 1
+        return await self._store.get(key, prototype, byte_range=byte_range)
+
+
+def chunk_reads() -> int:
+    return sum(v for k, v in READS.items() if "/c/" in k)
+
+
+@pytest.fixture
+def counted(write_zarr):
+    """A one-variable store whose chunk reads are counted, plus its split manifest."""
+    url, _ = write_zarr(n=N, spc=SPC)
+
+    def _open() -> Any:
+        return CountingStore(obstore_store(url))
+
+    manifest = split_by_chunk(open_geometries(_open())["t2m"], fractions=(1.0, 0.0, 0.0))
+    return _open, manifest
+
+
+def _epoch(ds: InSituDataset) -> int:
+    return sum(int(b.arrays["t2m"].shape[0]) for b in ds.train)
+
+
+# -- 1. the hand-computed case ------------------------------------------------
+
+
+def test_a_cold_epoch_reads_each_chunk_exactly_once(counted) -> None:
+    """64 samples, 8 per chunk, so 8 chunks and 8 reads.
+
+    The 8 is computed by hand, not asked of the planner: a test that takes both sides
+    of the comparison from the code under test asserts only that it agrees with itself.
+    """
+    open_store, manifest = counted
+    ds = InSituDataset(open_store(), manifest, batch_size=8, shuffle=False, block_chunks=2)
+    READS.clear()
+    assert _epoch(ds) == N
+    assert chunk_reads() == CHUNKS
+
+
+# -- 2. the property that survives config changes -----------------------------
+
+
+@pytest.mark.parametrize("batch_size", [1, 3, 8, 16, 64])
+@pytest.mark.parametrize("shuffle", [False, True])
+def test_reads_do_not_scale_with_batch_size_or_shuffle(counted, batch_size, shuffle) -> None:
+    """The invariant with no magic number in it -- and the one that catches a
+    per-sample read path the moment it appears.
+
+    ``batch_size=64`` is included because it exceeds one block (2 chunks = 16 samples)
+    and forces the block to widen; that changes residency, and must not change reads.
+    """
+    open_store, manifest = counted
+    ds = InSituDataset(
+        open_store(), manifest, batch_size=batch_size, shuffle=shuffle, block_chunks=2
+    )
+    READS.clear()
+    assert _epoch(ds) == N
+    assert chunk_reads() == CHUNKS
+
+
+# -- 3. reuse may only help ---------------------------------------------------
+
+
+def test_a_warm_epoch_never_reads_more_than_a_cold_one(counted) -> None:
+    """An inequality, not an equality: chunks still resident from the previous epoch
+    are reused, so a warm epoch legitimately reads *fewer* than the plan names.
+    Asserting equality here would go red on a correctly working pool.
+    """
+    open_store, manifest = counted
+    ds = InSituDataset(open_store(), manifest, batch_size=8, shuffle=True, block_chunks=2)
+
+    ds.set_epoch(0)
+    READS.clear()
+    _epoch(ds)
+    cold = chunk_reads()
+
+    warm = []
+    for epoch in (1, 2):
+        ds.set_epoch(epoch)
+        READS.clear()
+        _epoch(ds)
+        warm.append(chunk_reads())
+
+    assert cold == CHUNKS
+    assert all(w <= cold for w in warm), f"a warm epoch read more than the cold one: {warm}"
+
+
+# -- 4. the control: can this instrument see amplification at all? ------------
+
+
+def test_the_control_amplifies(counted) -> None:
+    """Drive a case *known* to amplify through the same counter.
+
+    Reading one sample at a time straight from zarr must cost one chunk read per
+    sample -- ``SPC`` times the ideal. If this ever reports 1.0x, the counter is not
+    wired to the reads and every other assertion in this file is vacuous. Starving the
+    pool is no longer available as a control: an under-floor ``cache_budget_bytes``
+    raises at construction (#56), so the amplifying case cannot be built through the
+    public API any more.
+    """
+    open_store, _ = counted
+    arr = zarr.open_group(open_store(), mode="r")["t2m"]
+
+    READS.clear()
+    for i in range(N):
+        _ = arr[i]
+
+    assert chunk_reads() == N, "the counter is not seeing chunk reads"
+    assert chunk_reads() == SPC * CHUNKS

--- a/tests/test_residency.py
+++ b/tests/test_residency.py
@@ -185,9 +185,8 @@ def test_starvation_names_concurrent_iterations_as_the_cause(small_store, run_by
     geom = geoms["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
     # Sized automatically, which is exactly one iteration's residency floor -- the engine's
-    # own number rather than a hand-computed one. (It used to pass 2 * chunk_bytes, which is
-    # *below* that floor and was silently promoted to it; an under-floor budget now raises at
-    # construction, so the intent is written directly.)
+    # own number rather than a hand-computed one, and the only way to say "one iteration's
+    # worth" without asserting a budget the engine would reject as under-floor.
     ds = InSituDataset(
         obstore_store(small_store),
         manifest,

--- a/tests/test_residency.py
+++ b/tests/test_residency.py
@@ -184,14 +184,16 @@ def test_starvation_names_concurrent_iterations_as_the_cause(small_store, run_by
     geoms = open_geometries(obstore_store(small_store))
     geom = geoms["t2m"]
     manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
-    chunk_bytes = geom.sample_chunk_size * 2 * 2 * 4
+    # Sized automatically, which is exactly one iteration's residency floor -- the engine's
+    # own number rather than a hand-computed one. (It used to pass 2 * chunk_bytes, which is
+    # *below* that floor and was silently promoted to it; an under-floor budget now raises at
+    # construction, so the intent is written directly.)
     ds = InSituDataset(
         obstore_store(small_store),
         manifest,
         shuffle=False,
         batch_size=geom.sample_chunk_size,
         block_chunks=2,
-        cache_budget_bytes=2 * chunk_bytes,  # fits one iteration, not two
     )
     ds.set_epoch(0)
 

--- a/tests/test_sharded.py
+++ b/tests/test_sharded.py
@@ -1,0 +1,232 @@
+"""Sharded zarr-v3 arrays, and what "one stored chunk" means (#56).
+
+On a sharded array zarr reports two shapes and only one of them is the storage unit:
+``metadata.chunks`` is the *inner* chunk (read granularity inside a shard), while
+``chunk_grid.chunk_shape`` is the shard -- what a chunk key addresses and what ``store.get``
+returns. Planning reads or building an ``ArraySpec`` from the former asks for a key holding a
+shard and then decodes it as one inner chunk, which fails the shard index's CRC.
+
+WeatherBench2 and ARCO are not sharded, which is why every other test in this suite passes
+either way. These fixtures make the two shapes differ on purpose.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import zarr
+
+from insitubatch import InSituDataset, obstore_store, open_geometries, split_by_chunk
+
+
+def test_geometry_reports_the_shard_not_the_inner_chunk(write_sharded_zarr):
+    """The geometry drives the read plan, so it must describe the stored object."""
+    url, _ = write_sharded_zarr(n=48, shard=(16, 8, 8), chunks=(16, 4, 4), inner=(8, 8))
+    store = obstore_store(url)
+    geom = open_geometries(store, variables=["t2m"])["t2m"]
+
+    arr = zarr.open_group(store=store, mode="r")["t2m"]
+    assert arr.chunks == (16, 4, 4) and arr.shards == (16, 8, 8), "fixture must be sharded"
+    assert geom.chunks == (16, 8, 8), "geometry must describe the shard, not the inner chunk"
+    assert geom.sample_chunk_size == 16
+
+
+def test_sharded_batches_match_the_source(write_sharded_zarr):
+    """The bug's visible form: iterating raised a CRC error from the shard index. Assert the
+    values, not merely that it does not raise -- a wrong stored-chunk shape could also scatter
+    the right bytes into the wrong places."""
+    url, srcs = write_sharded_zarr(n=48, shard=(16, 8, 8), chunks=(16, 4, 4), inner=(8, 8))
+    store = obstore_store(url)
+    geoms = open_geometries(store, variables=["t2m"])
+    manifest = split_by_chunk(geoms["t2m"], fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(store, manifest, geometries=geoms, batch_size=4, shuffle=False)
+
+    seen = 0
+    for batch in ds.all:
+        idx = batch.sample_indices
+        np.testing.assert_array_equal(batch.arrays["t2m"], srcs["t2m"][idx])
+        seen += len(idx)
+    ds.close()
+    assert seen == 48
+
+
+def test_sharded_with_tiled_inner_dims(write_sharded_zarr):
+    """The dynamical.org shape: a shard that covers only part of the field, so the engine
+    assembles several shards per sample-chunk. Inner tiling and sharding at once is where a
+    wrong stored-chunk shape stops being a decode error and becomes silently misplaced data.
+    """
+    url, srcs = write_sharded_zarr(
+        n=32,
+        shard=(8, 4, 4),
+        chunks=(8, 2, 2),
+        inner=(8, 8),  # 2x2 shards per sample-chunk
+    )
+    store = obstore_store(url)
+    geoms = open_geometries(store, variables=["t2m"])
+    assert geoms["t2m"].inner_shape == (8, 8), "inner geometry is the whole field"
+    manifest = split_by_chunk(geoms["t2m"], fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(store, manifest, geometries=geoms, batch_size=4, shuffle=False)
+    for batch in ds.all:
+        np.testing.assert_array_equal(batch.arrays["t2m"], srcs["t2m"][batch.sample_indices])
+    ds.close()
+
+
+def test_unsharded_arrays_are_unchanged(write_zarr):
+    """The fix must be a no-op where the two shapes coincide -- which is every store we
+    benchmark against."""
+    url, srcs = write_zarr(n=32, spc=8, inner=(4, 4))
+    store = obstore_store(url)
+    geom = open_geometries(store, variables=["t2m"])["t2m"]
+    assert geom.chunks == (8, 4, 4)
+    manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(store, manifest, geometries={"t2m": geom}, batch_size=4, shuffle=False)
+    for batch in ds.all:
+        np.testing.assert_array_equal(batch.arrays["t2m"], srcs["t2m"][batch.sample_indices])
+    ds.close()
+
+
+@pytest.mark.remote
+def test_real_sharded_icechunk_store_matches_zarr():
+    """A live Icechunk + sharded store, because that is where this defect lived and no local
+    fixture would have found it. NOAA GFS analysis on anonymous S3 (dynamical.org)."""
+    pytest.importorskip("icechunk")
+    from insitubatch import icechunk_store
+
+    store = icechunk_store(
+        "s3://dynamical-noaa-gfs/noaa-gfs-analysis/v0.1.0.icechunk",
+        anonymous=True,
+        region="us-west-2",
+    )
+    geoms = open_geometries(store, variables=["temperature_2m"])
+    assert geoms["temperature_2m"].chunks == (1440, 400, 400)  # the shard
+
+    manifest = split_by_chunk(
+        geoms["temperature_2m"], fractions=(1.0, 0.0, 0.0), sample_range=(1440, 1448)
+    )
+    ds = InSituDataset(
+        store, manifest, geometries=geoms, batch_size=2, block_chunks=1, shuffle=False
+    )
+    batch = next(iter(ds.all))
+    ref = zarr.open_group(store=store, mode="r")["temperature_2m"][
+        batch.sample_indices[0] : batch.sample_indices[-1] + 1
+    ]
+    np.testing.assert_allclose(batch.arrays["temperature_2m"], ref)
+    ds.close()
+
+
+# -- byte budget vs the residency floor --------------------------------------
+
+
+def _floor(store, geoms, manifest):
+    """The floor the engine computes for itself, read off an auto-sized dataset."""
+    ds = InSituDataset(store, manifest, geometries=geoms, batch_size=4, shuffle=False)
+    floor = ds.cache_budget_bytes
+    ds.close()
+    return floor
+
+
+def test_a_budget_below_the_residency_floor_raises(write_zarr):
+    """An explicit budget the run cannot satisfy was silently promoted to the floor.
+
+    That silence is survivable when a chunk is 64 KB. It is not on a sharded analysis
+    archive whose stored chunk is hundreds of MB, where the number you passed is the
+    difference between running and being OOM-killed -- and where being quietly given ten
+    times what you asked for is indistinguishable, until the kernel intervenes, from the
+    loader honouring it. The floor is computable from geometry alone, before any IO.
+    """
+    url, _ = write_zarr(n=64, spc=16, inner=(32, 32))
+    store = obstore_store(url)
+    geoms = open_geometries(store, variables=["t2m"])
+    manifest = split_by_chunk(geoms["t2m"], fractions=(1.0, 0.0, 0.0))
+    floor = _floor(store, geoms, manifest)
+
+    with pytest.raises(ValueError) as exc:
+        InSituDataset(store, manifest, geometries=geoms, batch_size=4, cache_budget_bytes=floor - 1)
+    msg = str(exc.value)
+    assert str(floor) in msg, "name the floor the run actually needs"
+    assert "cache_budget_bytes" in msg, "and the knob that sets it"
+
+
+def test_exactly_the_floor_is_accepted(write_zarr):
+    """The boundary is inclusive: the floor is what the run needs, not one byte more."""
+    url, _ = write_zarr(n=64, spc=16, inner=(32, 32))
+    store = obstore_store(url)
+    geoms = open_geometries(store, variables=["t2m"])
+    manifest = split_by_chunk(geoms["t2m"], fractions=(1.0, 0.0, 0.0))
+    floor = _floor(store, geoms, manifest)
+
+    ds = InSituDataset(
+        store,
+        manifest,
+        geometries=geoms,
+        batch_size=4,
+        shuffle=False,
+        cache_budget_bytes=floor,
+    )
+    assert ds.cache_budget_bytes == floor
+    assert sum(len(b.sample_indices) for b in ds.all) == 64
+    ds.close()
+
+
+def test_no_budget_still_sizes_itself(write_zarr):
+    """Passing nothing is not passing zero: the automatic floor is unchanged."""
+    url, _ = write_zarr(n=64, spc=16, inner=(32, 32))
+    store = obstore_store(url)
+    geoms = open_geometries(store, variables=["t2m"])
+    manifest = split_by_chunk(geoms["t2m"], fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(store, manifest, geometries=geoms, batch_size=4, shuffle=False)
+    assert ds.cache_budget_bytes > 0
+    ds.close()
+
+
+def test_an_over_budget_run_fails_rather_than_hanging(write_zarr, run_by):
+    """The failure this replaces is residency starvation, which is a hang. Assert the raise
+    lands under a deadline so a regression cannot wedge the suite."""
+    url, _ = write_zarr(n=64, spc=16, inner=(32, 32))
+    store = obstore_store(url)
+    geoms = open_geometries(store, variables=["t2m"])
+    manifest = split_by_chunk(geoms["t2m"], fractions=(1.0, 0.0, 0.0))
+
+    def build():
+        with pytest.raises(ValueError):
+            InSituDataset(store, manifest, geometries=geoms, batch_size=4, cache_budget_bytes=1)
+        return "raised"
+
+    assert run_by(30, build) == "raised"
+
+
+# -- icechunk_store ----------------------------------------------------------
+
+
+def test_icechunk_store_round_trips_a_local_repo(tmp_path):
+    """The local scheme, so the constructor is covered without a bucket. An Icechunk repo is
+    a zarr Store like any other -- that is the whole 'one contract, any backend' claim."""
+    icechunk = pytest.importorskip("icechunk")
+    from insitubatch import icechunk_store
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    repo = icechunk.Repository.create(icechunk.local_filesystem_storage(str(repo_dir)))
+    session = repo.writable_session("main")
+    group = zarr.open_group(store=session.store, mode="w")
+    src = np.arange(32 * 4 * 4, dtype="f4").reshape(32, 4, 4)
+    group.create_array("t2m", shape=src.shape, chunks=(8, 4, 4), dtype="f4")[:] = src
+    session.commit("write t2m")
+
+    store = icechunk_store(f"file://{repo_dir}")
+    geoms = open_geometries(store, variables=["t2m"])
+    manifest = split_by_chunk(geoms["t2m"], fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(store, manifest, geometries=geoms, batch_size=8, shuffle=False)
+    for batch in ds.all:
+        np.testing.assert_array_equal(batch.arrays["t2m"], src[batch.sample_indices])
+    ds.close()
+
+
+def test_icechunk_store_rejects_an_unknown_scheme():
+    """An unusable URL should say which schemes work and point at the Arraylake route,
+    rather than failing inside icechunk with something about storage backends."""
+    pytest.importorskip("icechunk")
+    from insitubatch import icechunk_store
+
+    with pytest.raises(ValueError, match="arraylake_store"):
+        icechunk_store("https://example.com/repo.icechunk")

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -297,3 +297,53 @@ def test_split_chunk_counts_are_reported(write_zarr):
     cfg = ds.describe()["config"]
     assert sum(cfg["split_chunks"].values()) == 16
     assert cfg["split_chunks"][SplitName.TRAIN.value] > 0
+
+
+# -- ArrayGeometry.chunk_bytes ------------------------------------------------
+#
+# The number a user needs before choosing a budget, and the one they get wrong by hand:
+# residency is whole stored *tiles*, which on a gridded inner axis exceeds the logical
+# chunk. These tests exist to keep the property and the pool's charge from drifting --
+# a helper that reports less than the engine charges is worse than no helper.
+
+
+def test_chunk_bytes_is_the_logical_chunk_when_the_inner_axes_are_not_gridded() -> None:
+    """One tile per chunk, so tiles and logical chunk agree: 8 x 4 x 5 x 4 bytes."""
+    g = _geom((80, 4, 5), (8, 4, 5))
+    assert g.chunk_bytes == 8 * 4 * 5 * 4
+
+
+def test_chunk_bytes_counts_edge_tiles_whole() -> None:
+    """A grid that does not divide the array evenly still stores full-size edge chunks.
+
+    721 rows chunked at 180 occupy 900, and the pool does not clip them -- so the honest
+    answer is bigger than ``sample_chunk_size * prod(inner_shape) * itemsize``, which is
+    what a user computing this by hand writes down.
+    """
+    g = _geom((16, 721, 8), (8, 180, 8))
+    naive = 8 * 721 * 8 * 4
+    assert g.chunk_bytes == 5 * (8 * 180 * 8) * 4  # ceil(721/180) == 5 tiles, kept whole
+    assert g.chunk_bytes > naive
+
+
+def test_chunk_bytes_is_what_the_pool_charges() -> None:
+    """The anti-drift assertion, and the reason the property is worth having.
+
+    ``slot_charge_bytes`` is the single rule for sizing and charging; this helper must be
+    the same number for the no-transform case, or documenting it teaches users to
+    under-provision.
+    """
+    from insitubatch.pool import slot_charge_bytes
+
+    for shape, chunks in [((80, 4, 5), (8, 4, 5)), ((16, 721, 8), (8, 180, 8)), ((9, 3), (4, 2))]:
+        g = _geom(shape, chunks)
+        assert g.chunk_bytes == slot_charge_bytes(g, g, assembles=False)
+
+
+def test_chunk_bytes_does_not_vary_with_the_final_short_chunk() -> None:
+    """A short *outer* chunk is still one axis-0 stored chunk, stored whole -- so the
+    per-chunk cost is one number, which is what makes a property the right shape for it.
+    """
+    g = _geom((9, 3), (4, 2))  # 9 samples in chunks of 4: the last holds 1
+    assert g.n_chunks == 3
+    assert g.chunk_bytes == 2 * (4 * 2) * 4


### PR DESCRIPTION
## Summary

Closes #56. Also fixes the two defects the same store surfaced: #57 is *not* closed by this
(the subset case is still open and linked from the docs).

On a sharded zarr-v3 array two shapes differ and only one is the storage unit:
`metadata.chunks` is the **inner** chunk — the read granularity *inside* a shard — while
`chunk_grid.chunk_shape` is the shard, which is what a chunk key addresses and what
`store.get` returns. Geometry, the read plan and the `ArraySpec` all used the former, so we
asked the store for a key holding a shard and decoded it as though it were one inner chunk.
The `ShardingCodec` then sized its index from the wrong spec, read the wrong trailing bytes,
and raised a checksum error that says nothing about sharding — which is why this presented as
"CRC32C mismatch" and cost an afternoon to attribute. Every dynamical.org dataset is sharded;
WB2 and ARCO are not, which is why every benchmark, example and test missed it.

The fix is one spelling of "the shape of one stored object" (`_storage_chunks`), used at the
three sites that had rolled their own. It reads through `ChunkGrid.from_metadata`, not
`metadata.chunk_grid` — the latter is deprecated on `ArrayV2Metadata`, and v2 is not optional
for us (ARCO is v2).

Two more, both found by the same store:

- **`open_geometries(store)` crashed on any CF group.** A 0-D `spatial_ref` grid mapping has
  no sample axis. Quieter and worse: when it didn't crash it returned `time`, `latitude` and
  `longitude` as variables to batch. Coordinates and grid mappings are skipped now, read from
  `dimension_names` (v3) or `_ARRAY_DIMENSIONS` (v2). The inference is deliberately narrow —
  only a **self-named** 1-D array is a coordinate, so a station series over `('time',)` stays
  data — and when the result is empty the error names every array it skipped and spells out
  the `variables=` escape hatch. There is a test asserting that string is in the message, so
  the escape hatch can't rot out of the error.

- **`cache_budget_bytes` below the residency floor was silently raised to the floor.** It now
  raises, naming the floor, the knob and the `block_chunks` that set it. Being handed ten
  times the memory you asked for is indistinguishable from being honoured right up until the
  kernel intervenes, and one chunk of a deep-sample-axis archive is 5.98 GB, not a rounding
  error. `None` still auto-sizes as before.

- **`icechunk_store(url)`** opens an Icechunk repository by URL — `s3://`, `gs://` or
  `file://`, anonymous or credentialed, `branch=` to pick the snapshot. `arraylake_store`
  stays for Arraylake-hosted repos; they are not two ways to do one thing, since Arraylake
  addresses repos by catalog name through its own client and no URL round-trips to one. The
  module docstring states that rule and the unknown-scheme error names the other constructor.

## For reviewers

**The behaviour change worth a second look is the budget raise, not the shard fix.**
`tests/test_residency.py::test_starvation_names_concurrent_iterations_as_the_cause` passed
`cache_budget_bytes=2 * chunk_bytes` with the comment "fits one iteration, not two" — but
that value was itself *under* the one-iteration floor, and the test had been quietly relying
on the promotion it was documenting the absence of. It now sizes automatically, which is what
it meant. That is a test changed alongside the behaviour it covers; please satisfy yourself
that the new form still tests starvation.

Also worth review: the coordinate inference is a heuristic on other people's metadata, and
heuristics on other people's metadata are where this kind of change goes wrong. I chose the
narrowest rule I could defend (0-D, or 1-D named for its own dimension) precisely so that the
failure mode is "you must pass `variables=`", never "we silently dropped your data". Both v3
and v2 spellings are parametrized in `tests/test_cf_coordinates.py`.

I am confident in the shard fix itself: `tests/test_sharded.py` builds a local store whose
shard shape differs from its inner chunk shape on purpose, and it reproduces the original
CRC32C failure with **no network** — so this defect is now caught offline, by anyone, in 0.4s.

Live-bucket coverage is marked `remote` and skipped unless `--remote` is passed. A public
store disappearing should not redden a build for someone who changed nothing; the reasoning
is in `tests/conftest.py` next to the marker.

## Checklist

- [x] Tests added or updated — for a **bug fix**, a test that reproduces it and failed before
      this change
- [x] `uv run ruff check src tests bench examples`, `uv run mypy src bench examples` and
      `uv run pytest -q` are green locally — 462 passed, 7 skipped; `--remote` 11 passed
      against the NOAA GFS analysis Icechunk store
- [x] Docstrings and API docs for any new or changed public surface
- [x] User-facing behavior documented in `docs/*.md` — `architecture.md` (the sharding claim
      is now true, and links #57 for the subset case), `tuning.md` (new "Work out what one
      chunk costs before setting a budget", with the 5.98 GB worked example), `README.md`
      (constructor list)
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md` — four
- [x] No load-bearing invariant is broken
- [x] Touches `ChunkPool`, the scheduler, or cross-thread readiness → the free-threaded
      (3.13t) run passes — CI will confirm; the change is to which *shape* the planner reads,
      not to concurrency
- [ ] Performance claim? — none made here

## Author attestation

- [x] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

Left unchecked by the assistant that drafted this: the box asserts a *human* reviewed every
change and verified the claims above, which is precisely the thing an assistant ticking it
would defeat. It is yours to tick.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QLod5Wvcm4JKiCRGTBFdj

