### PR TITLE
fix: release a pass's pool references after the scheduler stops, not before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- **Breaking out of a loader loop early permanently burned part of the chunk pool, and a
+  later epoch then died with "residency budget exhausted ... this would hang".** A pass
+  released its references *inside* the scheduler's `with` block -- before the scheduler was
+  closed. Closing is what stops the driver, and on a borrowed event loop it is not
+  synchronous: a cancelled-but-not-yet-unwound driver could still reach `try_admit` and
+  re-pin a slot under the owner that had just been released. Nothing releases that pin, and
+  the slot stays `FILLING` (its sibling tiles were cancelled) so it never becomes `READY`
+  and therefore never becomes evictable. The loss was cumulative and silent -- throughput,
+  shapes and memory all look normal -- until a budget sized for exactly two blocks had too
+  little left to admit the chunk a consumer was waiting for. It bit hardest where a batch
+  pins a whole block (one sample per chunk, `batch_size == block_chunks`), which is the
+  GRIB regime and the benchmark suite's own `c1` configuration: **every `c1` run of the
+  suite raised**, on S3 and GCS alike, while the published `c1` number was measured before
+  the defect existed. `release_owner` now runs after the `with` has closed. Bisected to
+  `5b8fae4`, which did not introduce the over-pinning: it removed the over-broad
+  `unpin_all()` that had been quietly wiping it at every epoch boundary (#34).
+
 - **Sharded zarr-v3 arrays could not be read at all, and said so with a checksum error.**
   On a sharded array zarr reports two shapes: `metadata.chunks` is the *inner* chunk (read
   granularity inside a shard) and `chunk_grid.chunk_shape` is the shard — the thing a chunk

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -585,12 +585,18 @@ class InSituDataset:
                             pool.revive_mismatch,
                             pool.revive_missing,
                         )
-                    # Last: drop this pass's references (and any partial its cancelled
-                    # fetches abandoned), after every counter above has been read. An
-                    # early `break` finalizes this generator, so this runs then too --
-                    # which is what keeps an abandoned pass from leaking budget.
-                    self._pool.release_owner(owner)
         finally:
+            # Drop this pass's references (and any partial its cancelled fetches
+            # abandoned) *after* the `with` above has closed the scheduler -- never
+            # inside it. Closing is what stops the driver, and on a borrowed event loop
+            # it is not synchronous: a driver cancelled but not yet unwound can still
+            # reach `try_admit`, and an admission after the release re-pins the slot
+            # under an owner that no longer exists. Nothing releases that pin, and the
+            # slot it holds stays FILLING -- its sibling tiles were cancelled -- so it
+            # can never become READY and therefore never becomes evictable. Each
+            # abandoned pass then burns part of the budget permanently, and a later
+            # epoch starves on a pool it cannot free (`Scheduler._starvation`).
+            #
             # A `finally` around the `with`, not a statement after it: an early `break`
             # throws GeneratorExit at the yield, which unwinds through the `with` (so the
             # scheduler still closes) but would skip anything that merely followed it. The
@@ -614,6 +620,7 @@ class InSituDataset:
             )
             if logger.isEnabledFor(logging.INFO):
                 logger.info("%s", format_pass(self.last_pass))
+            self._pool.release_owner(owner)
 
     def _log_epoch_summary(self, pool: ChunkPool, split: SplitName | None) -> None:
         """One INFO line per epoch *per split*: what the chunk cache and the batch buffers did.

--- a/tests/test_abandoned_pass.py
+++ b/tests/test_abandoned_pass.py
@@ -1,0 +1,152 @@
+"""An abandoned pass must give the pool back everything it held.
+
+Breaking out of a loader loop early is ordinary code -- a smoke run over the first N
+batches, an evaluation subset, ``itertools.islice`` -- and the pass that gets abandoned
+is usually abandoned *because* it was slow, so its driver is still fetching when the
+generator is finalized.
+
+The defect these tests pin: the release ran *inside* the scheduler's ``with`` block, so
+it happened before the driver was stopped. Closing is not synchronous on a borrowed
+event loop, so a cancelled-but-not-yet-unwound driver could still reach ``try_admit``
+and re-pin a slot under an owner that had just been released. Nothing releases that pin
+and the slot stays FILLING -- its sibling tiles were cancelled -- so it never becomes
+READY and therefore never becomes evictable. Every abandoned pass burned part of the
+budget for the life of the dataset, until a later epoch starved on a pool it could not
+free.
+
+Why the store injects latency: with an instant store the driver is usually done by the
+time the consumer breaks, so the race does not run and the test passes on broken code.
+The delay makes the driver certainly-in-flight at teardown, which is the condition the
+bug needs. It is not a timing *assertion* -- nothing here measures time.
+
+These assert the *invariant* (nothing is left held), not the consequence. The
+consequence -- a later epoch raising "residency budget exhausted ... this would hang" --
+was reproduced on cloud stores (the `era5_c1` family on GCS and S3, batch 16 over a
+16-chunk block) but not on any local fixture: each abandoned pass leaks only a few
+slots, and a fixture small enough for CI survives them. A version of that test was
+written, confirmed to pass against the broken code, and deleted -- a test that cannot
+fail is worse than no test, because it reads like coverage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+from zarr.storage import WrapperStore
+
+from insitubatch import obstore_store, open_geometries, split_by_chunk
+from insitubatch.pool import SlotState
+from insitubatch.source import InSituDataset
+
+# One sample per chunk, and a batch as wide as the shuffle block: the shape where a
+# batch pins a whole block, so a leak of even a few slots is fatal rather than absorbed
+# by slack. This is the benchmark suite's `c1` configuration (bench/run.py defaults).
+N, SPC, BATCH, BLOCK = 256, 1, 16, 16
+DELAY_S = 0.01
+
+
+class SlowStore(WrapperStore):  # type: ignore[type-arg]
+    """Delays chunk reads, so the driver is still fetching when the consumer breaks."""
+
+    async def get(self, key: str, prototype: Any, byte_range: Any = None) -> Any:
+        if "/c/" in key:
+            await asyncio.sleep(DELAY_S)
+        return await self._store.get(key, prototype, byte_range=byte_range)
+
+
+@pytest.fixture
+def slow(write_zarr):
+    url, _ = write_zarr(n=N, spc=SPC, inner=(8, 8))
+
+    def _open() -> Any:
+        return SlowStore(obstore_store(url))
+
+    geometries = open_geometries(_open())
+    manifest = split_by_chunk(geometries["t2m"], fractions=(1.0, 0.0, 0.0))
+    return _open, geometries, manifest
+
+
+def _dataset(slow) -> InSituDataset:
+    _open, geometries, manifest = slow
+    return InSituDataset(
+        _open(),
+        manifest,
+        geometries=geometries,
+        batch_size=BATCH,
+        block_chunks=BLOCK,
+        shuffle=True,
+        seed=0,
+    )
+
+
+def _abandon(ds: InSituDataset, after: int = 1) -> None:
+    """Consume `after` batches, then walk away -- the `break` every user writes."""
+    for i, _batch in enumerate(ds.train):
+        if i + 1 >= after:
+            break
+
+
+def test_an_abandoned_pass_leaves_no_references_behind(slow) -> None:
+    """The pool's reference map is empty once the pass is gone.
+
+    Asserted on the map rather than on throughput or memory because a leaked pin is
+    invisible to both until the budget happens to run out -- which is a later epoch's
+    problem, on a different machine, presenting as a hang.
+    """
+    ds = _dataset(slow)
+    _abandon(ds)
+
+    pool = ds._pool
+    assert pool._pinned == {}, f"references survived the pass: {pool._pinned}"
+    assert pool.active_owners == 0
+
+
+def test_an_abandoned_pass_leaves_no_unfinishable_slots(slow) -> None:
+    """No slot is left that can never finish.
+
+    A partial whose sibling tiles were cancelled can never reach READY, and only READY
+    slots are evictable -- so a partial left behind is budget that never comes back.
+
+    Settled first, deliberately. Closing cancels the driver's coroutines, but decode work
+    already handed to the process-wide executor keeps running: a slot can legitimately be
+    mid-write at the instant the pass ends, and it resolves a moment later (measured: 0
+    survivors in 40 trials). Asserting the instant instead of the outcome is a flake --
+    this test had one. What must never survive the settle is an *orphan*: quiescent,
+    unreferenced, and not READY, which is exactly what the leak left behind.
+    """
+    ds = _dataset(slow)
+    _abandon(ds)
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        pool = ds._pool
+        with pool._cv:
+            orphans = {
+                k: sl.state.name
+                for k, sl in pool._slots.items()
+                if sl.state is not SlotState.READY and sl.quiescent and pool._refs(k) == 0
+            }
+            busy = any(not sl.quiescent for sl in pool._slots.values())
+        if not busy:
+            break
+        time.sleep(0.05)
+    assert orphans == {}, f"slots left unfinishable: {orphans}"
+
+
+def test_repeated_abandonment_does_not_accumulate(slow) -> None:
+    """Ten abandoned passes leave the pool exactly as empty as one does.
+
+    The failure mode was cumulative -- each pass burned a few more slots -- so a single
+    abandonment can look survivable on a generous budget while a training loop that
+    breaks every epoch dies on epoch six.
+    """
+    ds = _dataset(slow)
+    for epoch in range(10):
+        ds.set_epoch(epoch)
+        _abandon(ds)
+
+    assert ds._pool._pinned == {}
+    assert ds._pool.active_owners == 0


### PR DESCRIPTION
## Summary

Breaking out of a loader loop early — a smoke run over the first N batches, an evaluation
subset, `itertools.islice` — permanently burned part of the chunk pool, and a later epoch
then died with `residency budget exhausted ... this would hang`.

A pass released its pool references *inside* the scheduler's `with` block, i.e. **before**
the scheduler was closed. Closing is what stops the driver, and on a borrowed event loop it
is not synchronous: a cancelled-but-not-yet-unwound driver could still reach `try_admit` and
re-pin a slot under the owner that had just been released. Nothing releases that pin, and the
slot stays `FILLING` (its sibling tiles were cancelled) so it never becomes `READY` and
therefore never becomes evictable. The loss was cumulative and silent — throughput, shapes and
memory all look normal — until a budget sized for exactly two blocks had too little left to
admit the chunk a consumer was waiting for.

Diagnostic at the moment of failure, on `era5_c1` over S3:

```
active owners tracked: []          <- both passes released
pinned refs per owner: {1: 16}     <- the abandoned pass still holds 16 pins
slot states: {'FILLING': 16}       <- never READY, never evictable
```

It bit hardest where a batch pins a whole block (one sample per chunk,
`batch_size == block_chunks`) — the GRIB regime, and the benchmark suite's own `c1`
configuration, **every** run of which raised on S3 and GCS alike. The published `c1` number
was measured before the defect existed.

**Bisected to `5b8fae4`**, which did *not* introduce the over-pinning: it removed the
over-broad `unpin_all()` that had been quietly wiping it at every epoch boundary (#34). The
published revision `b594f8b` runs the same configuration fine; `cb0944c^` fails identically,
so #41 is not implicated.

The fix moves `release_owner` into the outer `finally`, after the `with` has closed the
scheduler.

## For reviewers

- **The ordering argument is the whole change** — worth a second look at whether
  `Scheduler.close()` is genuinely the last point at which a `try_admit` can occur.
- **A related defect is NOT fixed here and produces the same error message.** A fresh pass
  can still starve intermittently when a second pass shares the loop: the driver admits
  read-ahead until the budget is full, leaving no slot for the chunk the consumer is waiting
  for (in every sighting, the chunk being admitted is one nobody is waiting for, and `no tile
  is in flight`). Measured at ~5% (1/20) with a concurrent abandoned pass, 0/65 without one;
  doubling the budget to 64 chunks did not help, which is why I read it as demand-vs-read-ahead
  ordering (the **M-RA** roadmap item) rather than sizing. I'd like to file it separately
  rather than widen this PR.
- `tests/test_abandoned_pass.py` asserts the *invariant* (nothing is left held), not the
  consequence. A version asserting the consequence was written, **confirmed to pass against
  the broken code**, and deleted — the cloud-scale leak is too small to exhaust a
  CI-sized fixture. The three that remain fail against `main` (one with the production
  `RuntimeError`); the module docstring records this.

## Author attestation

- [x] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

**Not ticked — this was drafted by Claude Code, and that box is the author's to tick.**

## Checklist

- [x] Tests added or updated — for a **bug fix**, a test that reproduces it and failed before
      this change
- [x] `uv run ruff check src tests bench examples`, `uv run mypy src bench examples` and
      `uv run pytest -q` are green locally (482 passed, 7 skipped on this branch alone;
      the 7 are the CUDA-gated `test_pinned.py` cases, which pass 21/21 on an L4)
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] No load-bearing invariant is broken
- [x] Touches `ChunkPool`, the scheduler, or cross-thread readiness → the free-threaded
      (3.13t) run passes — **not run.** This changes teardown ordering around the scheduler,
      so it is in scope for that gate and someone should run it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKdmX4Dwr3KRhgGCsE2CVs
