### PR TITLE
fix: fail a benchmark run when the engine under test does not run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@
   `5b8fae4`, which did not introduce the over-pinning: it removed the over-broad
   `unpin_all()` that had been quietly wiping it at every epoch boundary (#34).
 
+- **A benchmark run whose *subject* failed exited 0 with a tidy table.** Every engine
+  failure was caught and skipped so one flaky baseline could not kill an hours-long S3
+  sweep -- but that made a run in which `insitu` never ran indistinguishable from a
+  complete one, which is how the `c1` starvation above reached a results file as *absence*
+  rather than as a failure. Skips are now summarised at the end, and a skip of the engine
+  under test raises -- after every row is on disk, because re-running an S3 sweep to
+  recover the configs that did work is expensive. A failing baseline stays non-fatal: that
+  is a gap in the comparison, not a dead run.
+
+- **Six documented benchmark commands could not be pasted.** The suite dropped `--storage`
+  when it started deriving storage from the URL scheme, and the S3 invocations in
+  `docs/benchmarks.md` and `bench/benchmark_plan.md` kept passing it -- so the runbook for
+  a benchmark that costs an EC2 box and hours of reads died on `unrecognized arguments`
+  before the first byte. The flag is gone from those commands, and `tests/test_bench_docs.py`
+  now parses every documented `python -m bench` command against the real parser, so the
+  docs and the CLI cannot drift apart silently again.
+
 - **Sharded zarr-v3 arrays could not be read at all, and said so with a checksum error.**
   On a sharded array zarr reports two shapes: `metadata.chunks` is the *inner* chunk (read
   granularity inside a shard) and `chunk_grid.chunk_shape` is the shard — the thing a chunk

--- a/bench/benchmark_plan.md
+++ b/bench/benchmark_plan.md
@@ -210,20 +210,20 @@ across stories piles duplicates into one JSONL and muddles `--plot`.
 
 ```bash
 # (a) find best num_workers on one chunk size
-uv run python -m bench --url-prefix s3://$BUCKET/era5 --storage s3 \
+uv run python -m bench --url-prefix s3://$BUCKET/era5 \
   --out bench/results/story1_tune.jsonl \
   --engines workers,xbatcher --chunk-sizes 8 \
   --num-workers 8,16,32 --max-batches 64 --repeats 3 --warmup-batches 32
 
 # (b) the spectrum at the tuned best (drop `memory` here; it ignores --max-batches)
-uv run python -m bench --url-prefix s3://$BUCKET/era5 --storage s3 \
+uv run python -m bench --url-prefix s3://$BUCKET/era5 \
   --out bench/results/story1_spectrum.jsonl --fig-dir bench/figures/story1 \
   --engines naive,workers,xbatcher,insitu \
   --chunk-sizes 1,2,4,8,16,32 --num-workers 32 \
   --max-batches 64 --repeats 3 --warmup-batches 32 --plot
 
 # (c) the in-memory ceiling, on its own, on a moderate set (whole array preloaded)
-uv run python -m bench --url-prefix s3://$BUCKET/era5 --storage s3 \
+uv run python -m bench --url-prefix s3://$BUCKET/era5 \
   --out bench/results/story1_ceiling.jsonl \
   --engines memory,insitu --chunk-sizes 8 --repeats 3
 ```
@@ -247,7 +247,7 @@ Memory-flatness (story 2, the `block_chunks` axis stays flat in RSS while
 `max_inflight` rises) comes from the suite with an explicit `--block-chunks` sweep:
 
 ```bash
-uv run python -m bench --url-prefix s3://$BUCKET/era5 --storage s3 \
+uv run python -m bench --url-prefix s3://$BUCKET/era5 \
   --out bench/results/story2_mem.jsonl \
   --engines insitu --chunk-sizes 8 --block-chunks 8,32,128 \
   --max-batches 64 --repeats 3
@@ -270,7 +270,7 @@ train split (read-once "none" re-reads each epoch), and **full epochs** (no
 `--max-batches`) so epoch 0 caches the entire split and any epoch-1 draw order hits:
 
 ```bash
-uv run python -m bench --url-prefix s3://$BUCKET/era5 --storage s3 \
+uv run python -m bench --url-prefix s3://$BUCKET/era5 \
   --out bench/results/story3_cache.jsonl --fig-dir bench/figures/story3 \
   --engines insitu --caches resident --chunk-sizes 1,8,32 --epochs 2 \
   --repeats 3 --cache-dir /mnt/nvme/insitu-cache --plot
@@ -546,7 +546,7 @@ uv run python -m bench.probe_decode --s3-express \
   | tee bench/results/express_ceiling.log
 # the GRIB-end suite on Express (vs the same engines on regular S3)
 uv run python -m bench --s3-express \
-  --url-prefix s3://$XBUCKET/era5 --storage s3 \
+  --url-prefix s3://$XBUCKET/era5 \
   --out bench/results/express_suite.jsonl \
   --engines naive,workers,xbatcher,insitu --chunk-sizes 1 \
   --num-workers 32 --max-batches 64 --repeats 3 --warmup-batches 32

--- a/bench/run.py
+++ b/bench/run.py
@@ -55,6 +55,16 @@ def run_suite(
     # Auth knobs are named per backend: obstore uses request_payer / s3_express (S3),
     # gcsfs uses requester_pays. For an owned standard bucket both are empty and the
     # backend falls back to ambient credentials -- which is the M-GCS A/B case.
+    # Validated here, not on first use: an unknown label used to reach `_run_insitu`,
+    # raise per config, and be swallowed as a skip -- so a whole cache axis could measure
+    # nothing while the run looked complete (tests/test_plot.py asked for "memory" for
+    # months). Cheap, computable before any IO, so it is a boundary check.
+    unknown = sorted(set(caches) - {"none", "resident"})
+    if unknown:
+        raise ValueError(
+            f"unknown insitu cache mode(s) {unknown}; expected 'none' (read-once working "
+            "set) or 'resident' (hold the whole split)"
+        )
     store_kwargs: dict[str, bool] = {}
     if backend == "fsspec":
         if request_payer:
@@ -109,6 +119,9 @@ def run_suite(
                 print(f"  warmup failed: {type(exc).__name__}: {exc}")
 
     results: list[Result] = []
+    # (engine, label, reason) for every config that raised -- summarised at the end, and
+    # fatal if the engine under test is among them (see below).
+    skipped: list[tuple[str, str, str]] = []
     # Total configs, so the progress line can show [i/total] + ETA on long S3 runs.
     total = len(urls) * sum(
         (len(caches) if e == "insitu" else 1)  # insitu honors "none"/"resident"
@@ -169,11 +182,10 @@ def run_suite(
                                 try:
                                     rows = run(cfg, cache_dir=str(cdir), store_kwargs=store_kwargs)
                                 except Exception as exc:  # noqa: BLE001 - skip a failing engine
+                                    label = f"{engine}/{cache}/c{spc}/bc{bc}/w{nw}"
+                                    skipped.append((engine, label, f"{type(exc).__name__}: {exc}"))
                                     if verbose:
-                                        print(
-                                            f"  skip {engine}/{cache}/c{spc}/bc{bc}/w{nw}: "
-                                            f"{type(exc).__name__}: {exc}"
-                                        )
+                                        print(f"  skip {label}: {type(exc).__name__}: {exc}")
                                     continue
                                 for r in rows:
                                     append_jsonl(out, r)
@@ -189,10 +201,36 @@ def run_suite(
                                         )
     if verbose:
         print(f"\nwrote {len(results)} rows -> {out}")
+        if skipped:
+            print(f"\n{len(skipped)} config(s) skipped:")
+            for _engine, label, why in skipped:
+                print(f"  {label}: {why}")
+
+    # A baseline that cannot run is a gap in the comparison; the *subject* failing to run
+    # is not a benchmark at all. Both were equally quiet before: a skipped config printed
+    # one line thousands of lines above the table and the suite still exited 0, so a run
+    # that measured nothing looked exactly like a run that measured everything -- which is
+    # how a `c1` config that raised on every repeat reached a results file as absence.
+    # Raised at the END, after every row is on disk: the other configs' data is good and
+    # re-running an S3 sweep to recover it is expensive.
+    subject = [f"{label}: {why}" for engine, label, why in skipped if engine == "insitu"]
+    if subject:
+        raise RuntimeError(
+            f"the engine under test failed on {len(subject)} config(s), so this run cannot "
+            "support a comparison (rows for the configs that did run are in "
+            f"{out}):\n  " + "\n  ".join(subject)
+        )
     return results
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
+    """The suite's CLI, built where a test can reach it.
+
+    Separate from :func:`main` so the documented run commands can be checked against the
+    real flags: `--storage` was dropped when the suite started deriving storage from the
+    URL scheme, and every S3 command in the runbooks kept it for months -- copy-paste
+    instructions that die on `unrecognized arguments` before a single byte is read.
+    """
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--out", default=str(DEFAULT_OUT))
     p.add_argument("--data-dir", default=None, help="where to write local datasets (default: temp)")
@@ -227,7 +265,11 @@ def main() -> None:
     )
     p.add_argument("--plot", action="store_true", help="render Plotly graphs after the run")
     p.add_argument("--fig-dir", default="bench/figures")
-    a = p.parse_args()
+    return p
+
+
+def main() -> None:
+    a = build_parser().parse_args()
 
     kw: dict = dict(
         out=a.out,

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -516,7 +516,7 @@ Full dataset matrix and per-story commands are in the
 The story-1 spectrum on a pre-generated S3 family, then rebuild the figures:
 
 ```bash
-uv run python -m bench --url-prefix "s3://$BUCKET/era5" --storage s3 \
+uv run python -m bench --url-prefix "s3://$BUCKET/era5" \
   --out bench/results/story1_spectrum.jsonl \
   --engines naive,workers,xbatcher,insitu --chunk-sizes 1,2,4,8,16,32 \
   --num-workers 32 --max-batches 64 --repeats 3 --warmup-batches 32

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -352,3 +352,68 @@ def test_every_declared_arm_is_reachable_from_main() -> None:
     source = probe.main.__code__.co_consts
     branches = {c for c in source if isinstance(c, str)}
     assert set(ARMS) <= branches
+
+
+# -- the suite's own failure reporting ----------------------------------------
+#
+# A skipped config printed one line and the suite still exited 0, so a run in which the
+# engine under test never ran was indistinguishable from a complete one -- how a `c1`
+# config that raised on every repeat reached a results file as *absence* rather than as
+# a failure. A baseline that cannot run is a gap in the comparison and stays non-fatal.
+
+
+def _suite(tmp_path, **kw):
+    return run_suite(
+        out=tmp_path / "suite.jsonl",
+        data_dir=tmp_path / "data",
+        chunk_sizes=(1,),
+        caches=("none",),
+        n_samples=32,
+        inner=(4, 4),
+        batch_size=8,
+        block_chunks_sweep=(4,),
+        worker_sweep=(0,),
+        cache_dir=tmp_path / "cache",
+        epochs=1,
+        warmup_batches=0,
+        verbose=False,
+        **kw,
+    )
+
+
+def _raise_for(engine_name: str, monkeypatch) -> None:
+    import bench.run as bench_run
+
+    real = bench_run.run
+
+    def fake(cfg, **kwargs):
+        if cfg.engine == engine_name:
+            raise RuntimeError("engine exploded")
+        return real(cfg, **kwargs)
+
+    monkeypatch.setattr(bench_run, "run", fake)
+
+
+def test_a_failing_subject_fails_the_suite(tmp_path, monkeypatch) -> None:
+    """insitu raising on every config must not exit 0 with a tidy table."""
+    _raise_for("insitu", monkeypatch)
+
+    with pytest.raises(RuntimeError, match="engine under test"):
+        _suite(tmp_path, engines=("naive", "insitu"))
+
+
+def test_a_failing_subject_still_writes_the_rows_that_ran(tmp_path, monkeypatch) -> None:
+    """The raise comes last, so an expensive S3 sweep is not thrown away with it."""
+    _raise_for("insitu", monkeypatch)
+
+    with pytest.raises(RuntimeError):
+        _suite(tmp_path, engines=("naive", "insitu"))
+    assert (tmp_path / "suite.jsonl").read_text().count("naive") > 0
+
+
+def test_a_failing_baseline_does_not_fail_the_suite(tmp_path, monkeypatch) -> None:
+    """The control: a missing/broken baseline is a gap in the comparison, not a dead run."""
+    _raise_for("naive", monkeypatch)
+
+    results = _suite(tmp_path, engines=("naive", "insitu"))
+    assert {r.engine for r in results} == {"insitu"}

--- a/tests/test_bench_docs.py
+++ b/tests/test_bench_docs.py
@@ -1,0 +1,68 @@
+"""Every documented `python -m bench` command must still parse.
+
+The runbooks are copy-paste instructions for a run that costs an EC2 box and hours of
+S3 reads, so a command that no longer parses is not a typo -- it is an operator pasting
+a block, watching it die on ``unrecognized arguments``, and having to reconstruct the
+intent from the source. That is what happened to ``--storage s3``: the suite started
+deriving storage from the URL scheme and dropped the flag, and six documented commands
+across the benchmarks page and the benchmark plan kept passing it.
+
+Only flags are checked, not behaviour: the point is that the command *shape* in the docs
+and the parser cannot drift apart silently. Values are not run, and shell variables are
+substituted with a placeholder -- the docs define them in an earlier block.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from pathlib import Path
+
+import pytest
+
+from bench.run import build_parser
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = [
+    ROOT / "docs" / "benchmarks.md",
+    ROOT / "bench" / "benchmark_plan.md",
+    ROOT / "bench" / "ops_aws.md",
+    ROOT / "bench" / "ops_gcp.md",
+]
+
+# `uv run python -m bench` (the suite), up to the end of the command: shell line
+# continuations are joined. `-m bench.probe_*` is deliberately not matched -- the probes
+# carry their own parsers, and a shared regex that silently matched them would check
+# their flags against the wrong one.
+COMMAND = re.compile(r"(?:uv run )?python -m bench(?![.\w])(?P<args>(?:\\\n|[^\n])*)")
+SHELL_VAR = re.compile(r"\$\{?\w+\}?")
+
+
+def _commands() -> list[tuple[str, str]]:
+    found: list[tuple[str, str]] = []
+    for path in DOCS:
+        for block in re.findall(r"```(?:bash|sh)\n(.*?)```", path.read_text(), re.S):
+            for match in COMMAND.finditer(block):
+                args = match.group("args").replace("\\\n", " ")
+                found.append((f"{path.name}: {match.group(0).splitlines()[0][:60]}", args))
+    return found
+
+
+def test_the_docs_actually_contain_run_commands() -> None:
+    """The control: a regex that matches nothing would make every test below vacuous."""
+    assert len(_commands()) >= 5
+
+
+@pytest.mark.parametrize("where,args", _commands(), ids=lambda v: v if isinstance(v, str) else "")
+def test_a_documented_command_parses(where: str, args: str) -> None:
+    argv = [SHELL_VAR.sub("placeholder", tok) for tok in shlex.split(args)]
+    parser = build_parser()
+    # Value domains are dropped, flag names are not: the docs legitimately pass shell
+    # variables into choice-valued flags (`--backend "$BK"`), and a placeholder is never
+    # a valid choice. Checking that a flag *exists* is the drift this test is for.
+    for action in parser._actions:
+        action.choices = None
+    try:
+        parser.parse_args(argv)
+    except SystemExit as exc:  # argparse exits rather than raising on a bad flag
+        pytest.fail(f"{where}\n  args: {args.strip()}\n  argparse rejected it ({exc})")

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -17,7 +17,7 @@ def test_plot_smoke(tmp_path) -> None:
         data_dir=tmp_path / "d",
         chunk_sizes=(1, 4),  # chunk-size axis varies (G1)
         engines=("naive", "insitu", "memory"),
-        caches=("none", "memory"),
+        caches=("none", "resident"),  # the two real insitu modes; G4 needs the axis
         n_samples=48,
         inner=(4, 4),
         batch_size=8,


### PR DESCRIPTION
> Rebased onto `main` now that #60 is merged (`7db4e09`); this is a single commit against
> `main`, scoped to the benchmark harness and its docs.

## Summary

Three defects found while re-running the benchmarks for the release, all in the harness
rather than the engine.

**1. A run whose *subject* failed exited 0 with a tidy table.** Every engine failure was
caught and skipped so one flaky baseline could not kill an hours-long S3 sweep — but that
made a run in which `insitu` never ran look exactly like a complete one. It is how the `c1`
starvation fixed in #60 reached a results file as *absence*: `wrote 44 rows`, exit 0, and the
engine under test in none of them. Skips are now summarised at the end, and a skip of the
engine under test raises — **after** every row is on disk, since re-running an S3 sweep to
recover the configs that did work is expensive. A failing baseline stays non-fatal.

**2. The suite accepted an invalid cache label.** That guard immediately failed
`tests/test_plot.py`, which asks for `caches=("none", "memory")` — `"memory"` is not an insitu
cache mode, so those 4 configs had been raising and being silently swallowed. Fixed to
`("none", "resident")`, and `caches` is now validated at the boundary rather than on first use.

**3. Six documented commands could not be pasted.** The suite dropped `--storage` when it
started deriving storage from the URL scheme; the S3 invocations in `docs/benchmarks.md` and
`bench/benchmark_plan.md` kept passing it, so the runbook for a benchmark costing an EC2 box
and hours of reads died on `unrecognized arguments` before the first byte. `probe_memory` still
has the flag and keeps it.

## For reviewers

- **The scope of the raise is the judgement call.** It is deliberately narrow — only
  `engine == "insitu"` — on the grounds that a missing baseline is a gap in the comparison
  while a missing subject is not a benchmark. `test_a_failing_baseline_does_not_fail_the_suite`
  is the control that pins that distinction; if you'd rather it be a flag, say so.
- `tests/test_bench_docs.py` checks command *shape*, not values: it drops `choices` from the
  parser because the docs legitimately pass shell variables into choice-valued flags
  (`--backend "$BK"`). Mutation-checked — putting `--storage s3` back makes it fail.
- Reaching into `parser._actions` is the one piece of private-API use here; I couldn't find a
  public way to relax value domains for a shape check.

## Author attestation

- [x] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

**Not ticked — drafted by Claude Code; that box is the author's to tick.**

## Checklist

- [x] Tests added or updated
- [x] `uv run ruff check src tests bench examples`, `uv run mypy src bench examples` and
      `uv run pytest -q` are green locally (496 passed, 7 skipped)
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] No load-bearing invariant is broken
- [x] User-facing behavior documented — the corrected commands are the docs change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKdmX4Dwr3KRhgGCsE2CVs
