### PR TITLE
fix: a stall is only terminal if the waiters really cannot proceed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- **A healthy run could be killed with "residency budget exhausted ... this would hang".**
+  `Scheduler._starvation` turns an admission stall into a raise rather than a hang, and it
+  proves the stall terminal from three facts, the third being "a consumer is blocked in
+  `wait_ready`, so it can never reach its next unpin and free budget". That fact was read
+  off the registration in `ChunkPool._waiting` -- but a waiter registers *before* it tests
+  its condition and is removed only once its thread is rescheduled, so a waiter whose chunk
+  was already READY and referenced by its own owner -- one about to wake, gather and unpin,
+  which is precisely the thing that frees budget -- counted as blocked. Caught in the act on
+  a real store: at the instant the detector fired there were zero tile tasks outstanding and
+  exactly one waiter, on a chunk in state READY pinned by its own owner. The run was
+  correct, the working set was the intended two blocks, and it was aborted anyway. It
+  presented as an intermittent failure of the benchmark suite (~1 pass in 20) with a second
+  pass sharing the loop, and never on a quiet process -- the shape of a scheduling race, and
+  unaffected by raising `cache_budget_bytes`, which is what ruled out sizing. `wait_ready`
+  and `blocked_waiters` now share one definition of "can this waiter proceed", and only a
+  waiter that genuinely cannot is reported. A real deadlock still raises: the detector polls,
+  and an unsatisfiable waiter stays unsatisfiable.
+
 - **Breaking out of a loader loop early permanently burned part of the chunk pool, and a
   later epoch then died with "residency budget exhausted ... this would hang".** A pass
   released its references *inside* the scheduler's `with` block -- before the scheduler was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@
   waiter that genuinely cannot is reported. A real deadlock still raises: the detector polls,
   and an unsatisfiable waiter stays unsatisfiable.
 
+- **The same false verdict had a second cause: a queued delivery counted as no delivery.**
+  `_starvation`'s other premise -- "nothing is in flight, so no slot can become ready" --
+  was read off `_inflight_now`, which counts only tiles that have *acquired* the
+  `max_inflight` semaphore. A tile task that is created and waiting its turn delivers just
+  as surely, and at `max_inflight=1` almost every tile is queued rather than running: on a
+  public GCS store a single iteration with an automatically sized budget was killed with
+  28 tile tasks outstanding and its one waiter on a chunk in state FILLING that one of
+  those 28 was about to fill. The premise is now read off the tile tasks themselves, so a
+  stall with deliveries outstanding is what it always was -- a slow run, not a wedged one.
+  Found by sweeping loader configurations against a real store; it does not reproduce on a
+  local fixture, where the fetch is too fast to leave anything queued.
+
 - **Breaking out of a loader loop early permanently burned part of the chunk pool, and a
   later epoch then died with "residency budget exhausted ... this would hang".** A pass
   released its references *inside* the scheduler's `with` block -- before the scheduler was

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -688,7 +688,10 @@ class ChunkPool:
         # Keys currently blocked in wait_ready. A blocked consumer is one that cannot
         # unpin, which is what lets the scheduler prove an admission starvation is
         # terminal rather than merely slow (see Scheduler._admit).
-        self._waiting: dict[tuple[str, int], int] = {}  # key -> blocked waiter count
+        # (key, owner) -> waiter count. Keyed by owner because "can this waiter proceed?"
+        # is answered per owner: readiness alone is not enough, the slot must be referenced
+        # by *that* iteration (see wait_ready).
+        self._waiting: dict[tuple[tuple[str, int], int], int] = {}
 
     # -- cross-process arbitration (#42) -------------------------------------
 
@@ -936,17 +939,35 @@ class ChunkPool:
         with self._cv:
             return len(self._owners)
 
-    def blocked_waiters(self) -> list[tuple[str, int]]:
-        """``(path, chunk_index)`` keys some thread is currently blocked on in
-        :meth:`wait_ready`.
+    def _wait_satisfied(self, key: tuple[str, int], owner: int) -> bool:  # call under the lock
+        """Would :meth:`wait_ready` return (or raise) right now for this waiter?
 
-        A blocked consumer is a consumer that cannot reach its next
-        :meth:`unpin_keys`, so it can never free budget. The scheduler pairs this
-        with "no tile in flight" to tell a terminal starvation from a slow consumer
-        -- see :meth:`Scheduler._admit`. Read-only snapshot.
+        The one definition of that question, shared by the wait itself and by
+        :meth:`blocked_waiters`. Two callers deciding it separately is how the second one
+        came to mean something subtly different from the first.
+        """
+        if self._error is not None:
+            return True
+        slot = self._slots.get(key)
+        if slot is None:
+            return False  # not admitted yet -- the driver has not reached it
+        if slot.error is not None:
+            return True  # the wait raises rather than returns, but it does not block
+        return slot.state is SlotState.READY and self._pinned.get(key, {}).get(owner, 0) > 0
+
+    def blocked_waiters(self) -> list[tuple[str, int]]:
+        """``(path, chunk_index)`` keys a thread is blocked on in :meth:`wait_ready` **and
+        cannot yet proceed**.
+
+        A waiter whose condition already holds is excluded, even though its thread is
+        still parked: it is registered until the OS reschedules it, and reporting it as
+        blocked asserts something false about the future. The scheduler pairs this with
+        "no tile in flight" to prove a stall terminal (:meth:`Scheduler._starvation`), and
+        that proof is only as sound as this list -- a waiter that is about to wake up,
+        gather and unpin is precisely the thing that *will* free budget. Read-only snapshot.
         """
         with self._cv:
-            return list(self._waiting)
+            return [key for key, owner in self._waiting if not self._wait_satisfied(key, owner)]
 
     # -- admission / pinning / eviction -------------------------------------
 
@@ -1584,28 +1605,14 @@ class ChunkPool:
         """
         key = (array, chunk_index)
         with self._cv:
-            self._waiting[key] = self._waiting.get(key, 0) + 1
+            self._waiting[(key, owner)] = self._waiting.get((key, owner), 0) + 1
             try:
-                self._cv.wait_for(
-                    lambda: (
-                        self._error is not None
-                        or (
-                            key in self._slots
-                            and (
-                                self._slots[key].error is not None
-                                or (
-                                    self._slots[key].state is SlotState.READY
-                                    and self._pinned.get(key, {}).get(owner, 0) > 0
-                                )
-                            )
-                        )
-                    )
-                )
+                self._cv.wait_for(lambda: self._wait_satisfied(key, owner))
             finally:
-                if self._waiting[key] > 1:
-                    self._waiting[key] -= 1
+                if self._waiting[(key, owner)] > 1:
+                    self._waiting[(key, owner)] -= 1
                 else:
-                    del self._waiting[key]
+                    del self._waiting[(key, owner)]
             if self._error is not None:
                 raise self._error
             error = self._slots[key].error

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -315,6 +315,11 @@ class Scheduler:
         # it cancels unrelated zarr-sync work mid-flight. Mutated only on the loop thread
         # (create_task and the done-callback both run there), so it needs no lock.
         self._tasks: set[asyncio.Task] = set()
+        # Tile tasks only, and every one of them from creation until it finishes. Separate
+        # from `_tasks` because the two answer different questions: `_tasks` is "what must
+        # close() cancel" (the driver included), this is "is a delivery still coming" --
+        # which is what makes an admission stall non-terminal (see _starvation).
+        self._tiles: set[asyncio.Task] = set()
         self._loop.call_soon_threadsafe(self._setup)
         self._ready.wait(timeout=10)
 
@@ -460,7 +465,9 @@ class Scheduler:
                     continue  # cross-epoch hit: prepped chunk already resident, no fetch
                 task = asyncio.create_task(self._one(read))
                 self._tasks.add(task)
+                self._tiles.add(task)
                 task.add_done_callback(self._tasks.discard)
+                task.add_done_callback(self._tiles.discard)
                 tasks.append(task)
             await asyncio.gather(*tasks)
         except BaseException:
@@ -506,6 +513,15 @@ class Scheduler:
                 # parked before proving itself fatal -- that number is the evidence.
                 self.stats.admission_parked_s += time.perf_counter() - t0
 
+    def _delivery_pending(self) -> bool:
+        """Is any tile still on its way to a slot?
+
+        Every tile task lives in :attr:`_tiles` from creation until it finishes, so an
+        unfinished one means a delivery is coming -- whether it is fetching, decoding, or
+        merely queued behind ``max_inflight``.
+        """
+        return any(not task.done() for task in list(self._tiles))
+
     def _starvation(self, array: str, chunk_index: int) -> RuntimeError | None:
         """The error for a *provably* unbreakable admission stall, else ``None``.
 
@@ -513,8 +529,11 @@ class Scheduler:
 
         * ``try_admit`` just failed -- the budget is full of in-flight or referenced
           slots, so no eviction can make room.
-        * nothing is in flight -- no delivery is pending, so no slot can become ready
-          and satisfy a waiter on its own.
+        * no tile task is outstanding -- no delivery is pending, so no slot can become
+          ready and satisfy a waiter on its own. Read off the tasks rather than
+          ``_inflight_now``, which counts only tiles that have *acquired* the concurrency
+          semaphore: a created-but-queued task delivers just as surely, and at
+          ``max_inflight=1`` almost every tile is queued rather than running.
         * a consumer is blocked in ``wait_ready`` -- and a blocked consumer never
           reaches its next ``unpin_block``, so the one thing that could free budget
           will not happen.
@@ -527,7 +546,7 @@ class Scheduler:
         A merely slow consumer registers no waiter (it is computing, not blocked) or
         has work in flight, so it never trips this.
         """
-        if self._inflight_now:
+        if self._delivery_pending():
             return None
         waiting = self.pool.blocked_waiters()
         if not waiting:

--- a/tests/test_starvation_detector.py
+++ b/tests/test_starvation_detector.py
@@ -24,7 +24,10 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from insitubatch import obstore_store, open_geometries, split_by_chunk
 from insitubatch.pool import ChunkPool
+from insitubatch.scheduler import Scheduler
+from insitubatch.source import InSituDataset
 from insitubatch.types import ArrayGeometry
 
 ARRAY, CID, OWNER = "t2m", 3, 1
@@ -100,3 +103,81 @@ def test_a_failed_chunk_does_not_block(pool: ChunkPool) -> None:
     _register_waiter(pool, (ARRAY, CID), OWNER)
 
     assert pool.blocked_waiters() == []
+
+
+# -- premise 2: "nothing in flight" must mean "no delivery pending" -----------
+
+
+def test_a_queued_tile_task_counts_as_delivery_pending(write_zarr) -> None:
+    """`max_inflight=1` serialises fetches, so the gap between one tile releasing the
+    semaphore and the next acquiring it is wide -- and `_inflight_now` counts only tasks
+    that have acquired it. A run whose deliveries are merely *queued* is not stalled.
+
+    Observed on a real store at `max_inflight=1`: the detector fired with
+    `inflight_now=0`, 28 tile tasks created and unfinished, and its one waiter on a chunk
+    in state FILLING that one of those 28 was about to fill.
+    """
+    url, _ = write_zarr(n=512, spc=1, inner=(8, 8))
+    geometries = open_geometries(obstore_store(url))
+    manifest = split_by_chunk(geometries["t2m"], fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(
+        obstore_store(url),
+        manifest,
+        geometries=geometries,
+        batch_size=16,
+        block_chunks=4,
+        max_inflight=1,
+        shuffle=True,
+        seed=0,
+    )
+    ds.set_epoch(0)
+
+    got = sum(int(b.arrays["t2m"].shape[0]) for b in ds.train)
+    assert got == 512
+
+
+# -- premise 2, at the level the detector reads it ---------------------------
+
+
+class _UnfinishedTask:
+    """Stands in for a tile task that has been created and has not finished.
+
+    A real one needs a running loop and a store to fetch from; the detector only ever
+    asks `done()`, and *that* is the whole question -- whether a delivery is still coming.
+    """
+
+    def done(self) -> bool:
+        return False
+
+
+def _scheduler(write_zarr, pool_out: list[ChunkPool]) -> Scheduler:
+    url, _ = write_zarr(n=32, spc=4, inner=(4, 4))
+    geometries = open_geometries(obstore_store(url))
+    pool = ChunkPool(geometries)
+    pool_out.append(pool)
+    return Scheduler(obstore_store(url), geometries, pool)
+
+
+def test_a_queued_tile_task_is_not_a_terminal_stall(write_zarr) -> None:
+    """A stall with deliveries outstanding is a slow run, not a wedged one."""
+    pools: list[ChunkPool] = []
+    sched = _scheduler(write_zarr, pools)
+    pool = pools[0]
+    _register_waiter(pool, ("t2m", 5), OWNER)  # genuinely blocked: never admitted
+    sched._tiles.add(_UnfinishedTask())  # type: ignore[arg-type]
+
+    assert sched._starvation("t2m", 5) is None
+
+
+def test_a_stall_with_nothing_outstanding_is_still_terminal(write_zarr) -> None:
+    """The control: with no delivery coming and a genuinely blocked waiter, it must raise.
+
+    Without this, "never report a stall" would satisfy the test above and turn every real
+    deadlock back into the silent hang the detector exists to replace.
+    """
+    pools: list[ChunkPool] = []
+    sched = _scheduler(write_zarr, pools)
+    _register_waiter(pools[0], ("t2m", 5), OWNER)
+
+    err = sched._starvation("t2m", 5)
+    assert err is not None and "residency budget exhausted" in str(err)

--- a/tests/test_starvation_detector.py
+++ b/tests/test_starvation_detector.py
@@ -1,0 +1,102 @@
+"""A stall is only terminal if the waiters really cannot proceed.
+
+`Scheduler._starvation` turns an admission stall into a raise instead of a hang, and it
+proves the stall terminal from three facts, one of which is "a consumer is blocked in
+`wait_ready`, so it can never reach its next unpin and free budget". That fact was read
+off the registration in `_waiting`, which is a weaker claim than it looks: a waiter is
+registered *before* it tests its condition and is removed only after its thread is
+rescheduled, so a waiter whose chunk is already READY -- one that is about to wake,
+gather and unpin, i.e. exactly the thing that frees budget -- was reported as blocked.
+
+Observed on a real store: at the instant the detector fired, the sole waiter was on a
+chunk in state READY, pinned by its own owner. Nothing was wrong with the run; it was
+killed with "Nothing can free a slot, so this would hang" while holding a full, healthy,
+two-block working set. It reproduced roughly once in twenty passes on GCS and S3 with a
+second pass sharing the loop, and never on a quiet process -- the shape of a scheduling
+race, not of a budget.
+
+These tests fix the *question* rather than the timing: they construct the registered-but-
+satisfiable waiter directly, so nothing here depends on which thread the OS runs next.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from insitubatch.pool import ChunkPool
+from insitubatch.types import ArrayGeometry
+
+ARRAY, CID, OWNER = "t2m", 3, 1
+
+
+@pytest.fixture
+def pool() -> ChunkPool:
+    geom = ArrayGeometry(
+        path=ARRAY,
+        shape=(32, 4, 4),
+        chunks=(4, 4, 4),
+        dtype=np.dtype("f4"),
+        sample_axis=0,
+    )
+    return ChunkPool({ARRAY: geom})
+
+
+def _ready_chunk(pool: ChunkPool) -> tuple[str, int]:
+    """Admit one chunk and deliver its tile, so the slot is READY and referenced."""
+    assert pool.try_admit(ARRAY, CID, OWNER)
+    with pool.tile_write(ARRAY, CID, ()) as write:
+        write.deliver(np.zeros(pool._by_path[ARRAY].tile_shape(), dtype="f4"))
+    return (ARRAY, CID)
+
+
+def _register_waiter(pool: ChunkPool, key: tuple[str, int], owner: int) -> None:
+    """The window: a thread inside `wait_ready` that has registered and not yet re-run.
+
+    Poked in directly rather than raced for. A thread really parked here is
+    indistinguishable to the pool, and driving the OS scheduler into the window on demand
+    is exactly the flakiness this test exists to avoid.
+    """
+    with pool._cv:
+        pool._waiting[(key, owner)] = pool._waiting.get((key, owner), 0) + 1
+
+
+def test_a_waiter_whose_chunk_is_ready_is_not_blocked(pool: ChunkPool) -> None:
+    """The defect: this waiter is one scheduling quantum from freeing budget."""
+    key = _ready_chunk(pool)
+    _register_waiter(pool, key, OWNER)
+
+    assert pool.blocked_waiters() == []
+
+
+def test_a_waiter_on_an_unadmitted_chunk_is_blocked(pool: ChunkPool) -> None:
+    """The control: the detector must still see a genuine stall.
+
+    Without this, "report nothing" would pass the test above and silently convert every
+    real deadlock back into the hang the detector exists to prevent.
+    """
+    _register_waiter(pool, (ARRAY, 7), OWNER)
+
+    assert pool.blocked_waiters() == [(ARRAY, 7)]
+
+
+def test_a_ready_chunk_referenced_by_another_owner_still_blocks(pool: ChunkPool) -> None:
+    """Readiness alone is not the condition -- the slot must be referenced by *this* owner.
+
+    A second iteration's pin satisfies nothing for ours (#35), so a waiter in that state
+    is genuinely stuck and must be reported.
+    """
+    key = _ready_chunk(pool)
+    _register_waiter(pool, key, owner=OWNER + 1)
+
+    assert pool.blocked_waiters() == [key]
+
+
+def test_a_failed_chunk_does_not_block(pool: ChunkPool) -> None:
+    """A waiter on a failed slot wakes and raises; it is not waiting on the budget."""
+    assert pool.try_admit(ARRAY, CID, OWNER)
+    with pool.tile_write(ARRAY, CID, ()) as write:
+        write.fail(RuntimeError("bad chunk"))
+    _register_waiter(pool, (ARRAY, CID), OWNER)
+
+    assert pool.blocked_waiters() == []


### PR DESCRIPTION
## Summary

Two independent defects in `Scheduler._starvation`, both of which **abort a healthy run**
with `residency budget exhausted ... this would hang` and tell the operator to raise a
budget that was never the problem.

The detector proves an admission stall terminal from three facts. Two of them were weaker
claims than they looked.

**1. A registered waiter is not necessarily a blocked one.** `blocked_waiters()` returned
`list(self._waiting)` — every waiter — but a waiter registers *before* it tests its
condition and is removed only once its thread is rescheduled. So a waiter whose chunk was
already READY and pinned by its own owner counted as blocked: the very waiter about to
wake, gather and unpin, which is the thing that frees budget. Captured at the moment of
the raise, on GCS:

```
unfinished tile tasks: 0     inflight_now: 0
waiters (chunk, slot_state, pinned): [(4780, 'READY', True)]
waiters whose wait is ALREADY SATISFIABLE: 1 of 1
```

**2. A queued delivery counted as no delivery.** `_inflight_now` counts only tiles that
have *acquired* the `max_inflight` semaphore. A tile task created and waiting its turn
delivers just as surely, and at `max_inflight=1` almost every tile is queued rather than
running — so a single iteration on a public GCS store, with an automatically sized budget,
was killed while 28 tile tasks were outstanding and its one waiter sat on a chunk in state
FILLING that one of those 28 was about to fill:

```
inflight_now=0
tile tasks created but NOT finished: 28
waiters (chunk, slot_state): [(1966, 'FILLING')]
```

That same configuration now drains its epoch (4800 samples).

`wait_ready` and `blocked_waiters` now share one definition of "can this waiter proceed"
(`_wait_satisfied`), with `_waiting` keyed by `(key, owner)` because the condition is
per-owner; and "is a delivery coming" is read off the tile tasks (`_tiles`), kept separate
from `_tasks` because the two answer different questions — what `close()` must cancel
versus what is still on its way.

### How they were found, and what was ruled out

Defect 1 surfaced as an intermittent failure of the benchmark suite (~1 pass in 20) with a
second pass sharing the loop, and never on a quiet process. Three other explanations were
tested and eliminated first: chunks released before their last use (an ordering probe found
0 violations per pass across four configurations), pins surviving `release_owner`
(0 leaked across six abandoned passes on GCS), and — for that instance — pending tile tasks
(0 outstanding at fire time). Raising `cache_budget_bytes` to 64 chunks changed nothing,
which is what ruled out sizing.

Defect 2 was found afterwards by sweeping loader configurations against a real store: 26
local cases were clean, and `max_inflight=1` failed only on GCS.

## For reviewers

- **The risk in this change is the opposite of the bug**: if either premise now
  *under*-reports, a real deadlock hangs instead of raising — the silent wedge the detector
  exists to replace. Both new predicates therefore ship with controls that must keep
  failing: a waiter on an unadmitted chunk is still reported, another owner's pin still does
  not satisfy your wait (#35), and a stall with nothing outstanding still raises. The
  existing `tests/test_residency.py` case (two interleaved iterations on a one-iteration
  budget must raise, naming concurrent iterations) also still passes.
- **The tests target the premises, not the timing.** Neither defect reproduces on a local
  fixture — the fetch is too fast to leave anything queued, and the scheduling window is too
  narrow — so an integration test would be a coin flip that reads like coverage. Each test
  constructs the state directly and is mutation-checked: under the old semantics, 2 of the
  first set fail and 1 of the second, while every control still passes.
- `_wait_satisfied` deliberately mirrors the wait predicate exactly, including the "failed
  slot" and "poisoned pool" cases — a waiter that is about to *raise* is also not blocked on
  budget. Worth a check that I got that correspondence right.
- Verified separately on a real store: 26/26 local edge cases across the pool/scheduler
  surface (abandoned passes, concurrent iterations, windowed offsets, transforms, mmap
  cache, persist/revive, readonly miss, bad chunks, sharded, straddling and oversized
  batches), each under a hard deadline so a hang counts as a failure.

## Author attestation

- [x] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

**Not ticked — drafted by Claude Code; that box is the author's to tick.**

## Checklist

- [x] Tests added or updated — for a **bug fix**, a test that reproduces it and failed before
      this change
- [x] `uv run ruff check src tests bench examples`, `uv run mypy src bench examples` and
      `uv run pytest -q` are green locally (503 passed, 7 skipped; run pre-rebase on
      identical content, since the rebase only dropped #61's commit)
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] No load-bearing invariant is broken
- [x] Touches `ChunkPool`, the scheduler, or cross-thread readiness → the free-threaded
      (3.13t) run passes — **not run.** This is squarely in scope for that gate (it changes
      cross-thread readiness bookkeeping) and should be run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKdmX4Dwr3KRhgGCsE2CVs
