### PR TITLE
docs: list every command CI enforces, in all three places that claim to

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,8 +26,9 @@
 
 - [ ] Tests added or updated — for a **bug fix**, a test that reproduces it and failed before
       this change
-- [ ] `uv run ruff check src tests bench examples`, `uv run mypy src bench examples` and
-      `uv run pytest -q` are green locally
+- [ ] `uv run ruff check src tests bench examples`, `uv run ruff format --check src tests
+      bench examples`, `uv run mypy src bench examples` and `uv run pytest -q` are green
+      locally (`uv run --extra docs mkdocs build --strict` too, if you touched `docs/`)
 - [ ] Docstrings and API docs for any new or changed public surface
 - [ ] User-facing behavior documented in `docs/*.md`
 - [ ] A bullet added under `## Unreleased` in `CHANGELOG.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -456,7 +456,9 @@
   about their change — which is what happened on our first outside contribution (#32). The
   guide, the PR template and CLAUDE.md now list the same five commands. Pre-commit already
   ran the formatter, so anyone who installed the hooks was covered; the gap was only ever
-  in the written path.
+  in the written path — where the setup step described itself as "ruff + mypy", omitting
+  the formatter, and read as an optional convenience rather than the thing that keeps a
+  locally-green branch green in CI.
 
 ## 0.1.0 — 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -449,6 +449,15 @@
   those is not actionable. AI-assisted contributions are welcome under an explicit
   *accountability* rule rather than an authorship one.
 
+- **The contributing guide told contributors to run three commands; CI runs five.**
+  `ruff format --check` and `mkdocs build --strict` were missing from
+  `docs/contributing.md` and the PR checklist, so a contributor could do exactly what the
+  guide said, see green locally, and still fail CI on a formatting diff that says nothing
+  about their change — which is what happened on our first outside contribution (#32). The
+  guide, the PR template and CLAUDE.md now list the same five commands. Pre-commit already
+  ran the formatter, so anyone who installed the hooks was covered; the gap was only ever
+  in the written path.
+
 ## 0.1.0 — 2026-07-06
 
 **The sample-geometry generalization + a stable public API.** insitubatch is no longer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,13 @@ Contributor-facing rules (scope limits, dev setup, AI policy) live in
 ## Toolchain
 
 - **`uv`** manages everything (env, deps, running tools).
-- Verify: `uv run ruff check src tests bench examples`, `uv run mypy src bench examples`,
-  `uv run pytest -q`. Docs: `uv run --extra docs mkdocs build --strict` (CI runs it, so a
-  broken link fails the build). Pages under `docs/` **cannot** relatively link root files
-  (`DESIGN.md`, `GOVERNANCE.md`) — use the GitHub URL, as the existing pages do.
+- Verify: `uv run ruff check src tests bench examples`, `uv run ruff format --check src
+  tests bench examples`, `uv run mypy src bench examples`, `uv run pytest -q`. Docs:
+  `uv run --extra docs mkdocs build --strict` (CI runs it, so a broken link fails the
+  build). Those five are exactly what CI enforces, and docs/contributing.md plus the PR
+  checklist list the same set — keep the three in step. Pages under `docs/` **cannot**
+  relatively link root files (`DESIGN.md`, `GOVERNANCE.md`) — use the GitHub URL, as the
+  existing pages do.
 - **One framework per env.** torch/JAX/TF cannot share a process (Keras 3 pulls JAX in when
   installed), so a `.venv` carrying several **segfaults mid-suite** — the documented failure
   mode (README, "One framework per environment"), not a regression. If yours has them all:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -129,13 +129,24 @@ fastest way to find which file owns what.
 
 ## Running the tests
 
-The three commands CI runs, and the ones a reviewer will expect to be green:
+The four commands CI runs, and the ones a reviewer will expect to be green:
 
 ```bash
 uv run ruff check src tests bench examples
+uv run ruff format --check src tests bench examples
 uv run mypy src bench examples
 uv run pytest -q
 ```
+
+`--check` only reports; `uv run ruff format src tests bench examples` rewrites. The
+pre-commit hooks above format every commit for you, so this is the check most easily
+missed by anyone who has not installed them — and formatting is the one CI failure that
+tells you nothing about your change.
+
+**Tests that read a live cloud store** are marked `remote` and skipped unless you pass
+`--remote`. A run that skips them is a complete run: CI does not pass the flag either,
+because a public bucket going away must not turn into a red build for a contributor who
+changed nothing.
 
 **One framework per environment.** This is the single most common way a new contributor's
 run breaks, and it is not an insitubatch limitation. torch, JAX and TensorFlow cannot
@@ -160,6 +171,18 @@ publishes chunk readiness across threads, run the free-threaded job too — the 
 lock discipline and its cross-thread readiness signalling are exactly what it exercises. The full recipe (a separate
 `.venv-ft`, and why you must assert the GIL is actually off before trusting the run) is in
 the [README](https://github.com/emfdavid/insitubatch#free-threaded-313t). CI mirrors it.
+
+**The docs site is CI too.** `mkdocs build --strict` runs on every pull request, and
+`--strict` promotes a broken link or an orphaned page to a build failure — so a
+docs-only change can fail CI while every command above is green:
+
+```bash
+uv sync --extra docs
+uv run mkdocs build --strict
+```
+
+Pages under `docs/` cannot relatively link root files (`DESIGN.md`, `GOVERNANCE.md`);
+link those by GitHub URL, as the existing pages do.
 
 ## Code standards
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -96,9 +96,14 @@ tool versions, so nothing drifts between your machine and CI.
 ```bash
 git clone https://github.com/emfdavid/insitubatch.git
 cd insitubatch
-uv sync                    # core engine + dev tools
-uv run pre-commit install  # ruff + mypy on every commit
+uv sync                          # core engine + dev tools
+uv run pre-commit install        # ruff check + ruff format + mypy on every commit
 ```
+
+**Install the hooks.** They run the same ruff and mypy CI runs, and the formatter rewrites
+in place rather than reporting — so the one CI failure that tells you nothing about your
+change, a formatting diff, cannot reach you. Skipping them is the most common way a branch
+that is green locally goes red in CI.
 
 Extras, one at a time (see the framework caveat below):
 
@@ -196,8 +201,8 @@ link those by GitHub URL, as the existing pages do.
   under `-O`).
 - **mypy is clean and enforced.** Keep it that way: precise types, not `Any`, except for
   genuine third-party passthrough kwargs.
-- **ruff** with `E, F, I, UP, B, SIM` at line length 100. `uv run pre-commit install` makes
-  this automatic.
+- **ruff** with `E, F, I, UP, B, SIM` at line length 100, and `ruff format` for layout.
+  `uv run pre-commit install` makes both automatic.
 - **Comments explain *why*.** The codebase is dense with rationale for decisions that look
   arbitrary until you know what they route around. Match that; a comment restating the code
   is noise, a comment naming the failure mode is the point.


### PR DESCRIPTION
## Summary

`docs/contributing.md` opens **"The three commands CI runs"** and lists three. CI runs
**five**: `ruff check`, `ruff format --check`, `mypy`, `pytest`, and — on every pull
request — `mkdocs build --strict`.

So a contributor can do exactly what the guide says, see green locally, and still fail CI.
That is not hypothetical: it happened on our first outside contribution (#32), on a
formatting diff that says nothing about the change and gives no hint which command was
missing. The guide, the PR checklist and `CLAUDE.md` now list the same five.

Two further gaps the audit turned up, both in the guide only:

- **`mkdocs build --strict` runs on every PR**, and `--strict` promotes a broken link to a
  build failure — so a docs-only change can fail CI while every other command is green. The
  recipe, and the rule that pages under `docs/` cannot relatively link root files, were in
  `CLAUDE.md` but nowhere a contributor reads.
- **Tests marked `remote` skip unless `--remote` is passed.** Someone watching them skip had
  no way to know that is a complete run, or that CI does not pass the flag either.

### Pre-commit needs nothing added

Checked, since it is the other place these can drift. The hooks already run `ruff check`,
`ruff format` and `mypy` — anyone who ran `pre-commit install` was covered, and the gap was
only ever in the written path. Every tracked `.py` lives under the four paths CI checks
(`src tests bench examples`), so the hooks and CI cannot disagree about coverage. `pytest`
and the docs build stay out deliberately: both are too slow to sit on every commit, and the
guide is the right place to name them.

## For reviewers

- The wording change is "three" → "four" in the testing section plus a fifth (the docs
  build) called out separately, because it needs `--extra docs` and only matters when
  `docs/` changed. If you would rather see one flat list of five, say so.
- `CLAUDE.md` now says the three files list the same set, so a future edit to one is a
  prompt to check the others.
- Verified by running all five on this branch: ruff check, ruff format --check, mypy,
  `pytest -q` (496 passed, 7 skipped), and `mkdocs build --strict` (clean).

## Author attestation

- [ ] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

**Not ticked — drafted by Claude Code; that box is the author's to tick.**

## Checklist

- [x] `uv run ruff check src tests bench examples`, `uv run ruff format --check src tests
      bench examples`, `uv run mypy src bench examples` and `uv run pytest -q` are green
      locally (`uv run --extra docs mkdocs build --strict` too — this PR touches `docs/`)
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] User-facing behavior documented in `docs/*.md` — this PR *is* the documentation fix
- [x] No load-bearing invariant is broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)
