### PR TITLE
feat: bound read-ahead by the consumer, not by the pool (M-RA)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ site/
 
 # local backlog scratch (not tracked)
 ISSUES.md
+
+# Working notes for a design in progress: superseded the moment the code lands, and the
+# rules in CLAUDE.md send the parts worth keeping to DESIGN.md or CHANGELOG.md instead.
+design-notes/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+- **The windowed residency clamp charged every *view* of an array, not every array.** With
+  shuffle on, a windowed pass holds the split resident; that clamp multiplied the split by
+  the number of variables, but `t2m.shift(0/24/240)` are three views of one array and the
+  pool keys slots by `(path, chunk)` -- the planner already collapses them into one fetch.
+  Three leads therefore reserved three times the memory one of them needs. Counted once per
+  array, and extended by the window's reach in chunks so the clamp still covers the chunks a
+  lead reads beyond the split's edges: sizing to the split alone under-provisioned the
+  five-lead case (a floor of 1,638 against a measured live set of 1,711), and an under-sized
+  floor starves mid-epoch, which is the failure the floor exists to prevent. With the span
+  fix above, sparse forecast leads size to 1,878 chunk-equivalents where they cost 46,464 --
+  1.1-1.5x the measured requirement rather than 28x the whole dataset.
+
+  This costs no latency, and it is worth being precise about why: bounded read-ahead already
+  decoupled admission from the budget, so an inflated floor no longer makes the driver fetch
+  further ahead. Measured on the same store, a 9x difference in budget moved
+  time-to-first-batch not at all (1372 ms at 46,464 chunks, 1373 ms at 5,040). What it buys
+  is a configuration that can be *run*: an explicit budget covering the real need was
+  previously rejected outright, and `describe()` reported a number up to 45x too large.
+
 - **The residency floor was sized by the distance between offsets, so sparse forecast
   leads reserved memory nobody needed (#27).** `working_set_bytes` derived a single
   `window_factor` from `max(offset) - min(offset)` and applied it to every variable, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+- **One iteration could claim the entire chunk pool, so `zip(ds.train, ds.val)` deadlocked
+  at any budget (#64).** Admission parked only when the pool's byte budget was full, never
+  when a driver ran far ahead of its own consumer, so a driver walked its plan pinning
+  chunks until it held the whole pool: measured on a public GCS store, one owner held 32,
+  48, 64, 128 and 256 slots at 2x through 16x its 16-chunk working set, while the second
+  iteration acquired *none*. Raising `cache_budget_bytes` — what the error message advised
+  — enlarged the over-claim; the first budget that could have worked was one holding the
+  whole 19.9 GB split for a 66 MB working set. A pass now takes one fetch-ahead permit per
+  chunk, returned when its consumer releases that chunk, so it may run at most its own
+  working set ahead. Concurrent iterations work at the documented floor, and a single
+  iteration stops fetching the resident set before its first batch: on `era5_c8` over
+  in-region GCS with a 13.3 GB budget (GCP n2-standard-8, `block_chunks=16`,
+  `batch_size=32`, arms alternated three times in one session) time-to-first-batch went
+  from 965–10094 ms to 621–665 ms and throughput from 400–562 MB/s to 1082–1152 MB/s.
+
+  The bound is computed, never configured (`read_ahead_bound`), because there is no value
+  a caller could choose that beats it: below it the pass deadlocks against its own limit,
+  above it is the behaviour just described. `2 x block_chunks` is *not* that bound — a
+  windowed variable's chunk feeds several blocks and is released only at the last of them,
+  and a variable chunked finer than the reference grid contributes several chunks per
+  anchor chunk. Each of those found the rule by hanging the suite, and each now has a test.
+
+
 - **A healthy run could be killed with "residency budget exhausted ... this would hang".**
   `Scheduler._starvation` turns an admission stall into a raise rather than a hang, and it
   proves the stall terminal from three facts, the third being "a consumer is blocked in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **A fetch-ahead permit deficit hung the pass with nothing to read.** Bounded read-ahead
+  takes one permit per chunk and gets it back from the consumer's `unpin_block`, so a
+  consumer that cannot reach its next unpin never returns one. That wait was unbounded:
+  every other wait in the scheduler polls and proves itself terminal before giving up, but
+  this one presented as three idle threads, no log line, and no traceback -- the exact
+  failure the starvation detector was built to replace, reintroduced beside it. It bit
+  while developing per-block release, where a release that hands back fewer permits than
+  were taken is an easy mistake to make and, until now, an undiagnosable one. The wait is
+  now bounded and terminal on the same two facts as an admission stall (nothing in flight,
+  a consumer blocked where it cannot unpin), and it names the bound, the chunk, and what
+  the consumer is waiting on.
+
 - **The windowed residency clamp charged every *view* of an array, not every array.** With
   shuffle on, a windowed pass holds the split resident; that clamp multiplied the split by
   the number of variables, but `t2m.shift(0/24/240)` are three views of one array and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **The residency floor was sized by the distance between offsets, so sparse forecast
+  leads reserved memory nobody needed (#27).** `working_set_bytes` derived a single
+  `window_factor` from `max(offset) - min(offset)` and applied it to every variable, so
+  leads `{0, 24, 240}` on a one-sample-per-chunk store were charged for a 240-wide window
+  rather than the three chunks an anchor reads. Measured on a 2048-chunk store: the floor
+  came to 46,464 chunk-equivalents against a 1,638-chunk train split and a measured live
+  set of 1,280 -- **28x the whole dataset**. It was not merely wasteful: an explicit
+  `cache_budget_bytes` of twice the real need was *rejected* as below the floor, so the
+  forecast-lead configuration could not be run with a sane budget at all. Each variable is
+  now charged for what its own offset reads -- one chunk per anchor when the shift is a
+  whole number of chunks, two when it straddles a boundary -- and the same span term is
+  gone from the non-uniform-chunk-size branch, where a shift moves *which* chunks a
+  variable reads rather than how many. Sparse leads now size to 4,914; the estimate no
+  longer depends on which leads you train on, only how many.
+
 - **One iteration could claim the entire chunk pool, so `zip(ds.train, ds.val)` deadlocked
   at any budget (#64).** Admission parked only when the pool's byte budget was full, never
   when a driver ran far ahead of its own consumer, so a driver walked its plan pinning

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -495,7 +495,7 @@ class Scheduler:
                     # exactly like an admission and released by the same `unpin_block`, so
                     # skipping it here would return permits we never took.
                     if self._ahead is not None:
-                        await self._ahead.acquire()
+                        await self._take_ahead(read.array, read.chunk_index)
                     hit = self.pool.pin_if_ready(read.array, read.chunk_index, self._owner)
                     if not hit:
                         await self._admit(read.array, read.chunk_index)  # may await an unpin
@@ -551,6 +551,50 @@ class Scheduler:
                 # In the `finally` so a terminal starvation still reports the time it
                 # parked before proving itself fatal -- that number is the evidence.
                 self.stats.admission_parked_s += time.perf_counter() - t0
+
+    async def _take_ahead(self, array: str, chunk_index: int) -> None:
+        """Take a fetch-ahead permit, proving a stall terminal rather than waiting forever.
+
+        Permits come back from the consumer's ``unpin_block``, so a consumer that cannot
+        reach its next unpin never returns one -- the same shape as an admission stall, and
+        it deserves the same treatment. Waiting unbounded here would turn any miscount in
+        the permit accounting into three idle threads and no message, which is the failure
+        the starvation detector exists to replace.
+        """
+        assert self._ahead is not None
+        while True:
+            try:
+                await asyncio.wait_for(self._ahead.acquire(), STARVATION_POLL_S)
+                return
+            except TimeoutError:
+                starved = self._ahead_starvation(array, chunk_index)
+                if starved is not None:
+                    # `from None` for the same reason as in :meth:`_admit`: the poll
+                    # timeout is how we got here, not why.
+                    raise starved from None
+
+    def _ahead_starvation(self, array: str, chunk_index: int) -> RuntimeError | None:
+        """The error for a permit stall that cannot break, else ``None``.
+
+        Terminal on the same two facts as :meth:`_starvation`: nothing is on its way to a
+        slot, and a consumer is blocked where it cannot reach the unpin that would hand a
+        permit back. The cause differs, so the message does -- the budget is not the
+        problem, the distance this pass may run ahead of itself is.
+        """
+        if self._delivery_pending():
+            return None
+        waiting = self.pool.blocked_waiters()
+        if not waiting:
+            return None
+        return RuntimeError(
+            f"read-ahead permits exhausted: cannot start chunk {chunk_index} of {array!r}. "
+            f"This pass may hold {self._config.read_ahead_chunks} chunk(s) ahead of its own "
+            f"consumer; every one is outstanding, nothing is in flight, and the consumer is "
+            f"blocked on {sorted(waiting)[:4]}, so no permit can come back. The bound is "
+            "computed from the plan (`read_ahead_bound`) and must cover one block's reads "
+            "plus the next block's; a smaller one -- or a release that hands back fewer "
+            "permits than were taken -- deadlocks the pass against its own limit."
+        )
 
     def _delivery_pending(self) -> bool:
         """Is any tile still on its way to a slot?

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -183,6 +183,20 @@ class SchedulerConfig:
     ~= max_inflight * stored_chunk_nbytes (+ transform scratch). Residency is
     bounded separately by the pool's byte budget (admission evicts unpinned-LRU)."""
 
+    read_ahead_chunks: int = 0
+    """How many chunks this iteration may hold ahead of its own consumer.
+
+    ``0`` leaves admission bounded only by the pool's byte budget, so one driver claims
+    the whole pool however large it is -- which starves any other iteration sharing it
+    (#64) and, on a generous budget, fetches the resident set before the consumer's first
+    batch. :class:`~insitubatch.source.InSituDataset` always supplies a value, computed by
+    :func:`~insitubatch.source.read_ahead_bound`; ``0`` is what a caller driving a
+    :class:`Scheduler` directly gets.
+
+    It must be **at least** that computed bound. Below it the consumer waits for a chunk
+    the driver is not permitted to admit -- a deadlock of our own making rather than the
+    budget's -- which is why a non-zero value here is a testing seam, not a tuning knob."""
+
     decode_threads: int = 0
     """Size of the decode pool (the GIL-releasing codec decode runs here). ``0`` = auto =
     ``min(32, cpu+4)``.
@@ -308,6 +322,7 @@ class Scheduler:
         self._loop = _get_loop()
         self._inflight: asyncio.Semaphore | None = None
         self._capacity: asyncio.Event | None = None  # set on unpin -> wakes a parked admit
+        self._ahead: asyncio.Semaphore | None = None  # fetch-ahead permits (read_ahead_chunks)
         self._open_lock: asyncio.Lock | None = None
         self._ready = threading.Event()
         # OUR tasks, and only ours. `asyncio.all_tasks(loop)` is the *whole loop's* task
@@ -336,6 +351,14 @@ class Scheduler:
         the loop default on our behalf.
         """
         self._inflight = asyncio.Semaphore(self._config.max_inflight)
+        # One permit per *chunk* this iteration has admitted and whose consumer has not
+        # yet released it, so it bounds distance from the consumer rather than residency.
+        # `None` leaves admission bounded by the pool's byte budget alone.
+        self._ahead = (
+            asyncio.Semaphore(self._config.read_ahead_chunks)
+            if self._config.read_ahead_chunks
+            else None
+        )
         self._capacity = asyncio.Event()
         self._open_lock = asyncio.Lock()
         self._ready.set()
@@ -427,6 +450,16 @@ class Scheduler:
         self.pool.unpin_keys(keys, self._owner)
         if self._capacity is not None:
             self._loop.call_soon_threadsafe(self._capacity.set)
+        if self._ahead is not None:
+            # One permit back per chunk released: `release[bi]` holds each key once, and the
+            # driver took exactly one permit for it, so the two counts cannot drift.
+            self._loop.call_soon_threadsafe(self._release_ahead, len(keys))
+
+    def _release_ahead(self, n: int) -> None:  # on the loop
+        """Hand back `n` fetch-ahead permits, one per chunk the consumer released."""
+        assert self._ahead is not None
+        for _ in range(n):
+            self._ahead.release()
 
     def _on_drive_done(self, fut: Future) -> None:
         # Cancellation is normal: close() cancels a still-finishing drive at epoch
@@ -457,6 +490,12 @@ class Scheduler:
                 key = (read.array, read.chunk_index)
                 hit = decided.get(key)
                 if hit is None:
+                    # One permit per chunk, taken before we reference it and
+                    # returned by the consumer's unpin. Hits take one too: a hit is pinned
+                    # exactly like an admission and released by the same `unpin_block`, so
+                    # skipping it here would return permits we never took.
+                    if self._ahead is not None:
+                        await self._ahead.acquire()
                     hit = self.pool.pin_if_ready(read.array, read.chunk_index, self._owner)
                     if not hit:
                         await self._admit(read.array, read.chunk_index)  # may await an unpin

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -33,6 +33,7 @@ import queue
 import threading
 import time
 from collections.abc import Iterator, Sequence
+from dataclasses import replace
 from typing import TextIO
 
 import numpy as np
@@ -79,6 +80,49 @@ def _partition_blocks(order: np.ndarray, block_chunks: int) -> list[tuple[int, i
         (starts[k], starts[k + 1], appearance[k * block_chunks : (k + 1) * block_chunks])
         for k in range(len(starts) - 1)
     ]
+
+
+def read_ahead_bound(
+    block_keys: list[set[tuple[str, int]]], last_use: dict[tuple[str, int], int]
+) -> int:
+    """How many chunks a pass may hold ahead of its own consumer.
+
+    Computed, never configured. Below it the pass deadlocks against its own limit -- the
+    driver cannot admit the chunk the consumer is blocked on -- and above it admission is
+    bounded only by the pool, which is what lets one iteration claim the whole budget and
+    starve another (#64). Read-ahead depth is a cold-start knob rather than a throughput
+    one (see the benchmarks page), so there is no regime where a caller's number beats
+    this one.
+
+    The bound is, over blocks ``b``: everything still *live* at ``b`` -- first read at or
+    before it, last read at or after it -- plus the whole of block ``b+1``, which the
+    driver is permitted to be working on while the consumer gathers ``b``.
+
+    Both terms come from the read-unions the consumer actually waits on, because
+    ``block_chunks`` is the knob but not the count:
+
+    * a **windowed** variable reads ``anchor + offset``, so one chunk feeds several
+      blocks and is released only at the last of them -- its permit spans all of them;
+    * a variable chunked **finer than the reference grid** contributes several chunks per
+      anchor chunk, so a per-variable multiple of ``block_chunks`` under-counts it.
+    """
+    first_use: dict[tuple[str, int], int] = {}
+    for bi, keys in enumerate(block_keys):
+        for key in keys:
+            first_use.setdefault(key, bi)
+    opens = [0] * (len(block_keys) + 1)
+    closes = [0] * (len(block_keys) + 1)
+    for bi in first_use.values():
+        opens[bi] += 1
+    for bi in last_use.values():
+        closes[bi] += 1
+    live = peak = 0
+    for bi in range(len(block_keys)):
+        live += opens[bi]
+        nxt = len(block_keys[bi + 1]) if bi + 1 < len(block_keys) else 0
+        peak = max(peak, live + nxt)
+        live -= closes[bi]
+    return max(peak, 1)
 
 
 class InSituDataset:
@@ -448,6 +492,11 @@ class InSituDataset:
         for key, bi in last_use.items():
             release[bi].add(key)
 
+        # Computed, not configured (see `read_ahead_bound`). A non-zero value on the
+        # config is honoured so a test can supply a deliberately wrong one: a bound that
+        # cannot be wrong is a bound nothing proves the need for.
+        ahead = self.scheduler_config.read_ahead_chunks or read_ahead_bound(block_keys, last_use)
+
         def produce(sched: Scheduler) -> None:
             # Batches are cut over the WHOLE epoch order, not per block. Cutting them per
             # block (`range(rstart, rstop, bs)`) made every block whose row count was not a
@@ -514,7 +563,7 @@ class InSituDataset:
                 self.store,
                 self.geometries,
                 self._pool,
-                self.scheduler_config,
+                replace(self.scheduler_config, read_ahead_chunks=ahead),
                 owner=owner,
                 stats=stats,
             ) as sched:

--- a/src/insitubatch/summary.py
+++ b/src/insitubatch/summary.py
@@ -194,7 +194,6 @@ def working_set_bytes(
         def chunks_per_anchor(g: ArrayGeometry) -> int:
             return 1 if g.offset % spc0 == 0 else 2
 
-        per_chunk_all_vars = sum(bytes_per_chunk(g, o) for g, o in pairs)
         per_anchor_all_vars = sum(chunks_per_anchor(g) * bytes_per_chunk(g, o) for g, o in pairs)
         working_set = 2 * block_chunks * per_anchor_all_vars
         if windowed and shuffle:
@@ -204,8 +203,25 @@ def working_set_bytes(
             # once, the accepted memory cost of windows (spill to NVMe via cache_dir on large
             # splits). Only `.train` shuffles (eval views are sequential and spill only
             # locally), so size to the train split.
+            #
+            # Counted once per *array*, not once per view. The pool keys slots by
+            # `(path, chunk)` and the planner collapses several windowed views of one array
+            # into a single fetch, so `t2m.shift(0/24/240)` holds one slot per chunk between
+            # them -- charging three triples the estimate for the case windows exist for.
+            # Where views of one array disagree on slot size (a transform on one of them),
+            # the largest is what that slot must hold.
+            # The reach is added once, in chunks, rather than multiplied per variable: the
+            # union of chunks a windowed pass touches is the split shifted by each offset,
+            # so it runs past the split's edges by the offset range and no further. Sizing
+            # to the split alone under-provisions exactly the sparse-lead case (measured:
+            # a floor of 1,638 against a live set of 1,711), which starves mid-epoch.
+            per_path: dict[str, int] = {}
+            for g, o in pairs:
+                per_path[g.path] = max(per_path.get(g.path, 0), bytes_per_chunk(g, o))
+            span = max(offsets) - min(offsets)
             n_train_chunks = len(manifest.chunks[SplitName.TRAIN.value])
-            working_set = max(working_set, n_train_chunks * per_chunk_all_vars)
+            reach = n_train_chunks + -(-span // spc0)
+            working_set = max(working_set, reach * sum(per_path.values()))
         return working_set
 
     # Non-uniform chunk size: a variable maps the reference anchor grid onto its own chunks,

--- a/src/insitubatch/summary.py
+++ b/src/insitubatch/summary.py
@@ -173,7 +173,6 @@ def working_set_bytes(
     that grows (or shrinks) the data changes the footprint the budget must hold.
     """
     offsets = [g.offset for g in geoms]
-    span = max(offsets) - min(offsets)
     windowed = any(o != 0 for o in offsets)
     uniform_spc = len({g.sample_chunk_size for g in geoms}) == 1
 
@@ -183,13 +182,21 @@ def working_set_bytes(
     pairs = list(zip(geoms, out_geoms, strict=True))
     if uniform_spc:
         # Every variable's chunk aligns to the reference grid, so a block reads exactly its
-        # own chunks. A windowed read straddles at most one boundary, so an anchor chunk's
-        # read-union spans 2 + ceil(span/spc) chunks per variable; with every offset 0 the
-        # factor is 1 -- the plain 2 * block_chunks working set.
+        # own chunks. Each variable is charged for what *its own* offset reads: an anchor
+        # chunk's `spc` consecutive samples, shifted by that offset, land in one chunk when
+        # the shift is a whole number of chunks and straddle exactly one boundary otherwise.
+        #
+        # Per variable, deliberately. The distance between *different* variables' offsets
+        # says nothing about how many chunks either of them needs: forecast leads
+        # `{24h, 240h}` on a one-sample-per-chunk store are two reads, not 216.
         spc0 = geoms[0].sample_chunk_size
-        window_factor = 2 + (-(-span // spc0)) if windowed else 1
+
+        def chunks_per_anchor(g: ArrayGeometry) -> int:
+            return 1 if g.offset % spc0 == 0 else 2
+
         per_chunk_all_vars = sum(bytes_per_chunk(g, o) for g, o in pairs)
-        working_set = 2 * block_chunks * window_factor * per_chunk_all_vars
+        per_anchor_all_vars = sum(chunks_per_anchor(g) * bytes_per_chunk(g, o) for g, o in pairs)
+        working_set = 2 * block_chunks * per_anchor_all_vars
         if windowed and shuffle:
             # Shuffle permutes chunk order, so a windowed read can spill into chunks owned by
             # any other block: a chunk admitted early may be needed late. Until bounded
@@ -203,10 +210,15 @@ def working_set_bytes(
 
     # Non-uniform chunk size: a variable maps the reference anchor grid onto its own chunks,
     # so a block touches a variable-specific chunk count. A 2-block read-ahead window of
-    # 2*block_chunks*ref_spc anchor samples (plus the offset span) covers, per variable,
-    # ceil(window/spc)+1 of its chunks (the +1 for boundary misalignment).
+    # 2*block_chunks*ref_spc anchor samples covers, per variable, ceil(window/spc)+1 of its
+    # chunks (the +1 for boundary misalignment).
+    #
+    # The window is not widened by the offset span. A shift moves *which* chunks a variable
+    # reads, not how many: the same `window` consecutive samples land in the same count of
+    # its chunks wherever they start, and the +1 already pays for the misalignment. Adding
+    # the span charged every variable for the distance to the furthest *other* offset.
     def var_bytes(g: ArrayGeometry, o: ArrayGeometry, samples: int) -> int:
-        n_chunks = -(-(samples + span) // g.sample_chunk_size) + 1
+        n_chunks = -(-samples // g.sample_chunk_size) + 1
         return n_chunks * bytes_per_chunk(g, o)
 
     window_samples = 2 * block_chunks * ref_spc

--- a/tests/test_read_ahead_bound.py
+++ b/tests/test_read_ahead_bound.py
@@ -86,54 +86,52 @@ def test_a_single_block_still_admits_something() -> None:
 # -- the harness: can we still catch a wrong bound? --------------------------
 
 
-def test_an_undersized_bound_wedges_the_pass(write_zarr) -> None:
-    """Halve the computed bound and the pass stops making progress.
+def test_an_undersized_bound_raises_instead_of_wedging(write_zarr) -> None:
+    """A permit deficit must be diagnosable, not a silent hang.
 
-    `read_ahead_chunks` is deliberately not a user knob -- there is no value a caller
-    could choose that beats the computed one, and a too-small one deadlocks. It stays on
-    `SchedulerConfig` so this test can set one anyway: without a way to be wrong, none of
-    the cases above would be shown to matter.
+    Every other wait in the scheduler is bounded and proves itself terminal before giving
+    up -- that is what turns a stall into `residency budget exhausted` with a reason. The
+    fetch-ahead permit is a second thing a driver can wait on forever, so it needs the same
+    treatment: without it, any miscount in the permit accounting presents as three idle
+    threads and no message, which is the failure mode the starvation detector exists to
+    replace.
 
-    The fixture is sized so a correct run finishes in well under a second; the wait below
-    is two orders of magnitude longer, so this asserts a wedge rather than slowness.
+    `read_ahead_chunks` is not a user knob -- there is no value a caller could choose that
+    beats the computed one. It stays settable so this test can supply a deficit at all.
     """
     url, _ = write_zarr(n=128, spc=4, inner=(4, 4))
     geometries = open_geometries(obstore_store(url))
     manifest = split_by_chunk(geometries["t2m"], fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(
+        obstore_store(url),
+        manifest,
+        geometries=geometries,
+        batch_size=8,
+        block_chunks=4,
+        shuffle=True,
+        seed=0,
+    )
+    ds.scheduler_config = SchedulerConfig(
+        max_inflight=ds.scheduler_config.max_inflight, read_ahead_chunks=2
+    )
+    ds.set_epoch(0)
 
-    def drain(read_ahead: int | None) -> bool:
-        ds = InSituDataset(
-            obstore_store(url),
-            manifest,
-            geometries=geometries,
-            batch_size=8,
-            block_chunks=4,
-            shuffle=True,
-            seed=0,
-        )
-        if read_ahead is not None:
-            ds.scheduler_config = SchedulerConfig(
-                max_inflight=ds.scheduler_config.max_inflight, read_ahead_chunks=read_ahead
-            )
-        ds.set_epoch(0)
-        done = threading.Event()
+    result: dict[str, object] = {}
 
-        def body() -> None:
-            try:
-                for _batch in ds.train:
-                    pass
-            finally:
-                done.set()
+    def body() -> None:
+        try:
+            for _batch in ds.train:
+                pass
+            result["outcome"] = "completed"
+        except Exception as exc:  # noqa: BLE001 - the outcome is what is under test
+            result["outcome"] = exc
 
-        threading.Thread(target=body, daemon=True).start()
-        finished = done.wait(20)
-        if not finished:
-            # Close the pool so the wedged pass is not left parked on the shared loop for
-            # the rest of the session -- a leaked driver task is exactly the kind of
-            # cross-test interference the free-threaded job would surface as a mystery.
-            ds.close()
-            done.wait(5)
-        return finished
+    worker = threading.Thread(target=body, daemon=True)
+    worker.start()
+    worker.join(30)
 
-    assert drain(None), "the computed bound must let a pass finish"
-    assert not drain(2), "a bound below the floor must wedge -- else nothing above matters"
+    assert not worker.is_alive(), "an undersized bound hung instead of reporting"
+    assert isinstance(result["outcome"], Exception), f"expected a raise, got {result['outcome']}"
+    assert "read-ahead" in str(result["outcome"]), (
+        f"the error must name the fetch-ahead bound, not something else: {result['outcome']}"
+    )

--- a/tests/test_read_ahead_bound.py
+++ b/tests/test_read_ahead_bound.py
@@ -1,0 +1,139 @@
+"""The fetch-ahead bound is computed, and every term in it is load-bearing.
+
+Bounded read-ahead only works if the bound is right: below it the pass deadlocks against
+its own limit (the driver cannot admit the chunk its consumer is blocked on), and above it
+admission is bounded only by the pool -- which is what lets one iteration claim the whole
+budget and starve another.
+
+Each case here is a configuration that falsified a simpler rule. They are written against
+the pure function rather than a running pass because each was originally found as a *hang*,
+and a test whose failure mode is "the suite stops" is a bad trade for CI. The one test that
+does drive a real pass is the harness at the bottom: it exists to show the guard can still
+catch the broken case, since a bound that is never wrong is indistinguishable from a bound
+that is never checked.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from insitubatch import obstore_store, open_geometries, split_by_chunk
+from insitubatch.scheduler import SchedulerConfig
+from insitubatch.source import InSituDataset, read_ahead_bound
+
+
+def _last_use(block_keys: list[set[tuple[str, int]]]) -> dict[tuple[str, int], int]:
+    last: dict[tuple[str, int], int] = {}
+    for bi, keys in enumerate(block_keys):
+        for key in keys:
+            last[key] = bi
+    return last
+
+
+def _blocks(*groups: list[int]) -> list[set[tuple[str, int]]]:
+    return [{("t2m", c) for c in group} for group in groups]
+
+
+def test_plain_blocks_need_the_block_plus_one_ahead() -> None:
+    """Disjoint blocks of 4: the consumer holds one while the driver works the next."""
+    block_keys = _blocks([0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11])
+
+    assert read_ahead_bound(block_keys, _last_use(block_keys)) == 8
+
+
+def test_a_chunk_read_by_several_blocks_stays_counted_until_its_last() -> None:
+    """A windowed read spans blocks; its permit is held from first admission to last use.
+
+    Chunk 99 is read by blocks 0 and 2, so it is live across block 1 as well -- a rule
+    counting only two blocks' worth would not see it.
+    """
+    block_keys = _blocks([0, 1, 99], [2, 3], [4, 5, 99])
+    bound = read_ahead_bound(block_keys, _last_use(block_keys))
+
+    naive_two_blocks = 3 + 2  # |block 0| + |block 1|
+    assert bound > naive_two_blocks, "the chunk held across block 1 must be counted"
+
+
+def test_a_finer_chunked_variable_contributes_more_than_block_chunks() -> None:
+    """`block_chunks` is the knob, not the count.
+
+    With a variable chunked finer than the reference grid, one anchor chunk maps onto
+    several of its chunks, so any per-variable multiple of `block_chunks` under-counts.
+    """
+    block_keys = [
+        {("coarse", 0), ("fine", 0), ("fine", 1), ("fine", 2), ("fine", 3)},
+        {("coarse", 1), ("fine", 4), ("fine", 5), ("fine", 6), ("fine", 7)},
+    ]
+    bound = read_ahead_bound(block_keys, _last_use(block_keys))
+
+    block_chunks, n_variables = 1, 2
+    assert bound > block_chunks * n_variables * 2
+
+
+def test_the_bound_is_never_below_one_block_and_its_successor() -> None:
+    """The floor, asserted directly: whatever else is live, both blocks must fit."""
+    block_keys = _blocks([0, 1, 2, 3, 4], [5, 6])
+
+    assert read_ahead_bound(block_keys, _last_use(block_keys)) >= 5 + 2
+
+
+def test_a_single_block_still_admits_something() -> None:
+    """Degenerate plans must not produce a zero bound -- that admits nothing, forever."""
+    assert read_ahead_bound([], {}) >= 1
+    assert read_ahead_bound(_blocks([0]), _last_use(_blocks([0]))) >= 1
+
+
+# -- the harness: can we still catch a wrong bound? --------------------------
+
+
+def test_an_undersized_bound_wedges_the_pass(write_zarr) -> None:
+    """Halve the computed bound and the pass stops making progress.
+
+    `read_ahead_chunks` is deliberately not a user knob -- there is no value a caller
+    could choose that beats the computed one, and a too-small one deadlocks. It stays on
+    `SchedulerConfig` so this test can set one anyway: without a way to be wrong, none of
+    the cases above would be shown to matter.
+
+    The fixture is sized so a correct run finishes in well under a second; the wait below
+    is two orders of magnitude longer, so this asserts a wedge rather than slowness.
+    """
+    url, _ = write_zarr(n=128, spc=4, inner=(4, 4))
+    geometries = open_geometries(obstore_store(url))
+    manifest = split_by_chunk(geometries["t2m"], fractions=(1.0, 0.0, 0.0))
+
+    def drain(read_ahead: int | None) -> bool:
+        ds = InSituDataset(
+            obstore_store(url),
+            manifest,
+            geometries=geometries,
+            batch_size=8,
+            block_chunks=4,
+            shuffle=True,
+            seed=0,
+        )
+        if read_ahead is not None:
+            ds.scheduler_config = SchedulerConfig(
+                max_inflight=ds.scheduler_config.max_inflight, read_ahead_chunks=read_ahead
+            )
+        ds.set_epoch(0)
+        done = threading.Event()
+
+        def body() -> None:
+            try:
+                for _batch in ds.train:
+                    pass
+            finally:
+                done.set()
+
+        threading.Thread(target=body, daemon=True).start()
+        finished = done.wait(20)
+        if not finished:
+            # Close the pool so the wedged pass is not left parked on the shared loop for
+            # the rest of the session -- a leaked driver task is exactly the kind of
+            # cross-test interference the free-threaded job would surface as a mystery.
+            ds.close()
+            done.wait(5)
+        return finished
+
+    assert drain(None), "the computed bound must let a pass finish"
+    assert not drain(2), "a bound below the floor must wedge -- else nothing above matters"

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -412,3 +412,49 @@ def test_a_variable_chunked_finer_than_the_reference_is_not_widened_by_the_span(
         )
 
     assert floor(240) == floor(8), "a distant lead costs the same as a near one"
+
+
+def test_windowed_views_of_one_array_are_charged_once():
+    """Three leads on one array hold one slot per chunk between them, not three.
+
+    The pool keys slots by `(path, chunk)` and the planner collapses several windowed
+    views of one array into a single fetch, so charging the whole-split clamp per view
+    tripled the estimate for the case windows exist for.
+    """
+    g = _geom((256, 4, 4), (4, 4, 4))
+    manifest = split_by_chunk(g)
+
+    def other(path):
+        return ArrayGeometry(path=path, shape=(256, 4, 4), chunks=(4, 4, 4), dtype=np.dtype("f4"))
+
+    # Both arms are windowed with the same offsets, so both hit the whole-split clamp and
+    # the only difference is how many distinct arrays those offsets read.
+    aliased = [g.shift(0), g.shift(4), g.shift(8)]  # one path, three views
+    distinct = [g.shift(0), other("u10").shift(4), other("v10").shift(8)]
+
+    def floor(geoms):
+        return working_set_bytes(
+            geoms, geoms, manifest, block_chunks=4, ref_spc=4, shuffle=True, assembles=False
+        )
+
+    assert floor(aliased) < floor(distinct), "aliased views must not be charged three times"
+
+
+def test_the_windowed_clamp_reaches_past_the_split_edges():
+    """A lead reads chunks the split does not contain, so the clamp must cover them.
+
+    Sizing the clamp to the split alone under-provisions the sparse-lead case -- measured
+    at a floor of 1,638 against a live set of 1,711 -- and an under-sized floor starves
+    mid-epoch, which is the failure this floor exists to prevent.
+    """
+    g = _geom((256, 4, 4), (1, 4, 4))
+    manifest = split_by_chunk(g)
+    near = [g.shift(0), g.shift(1)]
+    far = [g.shift(0), g.shift(64)]
+
+    def floor(geoms):
+        return working_set_bytes(
+            geoms, geoms, manifest, block_chunks=4, ref_spc=1, shuffle=True, assembles=False
+        )
+
+    assert floor(far) > floor(near), "a wider reach touches more chunks and must be sized for"

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -347,3 +347,68 @@ def test_chunk_bytes_does_not_vary_with_the_final_short_chunk() -> None:
     g = _geom((9, 3), (4, 2))  # 9 samples in chunks of 4: the last holds 1
     assert g.n_chunks == 3
     assert g.chunk_bytes == 2 * (4 * 2) * 4
+
+
+# --- the residency floor is sized by the offsets, not by the distance between them ------
+
+
+def test_sparse_leads_cost_what_they_read_not_the_distance_between_them():
+    """Two forecast leads are two reads, however far apart they sit.
+
+    The floor was derived from `max(offset) - min(offset)`, so `{0, 240}` on a
+    one-sample-per-chunk store reserved for a 240-wide window -- against the two chunks an
+    anchor genuinely needs. Sizing by the span makes the budget a function of *which*
+    leads you train on rather than *how many*, and an explicit budget covering the real
+    need is then rejected as below the floor (#27).
+    """
+    g = _geom((256, 4, 4), (1, 4, 4))
+    manifest = split_by_chunk(g)
+
+    def floor(offsets):
+        geoms = [g.shift(o) for o in offsets]
+        return working_set_bytes(
+            geoms, geoms, manifest, block_chunks=4, ref_spc=1, shuffle=False, assembles=False
+        )
+
+    assert floor([0, 24]) == floor([0, 240]), "the span must not enter the floor"
+    assert floor([0, 24, 48]) == floor([0, 24, 2400]), "nor with more leads"
+    # and more leads *do* cost more -- the count is what matters
+    assert floor([0, 24, 48]) > floor([0, 24])
+
+
+def test_an_offset_that_straddles_a_chunk_boundary_costs_two_chunks():
+    """`spc=4`: a shift of a whole chunk reads one, a shift inside one reads two.
+
+    The control for the test above -- if the floor ignored offsets entirely it would also
+    be span-independent, and would under-provision every misaligned window.
+    """
+    g = _geom((256, 4, 4), (4, 4, 4))
+    manifest = split_by_chunk(g)
+
+    def floor(offset):
+        geoms = [g.shift(offset)]
+        return working_set_bytes(
+            geoms, geoms, manifest, block_chunks=4, ref_spc=4, shuffle=False, assembles=False
+        )
+
+    assert floor(4) == floor(0), "a whole-chunk shift stays within one chunk per anchor"
+    assert floor(2) == 2 * floor(0), "a shift inside a chunk straddles exactly one boundary"
+
+
+def test_a_variable_chunked_finer_than_the_reference_is_not_widened_by_the_span():
+    """The same defect lived in the non-uniform-spc branch as `samples + span`.
+
+    A shift moves *which* of a variable's chunks are read, not how many, so the window it
+    covers is the same width wherever it starts.
+    """
+    coarse = _geom((256, 4, 4), (8, 4, 4))
+    fine = _geom((256, 4, 4), (2, 4, 4))
+    manifest = split_by_chunk(coarse)
+
+    def floor(offset):
+        geoms = [coarse, fine.shift(offset)]
+        return working_set_bytes(
+            geoms, geoms, manifest, block_chunks=4, ref_spc=8, shuffle=False, assembles=False
+        )
+
+    assert floor(240) == floor(8), "a distant lead costs the same as a near one"


### PR DESCRIPTION
Closes #64. Closes #27.

Three commits: the read-ahead bound (#64), then two residency-floor fixes (#27) that the
first one made measurable — with `read_ahead_bound` computing the plan's real live set,
the floor could finally be checked against what a pass actually needs.

## Summary

Admission parked only when the pool's byte budget was full — never when a driver ran far
ahead of its own consumer. So a driver walked its plan pinning chunk after chunk until it
held **the whole pool**, whatever size that was. Measured on a public GCS store, one owner's
pins against its own 16-chunk working set:

| budget | resident | pins by owner | outcome |
|---|--:|---|---|
| 2x floor (32 chunks) | 32 | `{1: 32}` | deadlock |
| 4x floor (64) | 64 | `{1: 64}` | deadlock |
| 16x floor (256) | 256 | `{1: 256}` | deadlock |

The second iteration acquired **zero** slots in every row, so `zip(ds.train, ds.val)` — a
documented configuration — could not run at any budget short of the whole split (19.9 GB,
for a 66 MB working set). Raising `cache_budget_bytes`, which the starvation error advises,
enlarged the over-claim.

A pass now takes one **fetch-ahead permit** per chunk, returned when its consumer releases
that chunk, so it runs at most its own working set ahead of itself. Every budget above now
completes.

### The bound is computed, not configured

`read_ahead_bound(block_keys, last_use)` = `max over b of (live(b) + |block_keys[b+1]|)`.
There is no value a caller could choose that beats it — below it the pass deadlocks against
its own limit, above it is the behaviour this PR removes, and the benchmarks page already
establishes read-ahead depth as a cold-start knob rather than a throughput one.

**`2 x block_chunks` is not the bound.** Three configurations each falsified a simpler rule,
and each was found by hanging the suite rather than by reasoning:

- a **windowed** variable's chunk feeds several blocks and is released only at the last of
  them, so its permit spans all of them;
- a variable chunked **finer than the reference grid** contributes several chunks per anchor
  chunk, so any per-variable multiple of `block_chunks` under-counts;
- the driver is additionally allowed one block of read-ahead beyond what is live.

Both terms therefore come from the block read-unions the consumer actually waits on.

## Measurement

`era5_c8` over in-region GCS, GCP `n2-standard-8` (8 vCPU, us-central1-b), chunk 33.2 MB,
budget 13.3 GB (400 chunks), `block_chunks=16` (32-chunk floor), `batch_size=32`, 40
batches. Control and treatment are the same binary in the same session, arms alternated
three times:

| arm | TTFB | throughput |
|---|--:|--:|
| unbounded (today) | 1295 / 10094 / 965 ms | 533 / 400 / 562 MB/s |
| bounded (this PR) | 665 / 621 / 650 ms | 1082 / 1093 / 1152 MB/s |

Every bounded run beats every unbounded run on both axes, and bounded is far more
predictable. The 10-second outlier is the eager whole-split fetch this PR removes.

## Sizing the residency floor (#27)

`working_set_bytes` derived one `window_factor` from `max(offset) - min(offset)` and applied
it to every variable, and the whole-split clamp charged every *view* rather than every
array. Measured on a 2048-chunk store (1,638 in the train split), against the live set the
plan actually needs:

| offsets | floor before | after | measured live set | after / measured |
|---|--:|--:|--:|--:|
| none | 64 | 64 | 64 | 1.0x |
| dense ±1 | 4,914 | 1,640 | 1,356 | 1.2x |
| lead {0,24} | 3,328 | 1,662 | 898 | 1.9x |
| sparse {0,24,240} | **46,464** | **1,878** | 1,280 | 1.5x |
| sparse {0,24,48,96,240} | **77,440** | **1,878** | 1,711 | 1.1x |

The old floor demanded **28x the whole dataset** for three forecast leads, and it was not
merely wasteful: an explicit `cache_budget_bytes` of twice the real need was *rejected* as
below the floor, so that configuration could not be run at all. Sparse leads are what
dynamical.org's forecast archives look like.

**No latency claim.** Bounded read-ahead (the first commit) already decoupled admission from
the budget, so an inflated floor no longer makes the driver fetch further ahead: on the same
store, a 9x difference in budget moved TTFB not at all — 1372 ms at 46,464 chunks, 1373 ms
at 5,040. What the floor fixes buy is a runnable configuration and an honest `describe()`.

**One caution while fixing it:** charging per array without also extending the clamp by the
window's reach *under*-provisioned the five-lead case (floor 1,638 against a live set of
1,711). An under-sized floor starves mid-epoch, which is the failure the floor exists to
prevent, so the reach is added once in chunks — the additive form, not the multiplicative
one that made the original span term wrong.

## For reviewers

- **The free-threaded job is the gate I most want run.** This adds cross-thread signalling:
  permits are acquired on the loop and released from the producer thread via
  `call_soon_threadsafe`. I have no 3.13t environment, so CI is the first FT run.
- **Permit accounting is the correctness core.** Cache hits take a permit too — a hit is
  pinned exactly like an admission and released by the same `unpin_block`, so exempting it
  would return permits never taken. Audited over a full pass: 64 taken / 64 returned, plain
  and windowed.
- `tests/test_read_ahead_bound.py` tests the pure function for each configuration that broke
  a simpler rule, plus a harness that drives a real pass with a deliberately halved bound and
  asserts it wedges (fixture sized so a correct run takes well under a second against a
  20-second wait). That harness is why `SchedulerConfig.read_ahead_chunks` remains settable.
- **One measurement, one geometry.** I would not put the throughput numbers on the
  benchmarks page until a second store shape agrees.
- The floor fixes are checked against the *measured* live set rather than against a
  hand-derived formula, and every case is now at or above it — the direction that matters,
  since under-provisioning is a hang and over-provisioning is only memory.
- #27 was written up as suited to an outside contributor. I took it because it turned out to
  block a sane budget on the forecast-lead shape and because #65 made the correct number
  measurable; the harder follow-up it gestures at (re-fetching the window spill instead of
  holding the split) is untouched and still open for someone.

## Author attestation

- [x] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

**Not ticked — drafted by Claude Code; that box is the author's to tick.**

## Checklist

- [x] Tests added or updated
- [x] `ruff check`, `ruff format --check`, `mypy`, `pytest -q` green locally (514 passed,
      7 skipped)
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] No load-bearing invariant is broken
- [x] Touches `ChunkPool`, the scheduler, or cross-thread readiness → the free-threaded
      (3.13t) run passes — **not run locally; this PR is how it gets run.**
- [x] Performance claim carries hardware, store, geometry, config and alternating controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)
