### PR TITLE
fix: carry shuffle-block bounds with the order instead of reconstructing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+- **A shuffle-block's chunks were reconstructed from the draw order, and on any windowed
+  view the reconstruction was wrong (#68).** `_partition_blocks` re-derived block membership
+  by repacking the surviving chunks into fresh groups of `block_chunks`, but the rows stayed
+  laid out in the original grouping. Once `valid_anchor_range` dropped a whole chunk -- which
+  any lead offset does -- the two shifted against each other: on a 256-sample store with a
+  three-chunk lead, 77 blocks were recovered where 32 existed, and the chunks a block named
+  were a different partition from the chunks its own rows drew. The information to do it
+  correctly is not in the order at all, since a two-chunk block that lost a chunk is
+  indistinguishable from a one-chunk block, so the order builders now return the bounds they
+  lay down (`DrawOrder`) and dropping rows narrows a block instead of re-cutting them all.
+
+  It bit nobody yet, and that is the point: the planner expands each anchor into every chunk
+  that anchor reads, and retention pins a chunk to its last use, so misattribution changed no
+  sample and -- measured -- delayed no fetch (0 of 77 blocks fetch-complete later than their
+  own anchors, against 0 of 32 on the control). It was fatal only to the next change: per-block
+  release (#66) plans from the block's chunks and releases the block's read keys, so every
+  disagreement is a read-ahead permit taken and never returned. This is the third time the
+  planner has disagreed with the rest of the system about what a read is (#56 was the last).
+
+  `block_shuffled_order` and `sequential_order` now return a `DrawOrder` rather than a bare
+  array; its `.rows` is the array they used to return, and `sequential_order` takes
+  `block_chunks` so both orders carry one block definition.
+
 - **A fetch-ahead permit deficit hung the pass with nothing to read.** Bounded read-ahead
   takes one permit per chunk and gets it back from the consumer's `unpin_block`, so a
   consumer that cannot reach its next unpin never returns one. That wait was unbounded:

--- a/src/insitubatch/__init__.py
+++ b/src/insitubatch/__init__.py
@@ -19,6 +19,7 @@ from .pool import ChunkPool
 from .runtime import Depths, PassStats, StageTimes, bottleneck
 from .scheduler import Scheduler, SchedulerConfig
 from .shuffle import (
+    DrawOrder,
     block_shuffled_order,
     chunk_permutation,
     sequential_order,
@@ -77,6 +78,7 @@ __all__ = [
     "as_tf_dataset",
     "as_torch",
     "close_store",
+    "DrawOrder",
     "block_shuffled_order",
     "bottleneck",
     "build_stored_chunk_reads",

--- a/src/insitubatch/shuffle.py
+++ b/src/insitubatch/shuffle.py
@@ -15,6 +15,8 @@ knob. This module owns the *index math*; buffer.py owns the residency.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import numpy as np
 
 
@@ -45,6 +47,58 @@ def _chunk_rows(chunk_id: int, samples_per_chunk: int, n_samples: int) -> np.nda
 _EMPTY_ORDER = np.empty((0, 2), dtype=np.int64)
 
 
+@dataclass(eq=False, slots=True)
+class DrawOrder:
+    """One epoch's ``[chunk_id, within]`` draw rows, and the shuffle-blocks holding them.
+
+    The blocks are *laid down* here, by the builder that creates them, and travel with the
+    rows. They are not inferred from the rows afterwards, because in general they cannot
+    be: once a windowed view's edge anchors are dropped, a two-chunk block that lost a
+    chunk is indistinguishable from a one-chunk block, and any reconstruction has to guess
+    (#68). Dropping rows shrinks the block that held them; it never re-cuts the blocks.
+
+    ``bounds`` holds ``n_blocks + 1`` row offsets, so block ``i`` is
+    ``rows[bounds[i] : bounds[i + 1]]``. Blocks are contiguous, gapless, and cover every
+    row.
+    """
+
+    rows: np.ndarray
+    bounds: np.ndarray
+
+    def __len__(self) -> int:
+        return int(len(self.rows))
+
+    @property
+    def n_blocks(self) -> int:
+        return max(int(len(self.bounds)) - 1, 0)
+
+    def block(self, index: int) -> tuple[int, int]:
+        """Half-open row range ``[start, stop)`` of block ``index``."""
+        return int(self.bounds[index]), int(self.bounds[index + 1])
+
+    def keep(self, mask: np.ndarray) -> DrawOrder:
+        """Drop the rows ``mask`` excludes, narrowing the blocks that held them.
+
+        A block emptied outright is dropped -- it names no chunks and does no work -- but
+        the blocks around it keep their identity, which is the whole point of carrying the
+        bounds rather than re-deriving them from what survived.
+        """
+        kept = np.flatnonzero(mask)
+        # searchsorted maps an old row offset to the number of surviving rows before it,
+        # which is exactly its offset in the filtered array.
+        bounds = np.searchsorted(kept, self.bounds)
+        nonempty = np.concatenate([[True], np.diff(bounds) > 0])
+        return DrawOrder(self.rows[kept], bounds[nonempty])
+
+
+def _from_blocks(blocks: list[np.ndarray]) -> DrawOrder:
+    """Assemble one draw order from per-block row arrays, recording where each begins."""
+    if not blocks:
+        return DrawOrder(_EMPTY_ORDER.copy(), np.zeros(1, dtype=np.int64))
+    bounds = np.concatenate([[0], np.cumsum([len(b) for b in blocks])]).astype(np.int64)
+    return DrawOrder(np.concatenate(blocks, axis=0), bounds)
+
+
 def block_shuffled_order(
     chunk_ids: np.ndarray,
     samples_per_chunk: int,
@@ -53,48 +107,67 @@ def block_shuffled_order(
     block_chunks: int,
     seed: int,
     epoch: int,
-) -> np.ndarray:
+) -> DrawOrder:
     """Produce a shuffle-block-ordered list of ``[chunk_id, within]`` draws.
 
     Chunks are permuted per epoch; within each window of ``block_chunks`` chunks
     all samples are shuffled together. ``n_samples`` is the global sample-axis
-    length, used to size a short final chunk correctly. Returns an array of shape
-    ``(N, 2)`` where ``N`` is the number of samples covered by ``chunk_ids``.
+    length, used to size a short final chunk correctly.
+
+    Returns a :class:`DrawOrder`: ``rows`` of shape ``(N, 2)`` covering every sample in
+    ``chunk_ids``, and the ``bounds`` of the blocks this function just laid down. The
+    caller needs those bounds and cannot recover them from ``rows`` -- see
+    :class:`DrawOrder` -- so they are returned rather than left to be inferred.
     """
     if not len(chunk_ids):
-        return _EMPTY_ORDER.copy()  # an empty split yields nothing; see sequential_order
+        return _from_blocks([])  # an empty split yields nothing; see sequential_order
     perm = chunk_permutation(chunk_ids, seed=seed, epoch=epoch)
     rng = np.random.default_rng((seed, epoch, 7919))
 
-    rows: list[np.ndarray] = []
+    blocks: list[np.ndarray] = []
     for start in range(0, len(perm), block_chunks):
         block = perm[start : start + block_chunks]
         pairs = np.concatenate(
             [_chunk_rows(int(cid), samples_per_chunk, n_samples) for cid in block], axis=0
         )
         rng.shuffle(pairs)  # in-place, along axis 0
-        rows.append(pairs)
-    return np.concatenate(rows, axis=0)
+        blocks.append(pairs)
+    return _from_blocks(blocks)
 
 
 def sequential_order(
     chunk_ids: np.ndarray,
     samples_per_chunk: int,
     n_samples: int,
-) -> np.ndarray:
+    *,
+    block_chunks: int,
+) -> DrawOrder:
     """In-order ``[chunk_id, within]`` draws (no permutation, no shuffle).
 
     Used when ``shuffle=False`` (eval / inference / reconstruction): chunks in the
     given order, samples in order within each. Honours a short final chunk.
+
+    ``block_chunks`` changes no row -- nothing is shuffled -- but an unshuffled pass still
+    streams and releases in blocks, so it is grouped the same way. One block definition
+    across both orders is what lets the rest of the engine stay ignorant of which it walks.
 
     No chunks is an empty order of the same shape, not an error: a split can hold nothing
     because it was asked to (``fractions=(1.0, 0.0, 0.0)``) or because a small store
     rounded it to zero, and iterating it should yield nothing the way an empty list does.
     """
     if not len(chunk_ids):
-        return _EMPTY_ORDER.copy()
-    return np.concatenate(
-        [_chunk_rows(int(cid), samples_per_chunk, n_samples) for cid in chunk_ids], axis=0
+        return _from_blocks([])
+    return _from_blocks(
+        [
+            np.concatenate(
+                [
+                    _chunk_rows(int(cid), samples_per_chunk, n_samples)
+                    for cid in chunk_ids[start : start + block_chunks]
+                ],
+                axis=0,
+            )
+            for start in range(0, len(chunk_ids), block_chunks)
+        ]
     )
 
 

--- a/src/insitubatch/shuffle.py
+++ b/src/insitubatch/shuffle.py
@@ -51,11 +51,9 @@ _EMPTY_ORDER = np.empty((0, 2), dtype=np.int64)
 class DrawOrder:
     """One epoch's ``[chunk_id, within]`` draw rows, and the shuffle-blocks holding them.
 
-    The blocks are *laid down* here, by the builder that creates them, and travel with the
-    rows. They are not inferred from the rows afterwards, because in general they cannot
-    be: once a windowed view's edge anchors are dropped, a two-chunk block that lost a
-    chunk is indistinguishable from a one-chunk block, and any reconstruction has to guess
-    (#68). Dropping rows shrinks the block that held them; it never re-cuts the blocks.
+    The blocks are laid down by the builder that creates them and travel with the rows, so
+    every consumer reads one account of where a block begins and ends. Dropping rows narrows
+    the block that held them and leaves its neighbours' membership untouched.
 
     ``bounds`` holds ``n_blocks + 1`` row offsets, so block ``i`` is
     ``rows[bounds[i] : bounds[i + 1]]``. Blocks are contiguous, gapless, and cover every
@@ -79,9 +77,9 @@ class DrawOrder:
     def keep(self, mask: np.ndarray) -> DrawOrder:
         """Drop the rows ``mask`` excludes, narrowing the blocks that held them.
 
-        A block emptied outright is dropped -- it names no chunks and does no work -- but
-        the blocks around it keep their identity, which is the whole point of carrying the
-        bounds rather than re-deriving them from what survived.
+        A block emptied outright is dropped: it names no chunks and does no work. Every
+        other block keeps its membership, its row range shifted by the number of rows
+        removed ahead of it.
         """
         kept = np.flatnonzero(mask)
         # searchsorted maps an old row offset to the number of surviving rows before it,

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -33,7 +33,7 @@ import queue
 import threading
 import time
 from collections.abc import Iterator, Sequence
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from typing import TextIO
 
 import numpy as np
@@ -43,7 +43,7 @@ from .buffers import HostAllocator
 from .pool import ChunkPool, output_geometry, validate_scopes
 from .runtime import Depths, PassStats, StatsCollector, format_pass
 from .scheduler import Scheduler, SchedulerConfig
-from .shuffle import block_shuffled_order, sequential_order
+from .shuffle import DrawOrder, block_shuffled_order, sequential_order
 from .split import SplitManifest, valid_anchor_range
 from .store import close_store, open_geometries
 from .summary import DatasetReport, describe, print_summary, working_set_bytes
@@ -58,28 +58,21 @@ logger = logging.getLogger(__name__)
 DEFAULT_MAX_INFLIGHT = 32
 
 
-def _partition_blocks(order: np.ndarray, block_chunks: int) -> list[tuple[int, int, np.ndarray]]:
-    """Split a draw ``order`` into shuffle-blocks: ``(row_start, row_stop, chunk_ids)``.
+@dataclass(eq=False, slots=True)
+class _Block:
+    """One shuffle-block: where its rows are, what it draws from, and what it reads.
 
-    ``block_shuffled_order`` shuffles samples *within* a block of ``block_chunks``
-    chunks and concatenates blocks in chunk-permutation order, so every block is a
-    contiguous row range over disjoint chunks. We recover the blocks from the chunks'
-    first-appearance order (vectorized: O(chunks) of Python, not O(samples)), which
-    is robust to short final chunks where fixed-stride slicing would misalign.
+    Both halves come from the same rows. ``chunk_ids`` are the anchor chunks the driver
+    plans and fetches; ``read_keys`` are the ``(path, chunk)`` slots the consumer waits on
+    and releases, which a windowed view can push outside ``chunk_ids`` entirely. Deriving
+    them together, once, is the point: they were two derivations from two different inputs,
+    and on any windowed view they disagreed (#68).
     """
-    if not len(order):
-        return []
-    cids = order[:, 0].astype(np.int64)
-    _, first_pos = np.unique(cids, return_index=True)
-    appearance = cids[np.sort(first_pos)]  # chunk ids in order of first appearance
-    block_of = np.full(int(cids.max()) + 1, -1, dtype=np.int64)
-    block_of[appearance] = np.arange(len(appearance)) // block_chunks
-    block_per_row = block_of[cids]
-    starts = [0, *(np.flatnonzero(np.diff(block_per_row) != 0) + 1).tolist(), len(order)]
-    return [
-        (starts[k], starts[k + 1], appearance[k * block_chunks : (k + 1) * block_chunks])
-        for k in range(len(starts) - 1)
-    ]
+
+    start: int
+    stop: int
+    chunk_ids: np.ndarray
+    read_keys: set[tuple[str, int]]
 
 
 def read_ahead_bound(
@@ -391,7 +384,7 @@ class InSituDataset:
             ids = self.manifest.chunks[split.value]
         return np.asarray(ids, dtype=np.int64)
 
-    def _draw_order(self, split: SplitName | None, shuffle: bool) -> np.ndarray:
+    def _draw_order(self, split: SplitName | None, shuffle: bool) -> DrawOrder:
         chunk_ids = self._chunk_ids(split)
         spc = self._ref_spc  # the manifest's anchor grid, shared by every variable
         n_samples = self.manifest.n_samples
@@ -405,19 +398,31 @@ class InSituDataset:
                 epoch=self._epoch,
             )
         else:
-            order = sequential_order(chunk_ids, spc, n_samples)
+            order = sequential_order(chunk_ids, spc, n_samples, block_chunks=self.block_chunks)
         return self._drop_edge_anchors(order, spc, n_samples)
 
-    def _drop_edge_anchors(self, order: np.ndarray, spc: int, n_samples: int) -> np.ndarray:
+    def _drop_edge_anchors(self, order: DrawOrder, spc: int, n_samples: int) -> DrawOrder:
         """Keep only anchors whose every windowed read ``anchor + offset`` is on the
         array. Offset 0 (no window) keeps the whole order. Anchors are dropped, not
-        their chunks, so an edge chunk still contributes its interior anchors."""
+        their chunks, so an edge chunk still contributes its interior anchors -- and the
+        block that held them narrows rather than the blocks being re-cut around the gap."""
         offsets = [g.offset for g in self.geometries.values()]
         lo, hi = valid_anchor_range(offsets, n_samples)
         if lo == 0 and hi == n_samples:
             return order
-        anchor = order[:, 0] * spc + order[:, 1]
-        return order[(anchor >= lo) & (anchor < hi)]
+        anchor = order.rows[:, 0] * spc + order.rows[:, 1]
+        return order.keep((anchor >= lo) & (anchor < hi))
+
+    def _blocks(self, order: DrawOrder, spc: int) -> list[_Block]:
+        """The pass's blocks, each derived once from the rows the builder assigned it."""
+        blocks = []
+        for index in range(order.n_blocks):
+            start, stop = order.block(index)
+            rows = order.rows[start:stop]
+            blocks.append(
+                _Block(start, stop, np.unique(rows[:, 0]), self._block_read_keys(rows, spc))
+            )
+        return blocks
 
     def _block_read_keys(self, block_rows: np.ndarray, spc: int) -> set[tuple[str, int]]:
         """The ``(path, chunk)`` slots a block's anchors read across all variables --
@@ -450,8 +455,9 @@ class InSituDataset:
         """
         spc = self._ref_spc  # the manifest anchor grid, shared by every variable
         order = self._draw_order(split, shuffle)
-        blocks = _partition_blocks(order, self.block_chunks)
-        ordered_chunks = [int(c) for _rstart, _rstop, cids in blocks for c in cids]
+        rows = order.rows
+        blocks = self._blocks(order, spc)
+        ordered_chunks = [int(c) for block in blocks for c in block.chunk_ids]
 
         # One owner per pass, minted here and threaded through this iteration's scheduler
         # (admission pins) and its producer (block pins). Scoping references this way is
@@ -483,7 +489,7 @@ class InSituDataset:
         # block (shuffle permutes chunk order), and the driver fetches each chunk only
         # once, so a chunk must stay resident from admit until its *last* referencing
         # block drains. Release each chunk exactly there (last_use).
-        block_keys = [self._block_read_keys(order[rs:re], spc) for rs, re, _ in blocks]
+        block_keys = [block.read_keys for block in blocks]
         release: list[set[tuple[str, int]]] = [set() for _ in blocks]
         last_use: dict[tuple[str, int], int] = {}
         for bi, keys in enumerate(block_keys):
@@ -507,8 +513,8 @@ class InSituDataset:
             # with three shapes the retrace cache never settles).
             #
             # Blocks stay exactly what they were -- contiguous row ranges over disjoint
-            # chunks -- and `order` was always one flat array for the epoch, so a batch that
-            # crosses a boundary is just `order[start : start + bs]` not being truncated.
+            # chunks -- and the rows are one flat array for the epoch, so a batch that
+            # crosses a boundary is just `rows[start : start + bs]` not being truncated.
             # What the boundary needs is bookkeeping, tracked as two monotone frontiers over
             # the block list: `ready` (waited) and `freed` (released). Both only advance, and
             # each block passes through each exactly once, so this stays O(blocks) of Python.
@@ -516,21 +522,21 @@ class InSituDataset:
             ready = freed = 0
             try:
                 sched.start(ordered_chunks, spc)
-                for start in range(0, len(order), bs):
+                for start in range(0, len(rows), bs):
                     if stop.is_set():
                         return
-                    stop_row = min(start + bs, len(order))
+                    stop_row = min(start + bs, len(rows))
                     # Wait every block this batch draws from. A batch spans at most two
                     # (bs <= a block's rows in any sane configuration, and the loop is
                     # correct regardless): a block's batches draw across its whole
                     # read-union, so it must be assembled -- and claimed by the driver, see
                     # ChunkPool.wait_ready -- before gathering. Each wait is cheap once ready.
-                    while ready < len(blocks) and blocks[ready][0] < stop_row:
+                    while ready < len(blocks) and blocks[ready].start < stop_row:
                         for path, cid in block_keys[ready]:
                             sched.pool.wait_ready(path, cid, owner)
                         ready += 1
                     g0 = time.thread_time()
-                    batch = sched.pool.gather(order[start:stop_row], self.variables, spc)
+                    batch = sched.pool.gather(rows[start:stop_row], self.variables, spc)
                     # thread_time, not perf_counter: gather is work this thread does, and a
                     # wall clock here would bill it for whatever else held the GIL.
                     stats.gather_s += time.thread_time() - g0
@@ -545,7 +551,7 @@ class InSituDataset:
                     # into a read-ahead stall via `try_admit` parking on a full budget. Safe
                     # this early because `gather` COPIES out of the slots, so the batch never
                     # aliases chunk memory and the reference is already dead weight.
-                    while freed < len(blocks) and blocks[freed][1] <= stop_row:
+                    while freed < len(blocks) and blocks[freed].stop <= stop_row:
                         sched.unpin_block(release[freed])
                         freed += 1
                     b0 = time.thread_time()

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -62,11 +62,10 @@ DEFAULT_MAX_INFLIGHT = 32
 class _Block:
     """One shuffle-block: where its rows are, what it draws from, and what it reads.
 
-    Both halves come from the same rows. ``chunk_ids`` are the anchor chunks the driver
-    plans and fetches; ``read_keys`` are the ``(path, chunk)`` slots the consumer waits on
-    and releases, which a windowed view can push outside ``chunk_ids`` entirely. Deriving
-    them together, once, is the point: they were two derivations from two different inputs,
-    and on any windowed view they disagreed (#68).
+    ``chunk_ids`` are the anchor chunks the driver plans and fetches; ``read_keys`` are the
+    ``(path, chunk)`` slots the consumer waits on and releases, which a windowed view can
+    push outside ``chunk_ids`` entirely. Both are derived from this block's own rows, here
+    and only here, so the driver and the consumer share one account of what the block covers.
     """
 
     start: int
@@ -404,8 +403,8 @@ class InSituDataset:
     def _drop_edge_anchors(self, order: DrawOrder, spc: int, n_samples: int) -> DrawOrder:
         """Keep only anchors whose every windowed read ``anchor + offset`` is on the
         array. Offset 0 (no window) keeps the whole order. Anchors are dropped, not
-        their chunks, so an edge chunk still contributes its interior anchors -- and the
-        block that held them narrows rather than the blocks being re-cut around the gap."""
+        their chunks, so an edge chunk still contributes its interior anchors, and the block
+        that held a dropped anchor narrows by exactly that row."""
         offsets = [g.offset for g in self.geometries.values()]
         lo, hi = valid_anchor_range(offsets, n_samples)
         if lo == 0 and hi == n_samples:

--- a/src/insitubatch/summary.py
+++ b/src/insitubatch/summary.py
@@ -368,7 +368,7 @@ def describe(ds: InSituDataset, *, iterations: int = 1) -> DatasetReport:
     }
 
     order = ds._draw_order(SplitName.TRAIN, ds.shuffle)
-    quality = shuffle_quality(order, ds._ref_spc) if len(order) > 1 else None
+    quality = shuffle_quality(order.rows, ds._ref_spc) if len(order) > 1 else None
 
     cfg = ConfigReport(
         batch_size=ds.batch_size,

--- a/tests/test_block_structure.py
+++ b/tests/test_block_structure.py
@@ -1,0 +1,354 @@
+"""Structural invariants of a shuffle-block: what a block *is*, checked against an oracle.
+
+The engine's block bookkeeping is invisible to every value-level test in the suite.
+Retention pins a chunk from its first use to its last, so a block that claims the wrong
+chunks still delivers exactly the right samples -- the batches are correct and the
+structure underneath them is not. Nothing here asserts on data; these are assertions about
+the plan.
+
+**Where the answers come from.** An invariant is only worth asserting if its oracle is
+something other than the code under test, or the test says `f(x) == f(x)` in a costume. Two
+sources here are outside the engine's vectorized path:
+
+* **A per-sample walk.** ``_reference_read_keys`` resolves each drawn anchor one at a time,
+  and resolves ``sample -> chunk`` by *inverting* :meth:`ArrayGeometry.samples_in_chunk`
+  rather than by the floor-division the engine uses. Different direction, different
+  primitive. It stays independent permanently, and not by anyone's discipline: "the Python
+  hot path is O(chunks), not O(samples)" is a load-bearing invariant, so the engine can
+  never converge on this implementation. What we give up for throughput we get back as a
+  free oracle. ``samples_in_chunk`` is itself pinned against the ``zarr-indexing`` package
+  in `test_zarr_indexing_parity.py`, so the chain bottoms out outside this repository.
+* **An explicit live-set simulation.** ``_reference_peak`` holds a set and measures it,
+  where :func:`read_ahead_bound` does open/close arithmetic over first- and last-use maps.
+
+Both survive the unification these tests exist to guide (#68). When one definition of "the
+chunks this block reads" replaces the present two, an assertion that the two agree becomes
+an assertion that a value equals itself -- so no such assertion is made here. Every check
+below relates the engine to an oracle, or the block structure to the draw order it came
+from, and both of those still have content afterwards.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+from insitubatch import obstore_store, open_geometries, split_by_chunk
+from insitubatch.plan import build_stored_chunk_reads
+from insitubatch.shuffle import chunk_permutation
+from insitubatch.source import InSituDataset, _partition_blocks, read_ahead_bound
+from insitubatch.types import ArrayGeometry, SplitName
+
+Key = tuple[str, int]
+
+
+# -- the oracles ---------------------------------------------------------------
+
+
+def _sample_to_chunk(geom: ArrayGeometry) -> list[int]:
+    """``sample -> chunk`` by inverting ``samples_in_chunk``, not by dividing.
+
+    The engine computes this the other way round and in bulk. Building the table from the
+    chunk's own declared extent keeps the reference honest about *which* function it is
+    trusting: the one the zarr-indexing parity test already pins.
+    """
+    table = [-1] * geom.n_samples
+    for chunk in range(geom.n_chunks):
+        for sample in geom.samples_in_chunk(chunk):
+            table[sample] = chunk
+    assert -1 not in table, "samples_in_chunk does not tile the sample axis"
+    return table
+
+
+def _reference_read_keys(
+    rows: np.ndarray, geometries: dict[str, ArrayGeometry], ref_spc: int
+) -> set[Key]:
+    """The ``(path, chunk)`` slots ``rows`` read, resolved one drawn sample at a time."""
+    tables = {name: _sample_to_chunk(geom) for name, geom in geometries.items()}
+    keys: set[Key] = set()
+    for chunk_id, within in rows.tolist():
+        anchor = int(chunk_id) * ref_spc + int(within)
+        for name, geom in geometries.items():
+            keys.add((geom.path, tables[name][anchor + geom.offset]))
+    return keys
+
+
+def _reference_peak(block_keys: list[set[Key]]) -> int:
+    """Peak concurrent residency, by holding a live set rather than counting transitions.
+
+    A key is live from the block that first reads it through the block that last does; the
+    driver is additionally allowed to be working on block ``b+1`` while the consumer
+    gathers ``b``. That is the same rule :func:`read_ahead_bound` encodes, arrived at by
+    simulation instead of by arithmetic over first/last-use maps.
+    """
+    last_use = {key: bi for bi, keys in enumerate(block_keys) for key in keys}
+    live: set[Key] = set()
+    peak = 0
+    for bi, keys in enumerate(block_keys):
+        live |= keys
+        ahead = block_keys[bi + 1] if bi + 1 < len(block_keys) else set()
+        peak = max(peak, len(live | ahead))
+        live = {key for key in live if last_use[key] > bi}
+    return max(peak, 1)
+
+
+# -- the sweep -----------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Case:
+    """One geometry. ``offsets`` are windowed views of the single stored array."""
+
+    id: str
+    n: int
+    spc: int
+    block_chunks: int
+    offsets: tuple[int, ...]
+    shuffle: bool = True
+    fractions: tuple[float, float, float] = (1.0, 0.0, 0.0)
+
+
+CASES = [
+    # -- controls: no window, so no anchor is ever dropped --------------------
+    Case("plain", n=256, spc=4, block_chunks=2, offsets=(0,)),
+    Case("plain-sequential", n=256, spc=4, block_chunks=2, offsets=(0,), shuffle=False),
+    Case("plain-wide-blocks", n=256, spc=4, block_chunks=8, offsets=(0,)),
+    Case("plain-split", n=256, spc=4, block_chunks=2, offsets=(0,), fractions=(0.8, 0.1, 0.1)),
+    Case("plain-ragged-tail", n=250, spc=4, block_chunks=3, offsets=(0,)),
+    # -- windowed: `valid_anchor_range` drops edge anchors ---------------------
+    Case("lead-1", n=256, spc=4, block_chunks=2, offsets=(0, 1)),
+    Case("lead-one-chunk", n=256, spc=4, block_chunks=2, offsets=(0, 4)),
+    Case("lead-three-chunks", n=256, spc=4, block_chunks=2, offsets=(0, 12)),
+    Case("lead-sequential", n=256, spc=4, block_chunks=2, offsets=(0, 12), shuffle=False),
+    Case("history-and-lead", n=256, spc=4, block_chunks=2, offsets=(-4, 0, 4)),
+    Case("sparse-leads", n=256, spc=4, block_chunks=4, offsets=(0, 12, 60)),
+    Case("wide-blocks-windowed", n=256, spc=4, block_chunks=8, offsets=(0, 12)),
+    Case("one-sample-chunks", n=64, spc=1, block_chunks=4, offsets=(0, 3)),
+    Case("fat-chunks", n=256, spc=32, block_chunks=2, offsets=(0, 32)),
+    Case("ragged-tail-windowed", n=250, spc=4, block_chunks=3, offsets=(0, 12)),
+    Case(
+        "windowed-split", n=256, spc=4, block_chunks=2, offsets=(0, 12), fractions=(0.8, 0.1, 0.1)
+    ),
+]
+
+WINDOWED = [c for c in CASES if any(o != 0 for o in c.offsets)]
+
+
+@dataclass
+class Pass:
+    """One epoch's draw order and the block structure the engine derives from it."""
+
+    ds: InSituDataset
+    order: np.ndarray
+    blocks: list[tuple[int, int, np.ndarray]]
+    ref_spc: int
+
+    def rows(self, bi: int) -> np.ndarray:
+        start, stop, _ = self.blocks[bi]
+        return self.order[start:stop]
+
+    def declared(self, bi: int) -> set[Key]:
+        """The chunks the *driver* plans for block ``bi`` -- expanded from its chunk ids."""
+        _s, _e, cids = self.blocks[bi]
+        reads = build_stored_chunk_reads(cids, self.ds.geometries, self.ref_spc)
+        return {(r.array, r.chunk_index) for r in reads}
+
+    def awaited(self, bi: int) -> set[Key]:
+        """The chunks the *consumer* pins and releases for block ``bi``."""
+        return self.ds._block_read_keys(self.rows(bi), self.ref_spc)
+
+
+@pytest.fixture
+def build_pass(write_zarr):
+    """Open a dataset for one case and expose its epoch-0 draw order and blocks."""
+    made: list[InSituDataset] = []
+
+    def _build(case: Case) -> Pass:
+        url, _ = write_zarr(n=case.n, spc=case.spc, inner=(2, 2))
+        base = open_geometries(obstore_store(url))["t2m"]
+        geoms = {f"o{i}": base.shift(o) for i, o in enumerate(case.offsets)}
+        manifest = split_by_chunk(base, fractions=case.fractions)
+        ds = InSituDataset(
+            obstore_store(url),
+            manifest,
+            geometries=geoms,
+            batch_size=4,
+            block_chunks=case.block_chunks,
+            shuffle=case.shuffle,
+            seed=0,
+        )
+        made.append(ds)
+        ds.set_epoch(0)
+        order = ds._draw_order(SplitName.TRAIN, shuffle=case.shuffle)
+        return Pass(ds, order, _partition_blocks(order, ds.block_chunks), base.sample_chunk_size)
+
+    yield _build
+    for ds in made:
+        ds.close()
+
+
+# -- validate the instrument ---------------------------------------------------
+
+
+def test_the_reference_resolves_a_hand_computed_case() -> None:
+    """Point the oracle at an answer worked out by hand before trusting it on a sweep."""
+    geom = ArrayGeometry("t2m", (8, 2), (4, 2), np.dtype("f4"))
+    assert _sample_to_chunk(geom) == [0, 0, 0, 0, 1, 1, 1, 1]
+
+    # Anchors 2 and 3 with a lead of 2 read samples {2,3} for "now" and {4,5} for "next":
+    # chunk 0 for the first, chunk 1 for the second.
+    rows = np.array([[0, 2], [0, 3]], dtype=np.int64)
+    geoms = {"now": geom, "next": geom.shift(2)}
+    assert _reference_read_keys(rows, geoms, 4) == {("t2m", 0), ("t2m", 1)}
+
+
+def test_the_reference_agrees_with_the_engine_where_nothing_is_dropped(build_pass) -> None:
+    """The control for the oracle: with no window the engine's own math is known-good."""
+    p = build_pass(Case("plain", n=256, spc=4, block_chunks=2, offsets=(0,)))
+    assert _reference_read_keys(p.order, p.ds.geometries, p.ref_spc) == p.awaited(0) | set().union(
+        *(p.awaited(bi) for bi in range(len(p.blocks)))
+    )
+
+
+def test_the_peak_simulation_matches_a_hand_computed_schedule() -> None:
+    """Worked by hand: a key shared across blocks stays live, and one block runs ahead."""
+    a, b, c, d = ("x", 0), ("x", 1), ("x", 2), ("x", 3)
+
+    # b0={a,b} b1={b} b2={c}: draining b0 holds {a,b} while fetching b1's {b} -- already
+    # held, so 2. Draining b1 holds {b} and fetches {c}: also 2.
+    assert _reference_peak([{a, b}, {b}, {c}]) == 2
+
+    # Widen the block ahead and the peak follows it: {b} live, {c,d} arriving.
+    assert _reference_peak([{a, b}, {b}, {c, d}]) == 3
+
+    assert _reference_peak([]) == 1
+
+
+# -- the invariants ------------------------------------------------------------
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c.id for c in CASES])
+def test_blocks_tile_the_draw_order(build_pass, case: Case) -> None:
+    """Row ranges partition the order: contiguous, gapless, covering every drawn row."""
+    p = build_pass(case)
+    assert p.blocks, "a non-empty split must produce at least one block"
+    assert p.blocks[0][0] == 0
+    assert p.blocks[-1][1] == len(p.order)
+    for (_s, stop, _c), (nxt, _e, _d) in zip(p.blocks, p.blocks[1:], strict=False):
+        assert stop == nxt
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c.id for c in CASES])
+def test_a_block_declares_the_chunks_its_own_rows_draw_from(build_pass, case: Case) -> None:
+    """The anchor chunks a block names must be the ones its rows actually draw from.
+
+    This is the identity of a block. Everything downstream -- what to fetch, in what order,
+    what to pin, when to release -- is keyed on it.
+    """
+    p = build_pass(case)
+    for bi, (start, stop, cids) in enumerate(p.blocks):
+        drawn = {int(c) for c in p.order[start:stop, 0]}
+        assert drawn == {int(c) for c in cids}, (
+            f"block {bi}: rows draw from chunks {sorted(drawn)}, "
+            f"but the block declares {sorted(int(c) for c in cids)}"
+        )
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c.id for c in CASES])
+def test_blocks_are_slices_of_the_epoch_chunk_permutation(build_pass, case: Case) -> None:
+    """A block is `block_chunks` consecutive chunks of this epoch's permutation.
+
+    That is the definition -- `block_shuffled_order` groups the permutation and shuffles
+    within each group -- and it is the property internal consistency cannot see. A recovery
+    that re-groups the surviving chunks into fresh runs can be perfectly self-consistent
+    while describing blocks the shuffle never laid down, which changes both what is held
+    resident together and how far a chunk's residency has to stretch.
+
+    The oracle is :func:`chunk_permutation`, keyed on (seed, epoch) alone and tested in
+    `test_shuffle.py` -- a separate function from the one under test, and one that stays
+    separate however the block structure comes to be reported.
+    """
+    p = build_pass(case)
+    ids = np.asarray(p.ds.manifest.chunks["train"], dtype=np.int64)
+    laid_down = chunk_permutation(ids, seed=p.ds.seed, epoch=0) if case.shuffle else ids
+    drawn = {int(c) for c in p.order[:, 0]}  # edge-anchor drop can empty a chunk entirely
+    surviving = [int(c) for c in laid_down if int(c) in drawn]
+    expected = [
+        set(surviving[k : k + case.block_chunks])
+        for k in range(0, len(surviving), case.block_chunks)
+    ]
+    got = [{int(c) for c in cids} for _s, _e, cids in p.blocks]
+    # Membership, not order within a block: the rows are shuffled together, so which of a
+    # block's chunks is named first carries no meaning and the engine reports them by first
+    # appearance. The sequence *of* blocks does carry meaning and is compared.
+    assert got == expected, (
+        f"{len(got)} blocks against {len(expected)} in the permutation this epoch laid down"
+    )
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c.id for c in CASES])
+def test_the_awaited_keys_match_a_per_sample_walk(build_pass, case: Case) -> None:
+    """The vectorized residency set equals the one a per-sample walk resolves."""
+    p = build_pass(case)
+    for bi in range(len(p.blocks)):
+        assert p.awaited(bi) == _reference_read_keys(p.rows(bi), p.ds.geometries, p.ref_spc), (
+            f"block {bi}: the O(chunks) read-key math disagrees with an O(samples) walk"
+        )
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c.id for c in CASES])
+def test_the_driver_plans_every_chunk_its_consumer_will_wait_on(build_pass, case: Case) -> None:
+    """A consumer must never block on a slot the driver did not plan to fill.
+
+    The driver expands each block's chunk ids; the consumer waits on the keys its rows
+    Containment is the weaker half of what release-and-re-read needs -- #66 wants equality,
+    so that every permit taken comes back.
+
+    It costs nothing today, and the reason is worth stating so nobody weakens it by
+    accident: the planner expands each anchor into *every* chunk that anchor reads, so a
+    windowed view's spill chunk is fetched alongside the anchor needing it whatever block
+    the anchor was attributed to, and the pass-wide dedup plus retention covers the rest.
+    Measured over the failing geometries below, no block is fetch-complete later than its
+    own anchors -- 0 of 77 on `lead-three-chunks`, against 0 of 32 on the control. The
+    property is latent, which is precisely why it needs an assertion rather than a
+    benchmark: nothing observable will regress until per-block release makes it fatal.
+    """
+    p = build_pass(case)
+    for bi in range(len(p.blocks)):
+        missing = p.awaited(bi) - p.declared(bi)
+        assert not missing, (
+            f"block {bi}: the consumer waits on {sorted(missing)[:4]}, "
+            f"which the driver never planned for this block"
+        )
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c.id for c in CASES])
+def test_every_drawn_chunk_is_planned_exactly_once(build_pass, case: Case) -> None:
+    """Across the pass, the driver's plan covers what the consumer reads, without repeats.
+
+    Repeats matter as much as omissions: today's plan dedups over the whole pass, so a
+    chunk admitted twice is a reference nobody returns.
+    """
+    p = build_pass(case)
+    ordered = [int(c) for _s, _e, cids in p.blocks for c in cids]
+    assert len(ordered) == len(set(ordered)), "a chunk is planned by more than one block"
+    planned = {
+        (r.array, r.chunk_index)
+        for r in build_stored_chunk_reads(ordered, p.ds.geometries, p.ref_spc)
+    }
+    assert _reference_read_keys(p.order, p.ds.geometries, p.ref_spc) <= planned
+
+
+@pytest.mark.parametrize("case", CASES, ids=[c.id for c in CASES])
+def test_read_ahead_bound_covers_the_simulated_peak(build_pass, case: Case) -> None:
+    """The computed bound must be at least the peak a live-set simulation observes.
+
+    Below the peak the pass deadlocks against its own limit; the scheduler now reports that
+    rather than hanging, but reporting it is not the same as not doing it.
+    """
+    p = build_pass(case)
+    block_keys = [p.awaited(bi) for bi in range(len(p.blocks))]
+    last_use = {key: bi for bi, keys in enumerate(block_keys) for key in keys}
+    assert read_ahead_bound(block_keys, last_use) >= _reference_peak(block_keys)

--- a/tests/test_block_structure.py
+++ b/tests/test_block_structure.py
@@ -37,8 +37,8 @@ import pytest
 
 from insitubatch import obstore_store, open_geometries, split_by_chunk
 from insitubatch.plan import build_stored_chunk_reads
-from insitubatch.shuffle import chunk_permutation
-from insitubatch.source import InSituDataset, _partition_blocks, read_ahead_bound
+from insitubatch.shuffle import DrawOrder, chunk_permutation
+from insitubatch.source import InSituDataset, _Block, read_ahead_bound
 from insitubatch.types import ArrayGeometry, SplitName
 
 Key = tuple[str, int]
@@ -138,26 +138,27 @@ WINDOWED = [c for c in CASES if any(o != 0 for o in c.offsets)]
 
 @dataclass
 class Pass:
-    """One epoch's draw order and the block structure the engine derives from it."""
+    """One epoch's draw order and the blocks the engine walks it in."""
 
     ds: InSituDataset
-    order: np.ndarray
-    blocks: list[tuple[int, int, np.ndarray]]
+    order: DrawOrder
+    blocks: list[_Block]
     ref_spc: int
 
     def rows(self, bi: int) -> np.ndarray:
-        start, stop, _ = self.blocks[bi]
-        return self.order[start:stop]
+        block = self.blocks[bi]
+        return self.order.rows[block.start : block.stop]
 
     def declared(self, bi: int) -> set[Key]:
-        """The chunks the *driver* plans for block ``bi`` -- expanded from its chunk ids."""
-        _s, _e, cids = self.blocks[bi]
-        reads = build_stored_chunk_reads(cids, self.ds.geometries, self.ref_spc)
+        """The slots the *driver* plans for block ``bi`` -- expanded from its chunk ids."""
+        reads = build_stored_chunk_reads(
+            self.blocks[bi].chunk_ids, self.ds.geometries, self.ref_spc
+        )
         return {(r.array, r.chunk_index) for r in reads}
 
     def awaited(self, bi: int) -> set[Key]:
-        """The chunks the *consumer* pins and releases for block ``bi``."""
-        return self.ds._block_read_keys(self.rows(bi), self.ref_spc)
+        """The slots the *consumer* pins and releases for block ``bi``."""
+        return self.blocks[bi].read_keys
 
 
 @pytest.fixture
@@ -182,7 +183,8 @@ def build_pass(write_zarr):
         made.append(ds)
         ds.set_epoch(0)
         order = ds._draw_order(SplitName.TRAIN, shuffle=case.shuffle)
-        return Pass(ds, order, _partition_blocks(order, ds.block_chunks), base.sample_chunk_size)
+        spc = base.sample_chunk_size
+        return Pass(ds, order, ds._blocks(order, spc), spc)
 
     yield _build
     for ds in made:
@@ -207,9 +209,8 @@ def test_the_reference_resolves_a_hand_computed_case() -> None:
 def test_the_reference_agrees_with_the_engine_where_nothing_is_dropped(build_pass) -> None:
     """The control for the oracle: with no window the engine's own math is known-good."""
     p = build_pass(Case("plain", n=256, spc=4, block_chunks=2, offsets=(0,)))
-    assert _reference_read_keys(p.order, p.ds.geometries, p.ref_spc) == p.awaited(0) | set().union(
-        *(p.awaited(bi) for bi in range(len(p.blocks)))
-    )
+    everything = set().union(*(p.awaited(bi) for bi in range(len(p.blocks))))
+    assert _reference_read_keys(p.order.rows, p.ds.geometries, p.ref_spc) == everything
 
 
 def test_the_peak_simulation_matches_a_hand_computed_schedule() -> None:
@@ -234,26 +235,31 @@ def test_blocks_tile_the_draw_order(build_pass, case: Case) -> None:
     """Row ranges partition the order: contiguous, gapless, covering every drawn row."""
     p = build_pass(case)
     assert p.blocks, "a non-empty split must produce at least one block"
-    assert p.blocks[0][0] == 0
-    assert p.blocks[-1][1] == len(p.order)
-    for (_s, stop, _c), (nxt, _e, _d) in zip(p.blocks, p.blocks[1:], strict=False):
-        assert stop == nxt
+    assert p.blocks[0].start == 0
+    assert p.blocks[-1].stop == len(p.order)
+    for block, nxt in zip(p.blocks, p.blocks[1:], strict=False):
+        assert block.stop == nxt.start
 
 
 @pytest.mark.parametrize("case", CASES, ids=[c.id for c in CASES])
-def test_a_block_declares_the_chunks_its_own_rows_draw_from(build_pass, case: Case) -> None:
-    """The anchor chunks a block names must be the ones its rows actually draw from.
+def test_each_drawn_chunk_belongs_to_exactly_one_block(build_pass, case: Case) -> None:
+    """No chunk's rows straddle a boundary, and every drawn chunk is in some block.
 
-    This is the identity of a block. Everything downstream -- what to fetch, in what order,
-    what to pin, when to release -- is keyed on it.
+    Asserting instead that a block's chunk ids equal its own rows' chunks would be
+    tautological -- one is derived from the other. What is *not* given is that the
+    boundaries fall where no chunk spans two of them: a chunk in two blocks is pinned by
+    both and released by whichever drains last, which is how a shared residency becomes a
+    reference nobody returns.
     """
     p = build_pass(case)
-    for bi, (start, stop, cids) in enumerate(p.blocks):
-        drawn = {int(c) for c in p.order[start:stop, 0]}
-        assert drawn == {int(c) for c in cids}, (
-            f"block {bi}: rows draw from chunks {sorted(drawn)}, "
-            f"but the block declares {sorted(int(c) for c in cids)}"
+    seen: set[int] = set()
+    for bi, block in enumerate(p.blocks):
+        ids = {int(c) for c in block.chunk_ids}
+        assert seen.isdisjoint(ids), (
+            f"block {bi} shares chunks {sorted(seen & ids)} with an earlier block"
         )
+        seen |= ids
+    assert seen == {int(c) for c in p.order.rows[:, 0]}
 
 
 @pytest.mark.parametrize("case", CASES, ids=[c.id for c in CASES])
@@ -273,13 +279,17 @@ def test_blocks_are_slices_of_the_epoch_chunk_permutation(build_pass, case: Case
     p = build_pass(case)
     ids = np.asarray(p.ds.manifest.chunks["train"], dtype=np.int64)
     laid_down = chunk_permutation(ids, seed=p.ds.seed, epoch=0) if case.shuffle else ids
-    drawn = {int(c) for c in p.order[:, 0]}  # edge-anchor drop can empty a chunk entirely
-    surviving = [int(c) for c in laid_down if int(c) in drawn]
-    expected = [
-        set(surviving[k : k + case.block_chunks])
-        for k in range(0, len(surviving), case.block_chunks)
+    drawn = {int(c) for c in p.order.rows[:, 0]}  # edge-anchor drop can empty a chunk
+    # Group the permutation *first*, then remove what the drop took. Filtering before
+    # grouping would repack the survivors into fresh runs -- which is the defect, not the
+    # specification: a block that loses a chunk narrows, it does not borrow from its
+    # neighbour, and a block that loses all of them disappears.
+    groups = [
+        set(int(c) for c in laid_down[k : k + case.block_chunks]) & drawn
+        for k in range(0, len(laid_down), case.block_chunks)
     ]
-    got = [{int(c) for c in cids} for _s, _e, cids in p.blocks]
+    expected = [g for g in groups if g]
+    got = [{int(c) for c in block.chunk_ids} for block in p.blocks]
     # Membership, not order within a block: the rows are shuffled together, so which of a
     # block's chunks is named first carries no meaning and the engine reports them by first
     # appearance. The sequence *of* blocks does carry meaning and is compared.
@@ -332,13 +342,13 @@ def test_every_drawn_chunk_is_planned_exactly_once(build_pass, case: Case) -> No
     chunk admitted twice is a reference nobody returns.
     """
     p = build_pass(case)
-    ordered = [int(c) for _s, _e, cids in p.blocks for c in cids]
+    ordered = [int(c) for block in p.blocks for c in block.chunk_ids]
     assert len(ordered) == len(set(ordered)), "a chunk is planned by more than one block"
     planned = {
         (r.array, r.chunk_index)
         for r in build_stored_chunk_reads(ordered, p.ds.geometries, p.ref_spc)
     }
-    assert _reference_read_keys(p.order, p.ds.geometries, p.ref_spc) <= planned
+    assert _reference_read_keys(p.order.rows, p.ds.geometries, p.ref_spc) <= planned
 
 
 @pytest.mark.parametrize("case", CASES, ids=[c.id for c in CASES])

--- a/tests/test_empty_split.py
+++ b/tests/test_empty_split.py
@@ -62,9 +62,11 @@ def test_an_empty_split_is_repeatable(dataset) -> None:
 def test_the_order_builders_accept_no_chunks(order_fn) -> None:
     """Both draw orders, since `shuffle` picks between them and either can meet an empty split."""
     empty = np.array([], dtype=np.int64)
-    kwargs = {"block_chunks": 4, "seed": 0, "epoch": 0} if order_fn is block_shuffled_order else {}
+    kwargs = {"seed": 0, "epoch": 0} if order_fn is block_shuffled_order else {}
 
-    order = order_fn(empty, 4, 64, **kwargs)
+    order = order_fn(empty, 4, 64, block_chunks=4, **kwargs)
 
     assert len(order) == 0
-    assert order.ndim == 2 and order.shape[1] == 2, "shape must stay (N, 2) so callers can index"
+    assert order.n_blocks == 0, "no chunks is no blocks, not one empty one"
+    rows = order.rows
+    assert rows.ndim == 2 and rows.shape[1] == 2, "shape must stay (N, 2) so callers can index"

--- a/tests/test_shuffle.py
+++ b/tests/test_shuffle.py
@@ -24,7 +24,7 @@ def test_permutation_is_deterministic_per_epoch() -> None:
 def test_order_covers_every_sample_exactly_once() -> None:
     ids = np.arange(20)
     spc, n = 8, 20 * 8
-    order = block_shuffled_order(ids, spc, n, block_chunks=4, seed=0, epoch=0)
+    order = block_shuffled_order(ids, spc, n, block_chunks=4, seed=0, epoch=0).rows
     assert order.shape == (n, 2)
     ranks = order[:, 0] * spc + order[:, 1]
     assert np.array_equal(np.sort(ranks), np.arange(n))
@@ -34,7 +34,7 @@ def test_order_handles_partial_final_chunk() -> None:
     # 5 chunks, spc=8, but only 37 samples -> last chunk holds 5, not 8.
     ids = np.arange(5)
     spc, n = 8, 37
-    order = block_shuffled_order(ids, spc, n, block_chunks=2, seed=0, epoch=0)
+    order = block_shuffled_order(ids, spc, n, block_chunks=2, seed=0, epoch=0).rows
     assert order.shape == (n, 2)
     ranks = order[:, 0] * spc + order[:, 1]
     assert np.array_equal(np.sort(ranks), np.arange(n))  # no out-of-range indices
@@ -45,7 +45,7 @@ def test_order_handles_partial_final_chunk() -> None:
 def test_sequential_order_is_in_order_and_complete() -> None:
     ids = np.arange(5)
     spc, n = 8, 37
-    order = sequential_order(ids, spc, n)
+    order = sequential_order(ids, spc, n, block_chunks=2).rows
     ranks = order[:, 0] * spc + order[:, 1]
     assert ranks.tolist() == list(range(n))  # strictly in order, no shuffle
 
@@ -54,9 +54,9 @@ def test_bigger_blocks_improve_shuffle_quality() -> None:
     ids = np.arange(64)
     spc, n = 16, 64 * 16
     q_small = shuffle_quality(
-        block_shuffled_order(ids, spc, n, block_chunks=1, seed=0, epoch=0), spc
+        block_shuffled_order(ids, spc, n, block_chunks=1, seed=0, epoch=0).rows, spc
     )
     q_large = shuffle_quality(
-        block_shuffled_order(ids, spc, n, block_chunks=32, seed=0, epoch=0), spc
+        block_shuffled_order(ids, spc, n, block_chunks=32, seed=0, epoch=0).rows, spc
     )
     assert q_large > q_small  # wider block -> closer to global mixing

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -16,34 +16,65 @@ from insitubatch import (
     open_geometries,
     split_by_chunk,
 )
-from insitubatch.shuffle import block_shuffled_order
-from insitubatch.source import InSituDataset, _partition_blocks
+from insitubatch.shuffle import block_shuffled_order, sequential_order
+from insitubatch.source import InSituDataset
 
 
-def test_partition_blocks_covers_disjoint_contiguous_blocks() -> None:
-    # 10 chunks x 4 samples, block_chunks=3 -> blocks of 3,3,3,1 chunks.
+def test_the_builder_lays_down_blocks_of_block_chunks_each() -> None:
+    """The order carries its own block bounds: contiguous, gapless, and correctly sized.
+
+    10 chunks x 4 samples at ``block_chunks=3`` -> blocks of 3, 3, 3, 1 chunks. The bounds
+    come from the builder that grouped the permutation, so nothing downstream has to infer
+    them from the rows -- which, once a windowed view drops anchors, is not possible (#68).
+    """
     chunk_ids = np.arange(10, dtype=np.int64)
     order = block_shuffled_order(chunk_ids, 4, 40, block_chunks=3, seed=0, epoch=0)
-    blocks = _partition_blocks(order, block_chunks=3)
 
-    assert [len(b[2]) for b in blocks] == [3, 3, 3, 1]  # chunk counts per block
-    # Row ranges tile the whole order contiguously, and chunk sets are disjoint.
-    assert blocks[0][0] == 0 and blocks[-1][1] == len(order)
+    assert order.n_blocks == 4
+    assert [order.block(i)[1] - order.block(i)[0] for i in range(4)] == [12, 12, 12, 4]
+    assert order.block(0)[0] == 0
+    assert order.block(3)[1] == len(order)
+
     seen: set[int] = set()
     prev_stop = 0
-    for rstart, rstop, chunks in blocks:
-        assert rstart == prev_stop
-        prev_stop = rstop
-        ids = {int(c) for c in chunks}
+    for i in range(order.n_blocks):
+        start, stop = order.block(i)
+        assert start == prev_stop
+        prev_stop = stop
+        ids = {int(c) for c in order.rows[start:stop, 0]}
         assert seen.isdisjoint(ids)
-        # every row in this block draws only from this block's chunks
-        assert set(int(c) for c in order[rstart:rstop, 0]) == ids
         seen |= ids
     assert seen == set(range(10))
 
 
-def test_partition_blocks_empty() -> None:
-    assert _partition_blocks(np.empty((0, 2), dtype=np.int64), block_chunks=4) == []
+def test_dropping_rows_narrows_a_block_rather_than_re_cutting_them() -> None:
+    """A block that loses rows keeps its identity; one that loses all of them goes away.
+
+    This is what a reconstruction cannot do. Re-deriving the grouping from the survivors
+    repacks them into fresh runs of ``block_chunks``, so a block that lost a chunk silently
+    borrows one from its neighbour -- self-consistent, and not the blocks the shuffle laid
+    down (#68).
+    """
+    order = block_shuffled_order(
+        np.arange(10, dtype=np.int64), 4, 40, block_chunks=3, seed=0, epoch=0
+    )
+    keep = np.ones(len(order), dtype=bool)
+    keep[: order.block(0)[1]] = False  # the whole of block 0
+    keep[order.block(1)[0] + 1] = False  # one row of block 1
+
+    narrowed = order.keep(keep)
+
+    assert narrowed.n_blocks == 3, "the emptied block is dropped, the others survive"
+    assert len(narrowed) == len(order) - 12 - 1
+    assert narrowed.block(0)[1] - narrowed.block(0)[0] == 11  # block 1, one row lighter
+    assert narrowed.block(0)[0] == 0 and narrowed.block(2)[1] == len(narrowed)
+
+
+def test_an_empty_order_has_no_blocks() -> None:
+    empty = sequential_order(np.empty(0, dtype=np.int64), 4, 40, block_chunks=4)
+    assert empty.n_blocks == 0
+    assert len(empty) == 0
+    assert empty.rows.shape == (0, 2)
 
 
 def test_unequal_sample_length_raises(tmp_path) -> None:


### PR DESCRIPTION
## Summary

Closes #68.

A shuffle-block's chunks were **reconstructed** from the emitted draw order. `_partition_blocks`
repacked the surviving chunks into fresh groups of `block_chunks` while the rows stayed laid out
in the grouping the shuffle actually laid down. The moment `valid_anchor_range` dropped a whole
chunk -- which any lead offset does -- the two shifted against each other:

```
256 samples, spc=4, block_chunks=2, offsets {0, 12}
  rows=244  chunks 64 -> 61 (61, 62, 63 dropped)
  expected blocks=31   recovered blocks=77
  blocks whose declared chunks != the chunks their own rows draw: 66 of 77

  block 11: rows cover chunks [3], but blocks[11].cids = [3, 24]
  block 12: rows cover chunks [1], but blocks[12].cids = [30, 46]
```

This cannot be fixed in place: a two-chunk block that lost a chunk is indistinguishable from a
one-chunk block, so the information is not in the order. The boundaries now come from the builder
that creates them. `block_shuffled_order` and `sequential_order` return a `DrawOrder` carrying
rows *and* bounds, and `DrawOrder.keep` narrows the block that lost rows instead of re-cutting
every block after it.

That collapses the two definitions of "the chunks this block reads" into one `_Block`, derived
once from the rows the builder assigned it: `chunk_ids` for the driver to plan, `read_keys` for
the consumer to pin and release.

**Nothing observable changes, and that is worth being precise about.** The planner expands each
anchor into every chunk that anchor reads, and retention pins a chunk to its last use, so the
misattribution altered no sample and -- measured -- delayed no fetch: no block was fetch-complete
later than its own anchors, 0 of 77 on the worst geometry against 0 of 32 on the unwindowed
control. It was fatal only to the *next* change. Per-block release (#66) plans from a block's
chunks and releases that block's read keys, so every disagreement above is a read-ahead permit
taken and never returned; that is what the parked spike on `feat/unpin-and-reread` fails on.

This is the third time the planner has disagreed with the rest of the system about what a read
is (#56 was the last).

## For reviewers

**The API change is the thing to look at.** `block_shuffled_order` and `sequential_order` are
public (exported since 0.1.0) and now return `DrawOrder` rather than a bare array. `.rows` is
exactly what they used to return, and `sequential_order` gains a required `block_chunks` so both
orders carry one block definition. No docs page referenced either function. If you would rather
these stayed array-returning, the alternative is a second pair of functions that also return
bounds -- which is the "two obvious ways" this PR exists to delete.

**Behaviour is meant to be unchanged**, and the tests are built so that claim is checkable rather
than asserted. `tests/test_block_structure.py` (first commit, red before the second) takes every
answer from an oracle *outside* the code under test, so unifying the two definitions does not
turn any assertion into `f(x) == f(x)`:

* a per-sample walk that inverts `samples_in_chunk` instead of dividing -- kept permanently
  independent by the O(chunks)-not-O(samples) invariant, which forbids the engine from ever
  converging on it;
* `chunk_permutation`, for the blocks the shuffle actually laid down;
* an explicit live-set simulation, against `read_ahead_bound`'s open/close arithmetic.

19 of 115 failed on `main` across 7 geometries and 3 properties; all 115 pass here. Two
assertions were deliberately *not* written because unification makes them vacuous, and one that
did go vacuous (a block's chunk ids equal its own rows' chunks) was replaced by the disjointness
property it was really protecting.

Three instrument checks fired before any of this was trusted: a hand-computed peak that was
wrong, an oracle comparing within-block chunk order that carries no meaning, and a fourth claim
-- that misattribution inverts fetch priority -- that was measured, found false, and withdrawn.

## Author attestation

- [x] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

Left unticked deliberately: it asserts that a human reviewed every change and verified the
claims above, which is yours to assert and not mine to assert on your behalf.

## Checklist

- [x] Tests added or updated — the reproducer commit is separate and fails on `main`
- [x] `ruff check`, `ruff format --check`, `mypy`, `pytest -q` and `mkdocs build --strict` green
      locally (641 passed + `test_tf.py` 2 passed in its own process)
- [x] Docstrings for the new public surface (`DrawOrder`)
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] No load-bearing invariant is broken — the hot path stays O(chunks); the O(samples) walk
      lives only in the test, which is what makes it a usable oracle
- [x] Touches the scheduler / cross-thread readiness → 3.13t run passes (CI)

