### PR TITLE
feat: release a windowed shuffled pass's spill per block and re-read it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@
   learn the policy too: a released chunk is only *evictable*, so sized for retention nothing is
   ever evicted and releasing buys nothing.
 
+  A chunk two blocks read is admitted once per block, and the driver may run three blocks
+  ahead of its consumer, so the second admission can land while the first block's tiles are
+  still in flight. The driver now skips a fetch whose delivery is already underway, which
+  took duplicate concurrent tile fetches from 2.3% to 0.8% on a 16-tile-per-chunk geometry.
+  The duplicates were never a correctness problem -- a slot publishes only when quiescent,
+  so a duplicate's own writer holds it open until it lands -- but a duplicate fetch is a
+  refetch, which is the cost this policy exists to avoid.
+
   The per-epoch line now reports re-reads and evictions whenever they are non-zero. A hit rate
   alone cannot show this -- a re-read served from the cache counts as a hit -- so rising
   re-reads at a steady hit rate are the signal that a budget is churning rather than holding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@
   coming and the other pass waiting on it forever. Two concurrent iterations sharing a pool
   is the ordinary case, and either may be abandoned by an early `break`.
 
+  Starting a second concurrent iteration the budget cannot hold now raises there, naming the
+  budget to pass, instead of running until one of them starves. Under-sizing for concurrent
+  iterations already raised (it is why `zip(ds.train, ds.val)` on an auto budget has always
+  been a configuration error), but *whether* an under-sized pool reached the stall depended on
+  how the two interleaved -- and releasing the spill makes the floor small enough that the
+  same configuration began succeeding and failing on consecutive runs. The arithmetic is
+  complete when the second iteration starts, so it is answered there. `Scheduler._starvation`
+  stays as the backstop for what arithmetic cannot predict.
+
   The per-epoch line now reports re-reads and evictions whenever they are non-zero. A hit rate
   alone cannot show this -- a re-read served from the cache counts as a hit -- so rising
   re-reads at a steady hit rate are the signal that a budget is churning rather than holding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,17 @@
 
   A chunk two blocks read is admitted once per block, and the driver may run three blocks
   ahead of its consumer, so the second admission can land while the first block's tiles are
-  still in flight. The driver now skips a fetch whose delivery is already underway, which
-  took duplicate concurrent tile fetches from 2.3% to 0.8% on a 16-tile-per-chunk geometry.
-  The duplicates were never a correctness problem -- a slot publishes only when quiescent,
-  so a duplicate's own writer holds it open until it lands -- but a duplicate fetch is a
-  refetch, which is the cost this policy exists to avoid.
+  still in flight -- which had it fetching them a second time, 2.3% of all fetches on a
+  16-tile-per-chunk geometry. Never a correctness problem (a slot publishes only when
+  quiescent, so the duplicate's own writer holds it open until it lands), but a duplicate
+  fetch is a refetch, and avoiding refetches is the whole point of the policy. The driver
+  now skips a chunk it already has tile tasks outstanding for, which removes all of them.
+
+  Its own tasks, strictly. `ChunkPool` records how many writers a slot has and not whose
+  they are, so skipping on any writer lets one pass rely on another's fetch -- and a pass
+  abandoned mid-fetch unwinds without delivering, leaving the slot FILLING with nothing
+  coming and the other pass waiting on it forever. Two concurrent iterations sharing a pool
+  is the ordinary case, and either may be abandoned by an early `break`.
 
   The per-epoch line now reports re-reads and evictions whenever they are non-zero. A hit rate
   alone cannot show this -- a re-read served from the cache counts as a hit -- so rising

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+- **A windowed, shuffled pass held close to the whole train split resident (#66).** A windowed
+  view reads `anchor + offset` and shuffle permutes chunk order, so a chunk one block reads can
+  be needed again most of an epoch later; held from first use to last, residency was the split
+  rather than two blocks. That is decode-once, and it is the right trade only while the split
+  fits. With `persist=True` each block now hands its chunks back as it drains and a later block
+  re-admits them from the on-disk cache. Measured on a 256-chunk split: the floor falls from 259
+  chunks to 12 for a three-chunk lead, and 316 to 18 for leads `{0, 24, 240}`, delivering the
+  same samples.
+
+  A rule rather than a knob, and it keys on `persist` rather than on `cache_dir` -- only a
+  persisted slot survives its own eviction as a revivable file. With `cache_dir` alone the
+  backing is unlinked when the slot is evicted, so the same 249 re-reads were served 2% from
+  cache instead of 49%, which is the opposite of the trade the policy assumes. The floor had to
+  learn the policy too: a released chunk is only *evictable*, so sized for retention nothing is
+  ever evicted and releasing buys nothing.
+
+  The per-epoch line now reports re-reads and evictions whenever they are non-zero. A hit rate
+  alone cannot show this -- a re-read served from the cache counts as a hit -- so rising
+  re-reads at a steady hit rate are the signal that a budget is churning rather than holding.
+
 - **A shuffle-block's chunks were reconstructed from the draw order, and on any windowed
   view the reconstruction was wrong (#68).** `_partition_blocks` re-derived block membership
   by repacking the surviving chunks into fresh groups of `block_chunks`, but the rows stayed

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -293,6 +293,26 @@ tiles — so for anything but a single-variable run, ask
 [`describe()`](api.md#insitubatch.InSituDataset.describe), which reports the number the
 engine will actually use rather than one you assembled by hand.
 
+### Two iterations at once are refused, not left to stall
+
+Every active iteration holds its own references, so N of them need N floors. The budget is
+sized for one, because the engine cannot know how many you intend to run. Starting a second
+one the budget cannot hold now raises there, naming the number to pass:
+
+```
+cache_budget_bytes=49152 cannot hold 2 concurrent iterations: each needs 49152 bytes
+co-resident, so 2 need 98304. ... Pass cache_budget_bytes=98304 or more, or iterate the
+splits one after another rather than together.
+```
+
+`zip(ds.train, ds.val)` and two `DataLoader`s both count as two. Iterating the splits one
+after another — the ordinary epoch — never has two live at once, however many passes it runs.
+
+The arithmetic is complete when the second iteration starts, so it is answered there rather
+than left to starve mid-epoch: whether an under-sized pool reaches the stall at all depends on
+how the two interleave, so the same configuration would otherwise succeed and fail on
+consecutive runs.
+
 ### Windowed and shuffled: hold the split, or release and re-read
 
 A windowed view reads `anchor + offset`, and shuffle permutes chunk order, so a chunk one

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -282,6 +282,8 @@ costs, then check that against the memory you actually have:
 geom = open_geometries(store, variables=["temperature_2m"])["temperature_2m"]
 geom.chunk_bytes                      # bytes one sample-axis chunk occupies once resident
 2 * block_chunks * geom.chunk_bytes   # the floor: current block + one read-ahead
+                                      # (3 blocks when a windowed shuffled pass
+                                      #  releases its spill -- see below)
 ```
 
 Compare that with `free -h` (the `available` column, not `free`) and leave room for the
@@ -290,6 +292,35 @@ a `chunk_transform` can make the transformed output the binding term instead of 
 tiles — so for anything but a single-variable run, ask
 [`describe()`](api.md#insitubatch.InSituDataset.describe), which reports the number the
 engine will actually use rather than one you assembled by hand.
+
+### Windowed and shuffled: hold the split, or release and re-read
+
+A windowed view reads `anchor + offset`, and shuffle permutes chunk order, so a chunk one
+block reads may be needed again many blocks later. Held from first use to last, that makes
+the resident set close to the whole train split rather than two blocks — the cost of
+decode-once when several views share one array.
+
+Passing `persist=True` (with a `cache_dir`) changes the trade automatically: each block's
+chunks are handed back as that block drains, and a chunk a later block needs is admitted
+again from the on-disk cache. Residency falls to the three-block floor. Measured on a
+256-chunk split with a three-chunk lead, the floor goes from 259 chunks to 12, and from 316
+to 18 for leads `{0, 24, 240}` — with the same samples delivered.
+
+It is a rule rather than a knob because it is only a good trade when the second admission is
+local. `persist=True` is what makes an evicted slot revivable; with `cache_dir` alone the
+backing is unlinked on eviction and the re-read pays the fetch and the decode again. Put the
+cache on NVMe.
+
+The per-epoch summary reports the churn, because a hit rate cannot show it — a re-read served
+from the cache counts as a hit:
+
+```
+epoch 0 (train): chunks 246/502 hit (49%), peak resident 12,
+                 249 re-read (spill released per block, revived from the cache), 479 evicted
+```
+
+Rising re-reads at a steady hit rate mean the budget is churning rather than holding, and the
+floor is the number to raise.
 
 **Do not compute this as `sample_chunk_size × prod(inner_shape) × itemsize`.** Residency is
 the array's stored *tiles*, kept whole: a grid that does not divide the array evenly still

--- a/src/insitubatch/plan.py
+++ b/src/insitubatch/plan.py
@@ -21,6 +21,8 @@ def build_stored_chunk_reads(
     chunk_ids: Sequence[int] | np.ndarray,
     geometries: dict[str, ArrayGeometry],
     ref_spc: int,
+    *,
+    groups: Sequence[int] | None = None,
 ) -> list[StoredChunkRead]:
     """Expand outer chunk ids into deduped stored-chunk reads, in priority order.
 
@@ -47,10 +49,27 @@ def build_stored_chunk_reads(
     differently from the reference maps those anchor samples onto *its own* chunks -- so one
     anchor chunk expands to the (offset-shifted) chunks each variable needs. With every
     ``offset == 0`` and a uniform chunk size this is exactly ``anchor chunk -> itself``.
+    ``groups`` scopes that dedup to consecutive runs of ``chunk_ids`` -- the consumer's
+    shuffle-blocks -- rather than the whole pass. A chunk that two blocks read is then
+    admitted once *per block*, which is what lets the consumer release it when its block
+    drains and have it re-admitted later; the pool serves that second admission from
+    residency or from ``cache_dir``, and re-reads it only if neither holds it.
+
+    Per block rather than per anchor, deliberately: the consumer releases each of a block's
+    keys once, so admitting a key twice inside one block would leave a reference nobody
+    returns -- and a slot pinned forever is a starved pass, not a slow one.
     """
     reads: list[StoredChunkRead] = []
     seen: set[StoredChunkRead] = set()
-    for cid in chunk_ids:
+    boundaries: set[int] = set()
+    if groups:
+        at = 0
+        for n in groups:
+            boundaries.add(at)
+            at += n
+    for i, cid in enumerate(chunk_ids):
+        if i in boundaries:
+            seen.clear()  # a new block admits what it reads
         for geom in geometries.values():
             for read_cid in _read_chunks(geom, int(cid), ref_spc):
                 for inner in geom.inner_coords():

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -668,8 +668,8 @@ class ChunkPool:
         self._buffers = BatchBuffers()
         self._budget = budget_bytes  # None => unbounded (never self-evicts)
         # What ONE iteration needs co-resident, so a second one can be refused at the
-        # boundary instead of stalling mid-epoch. 0 disables the check (a pool built
-        # without a floor cannot say what a second iteration would cost).
+        # boundary. 0 disables the check: a pool built without a floor cannot say what a
+        # second iteration would cost.
         self._iteration_bytes = iteration_bytes
         self._bytes = 0
         # OrderedDict in recency order (LRU front -> MRU back). Eviction targets only
@@ -1026,11 +1026,10 @@ class ChunkPool:
     def _note_touch(self, key: tuple[str, int]) -> None:  # call under the lock
         """Count a chunk this pass has already taken once as a re-read.
 
-        Called where the driver actually *takes* a chunk -- every path that references one
-        for this pass, and no path that merely asks whether it could. A take is one of "the
-        slot was already resident", "it was revived from disk" or "a fresh slot was
-        allocated", so noting it anywhere earlier counts the failed `pin_if_ready` that
-        precedes an admission as a second take, and every chunk looks re-read.
+        Called from every path that *takes* a chunk for this pass -- "already resident",
+        "revived from disk", "a fresh slot allocated" -- and from no path that merely asks
+        whether it could. A failed `pin_if_ready` precedes most admissions, so a take is
+        counted where it succeeds, not where it is attempted.
 
         Under retention a chunk is taken once per pass and this stays zero. Under a released
         spill it is the number a reader needs to judge the trade: a re-read of a persisted

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -1088,6 +1088,25 @@ class ChunkPool:
             self.max_resident_bytes = max(self.max_resident_bytes, self._bytes)
             return True
 
+    def delivery_underway(self, array: str, chunk_index: int) -> bool:
+        """Is this slot already filled, or being filled by a writer that will publish it?
+
+        When the spill is released, a chunk two shuffle-blocks read is admitted once per
+        block, and the second admission can land while the first block's tiles are still in
+        flight -- the driver is allowed to run several blocks ahead of its consumer. Fetching
+        those tiles again would pay the fetch and the decode a second time for bytes already
+        on their way, which is exactly the cost the released spill is trying to avoid.
+
+        A slot FILLING with **no** writer is not underway: that is an abandoned partial left
+        by a cancelled pass, and it will never complete unless somebody fetches it. Nor is a
+        FAILED one, which quiesces and is dropped so a later pass can refetch.
+        """
+        with self._cv:
+            slot = self._slots.get((array, chunk_index))
+            if slot is None or slot.state is SlotState.FAILED:
+                return False
+            return slot.state is SlotState.READY or slot.writers > 0
+
     def is_ready(self, array: str, chunk_index: int) -> bool:
         """True if the chunk is resident, fully assembled, and not failed (a hit)."""
         with self._cv:

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -517,6 +517,7 @@ class ChunkPool:
         chunk_transforms: Sequence[ChunkTransform] = (),
         backing_dir: str | Path | None = None,
         budget_bytes: int | None = None,
+        iteration_bytes: int = 0,
         persist: bool = False,
         readonly_cache: bool = False,
         reset_stale_cache: bool = False,
@@ -666,6 +667,10 @@ class ChunkPool:
         # wrong-data bug. See BatchBuffers' own docstring.
         self._buffers = BatchBuffers()
         self._budget = budget_bytes  # None => unbounded (never self-evicts)
+        # What ONE iteration needs co-resident, so a second one can be refused at the
+        # boundary instead of stalling mid-epoch. 0 disables the check (a pool built
+        # without a floor cannot say what a second iteration would cost).
+        self._iteration_bytes = iteration_bytes
         self._bytes = 0
         # OrderedDict in recency order (LRU front -> MRU back). Eviction targets only
         # a *ready, unreferenced* slot: a not-ready slot is an in-flight fetch, and a
@@ -874,9 +879,41 @@ class ChunkPool:
         and threads it through; nothing in the public API names an owner.
         """
         with self._cv:
+            self._refuse_if_budget_cannot_hold(len(self._owners) + 1)
             self._owner_seq += 1
             self._owners.add(self._owner_seq)
             return self._owner_seq
+
+    def _refuse_if_budget_cannot_hold(self, iterations: int) -> None:  # call under the lock
+        """Raise when the budget cannot hold ``iterations`` working sets at once.
+
+        Every active iteration holds its own references, so N of them need N floors. When
+        the budget cannot cover that, the pass does not fail cleanly -- it runs until one
+        iteration's admission finds every slot pinned by the other and reports starvation,
+        somewhere mid-epoch. Whether it gets there at all depends on how the two interleave,
+        so the same configuration can succeed and fail on consecutive runs.
+
+        The arithmetic is known when the second iteration starts, so it is answered there.
+        This does not replace :meth:`Scheduler._starvation`, which still catches what the
+        arithmetic cannot predict -- a floor that under-estimates, or a third iteration
+        appearing later.
+        """
+        if iterations < 2 or not self._iteration_bytes or self._budget is None:
+            return
+        if iterations * self._iteration_bytes <= self._budget:
+            return
+        raise RuntimeError(
+            f"cache_budget_bytes={self._budget} cannot hold {iterations} concurrent "
+            f"iterations: each needs {self._iteration_bytes} bytes co-resident, so "
+            f"{iterations} need {iterations * self._iteration_bytes}. The budget is sized "
+            "for one iteration because the engine cannot know how many you intend to run. "
+            f"Pass cache_budget_bytes={iterations * self._iteration_bytes} or more, or "
+            "iterate the splits one after another rather than together (`zip(ds.train, "
+            "ds.val)` and two DataLoaders both count as two). Raised here rather than as "
+            "starvation mid-epoch: whether an under-sized pool reaches the stall depends on "
+            "how the iterations interleave, and a run that fails only sometimes is worse "
+            "than one that fails at the boundary."
+        )
 
     def _refs(self, key: tuple[str, int]) -> int:  # call under the lock
         """Total outstanding references to ``key`` across every owner."""

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -599,6 +599,9 @@ class ChunkPool:
         self.misses = 0
         self.revive_mismatch = 0  # persisted entry whose stored shape/dtype no longer matches
         self.revive_missing = 0  # persisted entry whose .npy was unreadable/gone
+        self.evictions = 0  # ready slots dropped to make room -- the cost side of a small budget
+        self.rereads = 0  # chunks admitted again in the same pass after being released
+        self._seen_this_pass: set[tuple[str, int]] = set()  # for rereads; cleared per pass
         self.manifest_entries = 0
         # Cross-run persistence: keep slot files past close, write a manifest of completed
         # entries, and revive them on reopen. Requires a dir to keep the files in. The dir
@@ -983,6 +986,24 @@ class ChunkPool:
 
     # -- admission / pinning / eviction -------------------------------------
 
+    def _note_touch(self, key: tuple[str, int]) -> None:  # call under the lock
+        """Count a chunk this pass has already taken once as a re-read.
+
+        Called where the driver actually *takes* a chunk -- every path that references one
+        for this pass, and no path that merely asks whether it could. A take is one of "the
+        slot was already resident", "it was revived from disk" or "a fresh slot was
+        allocated", so noting it anywhere earlier counts the failed `pin_if_ready` that
+        precedes an admission as a second take, and every chunk looks re-read.
+
+        Under retention a chunk is taken once per pass and this stays zero. Under a released
+        spill it is the number a reader needs to judge the trade: a re-read of a persisted
+        slot is a local read of decoded bytes; one that is not is a refetch.
+        """
+        if key in self._seen_this_pass:
+            self.rereads += 1
+        else:
+            self._seen_this_pass.add(key)
+
     def try_admit(self, array: str, chunk_index: int, owner: int) -> bool:
         """Reserve + allocate + reference one outer-chunk slot, evicting ready-LRU for room.
 
@@ -1019,6 +1040,7 @@ class ChunkPool:
                 # Already resident (in-flight, or a ready cross-epoch hit) -> incref and
                 # reuse. A FAILED slot is NOT reusable: it quiesces and is dropped, so a
                 # later epoch refetches instead of re-raising a stale error forever.
+                self._note_touch(key)
                 self._pin(key, owner)  # the pin IS this owner's claim (see wait_ready)
                 self._cv.notify_all()  # a ready hit may now satisfy a waiter
                 return True
@@ -1029,6 +1051,7 @@ class ChunkPool:
                 if not self._revive(key):
                     raise self._readonly_miss(array, chunk_index)
                 self.hits += 1  # revived from disk -> no fetch (as in pin_if_ready)
+                self._note_touch(key)
                 self._pin(key, owner)
                 self._cv.notify_all()
                 return True
@@ -1059,6 +1082,7 @@ class ChunkPool:
                 scratch=scratch,
             )
             self._bytes += nbytes
+            self._note_touch(key)
             self._pin(key, owner)
             self.max_resident = max(self.max_resident, len(self._positions()))
             self.max_resident_bytes = max(self.max_resident_bytes, self._bytes)
@@ -1087,6 +1111,7 @@ class ChunkPool:
             if not (slot is not None and slot.state is SlotState.READY) and not self._revive(key):
                 return False
             self.hits += 1  # resident (cross-epoch) or revived (cross-run) -> no fetch
+            self._note_touch(key)
             self._pin(key, owner)  # the pin IS this owner's claim; publish it
             self._cv.notify_all()
             return True
@@ -1250,6 +1275,8 @@ class ChunkPool:
             self.hits = self.misses = 0
             self.max_resident = self.max_resident_bytes = 0  # peaks are per-pass too
             self.revive_mismatch = self.revive_missing = 0
+            self.evictions = self.rereads = 0
+            self._seen_this_pass.clear()
             self._buffers.reset_counters()  # batch outputs too -- same epoch boundary
 
     def _pin(self, key: tuple[str, int], owner: int) -> None:  # call under the lock
@@ -1279,6 +1306,7 @@ class ChunkPool:
             victim = next((k for k, sl in self._slots.items() if self._evictable(k, sl)), None)
             if victim is None:  # everything resident is in-flight or pinned -> no room
                 return False
+            self.evictions += 1
             self._drop(victim)
         return True
 

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -1088,25 +1088,6 @@ class ChunkPool:
             self.max_resident_bytes = max(self.max_resident_bytes, self._bytes)
             return True
 
-    def delivery_underway(self, array: str, chunk_index: int) -> bool:
-        """Is this slot already filled, or being filled by a writer that will publish it?
-
-        When the spill is released, a chunk two shuffle-blocks read is admitted once per
-        block, and the second admission can land while the first block's tiles are still in
-        flight -- the driver is allowed to run several blocks ahead of its consumer. Fetching
-        those tiles again would pay the fetch and the decode a second time for bytes already
-        on their way, which is exactly the cost the released spill is trying to avoid.
-
-        A slot FILLING with **no** writer is not underway: that is an abandoned partial left
-        by a cancelled pass, and it will never complete unless somebody fetches it. Nor is a
-        FAILED one, which quiesces and is dropped so a later pass can refetch.
-        """
-        with self._cv:
-            slot = self._slots.get((array, chunk_index))
-            if slot is None or slot.state is SlotState.FAILED:
-                return False
-            return slot.state is SlotState.READY or slot.writers > 0
-
     def is_ready(self, array: str, chunk_index: int) -> bool:
         """True if the chunk is resident, fully assembled, and not failed (a hit)."""
         with self._cv:

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -490,10 +490,9 @@ class Scheduler:
         # (path, chunk) is first-seen on its first tile. Residency is held by the
         # consumer's per-block pins, not here -- admission only allocates the slot, and
         # a not-ready (in-flight) slot is eviction-protected until its fetch completes.
-        # Reads are chunk-major, so an admission decision only has to survive the run of
-        # tiles belonging to one chunk. Holding it for the whole pass would skip the second
-        # admission of a chunk a later block reads again, which is what a released spill
-        # depends on.
+        # Reads are chunk-major, so an admission decision is scoped to the run of tiles
+        # belonging to one chunk. A released spill admits a chunk once per block that reads
+        # it, and each of those admissions is its own decision.
         current: tuple[str, int] | None = None
         current_hit = False
         tasks: list[asyncio.Task] = []
@@ -518,11 +517,11 @@ class Scheduler:
                         # second admission can land while *our own* earlier tiles for it
                         # are still in flight; fetching them again duplicates the work.
                         #
-                        # Our own, strictly. The pool counts writers without recording
-                        # whose they are, so skipping on any writer lets one pass rely on
-                        # another's fetch -- and a pass abandoned mid-fetch unwinds without
-                        # delivering, leaving the other waiting on a delivery nobody will
-                        # make. A pass may only stand on its own outstanding work.
+                        # Our own, strictly (#75). A pass may only stand on work it can
+                        # guarantee: its own tasks end with it, whereas another pass's are
+                        # cancelled when that pass is abandoned, and a slot whose writer
+                        # unwinds without delivering leaves whoever skipped waiting on a
+                        # delivery that is not coming.
                         current_hit = key in self._fetching
                 if current_hit:
                     continue  # already resident, or on its way -- nothing for us to fetch

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -62,6 +62,7 @@ import time
 from collections.abc import Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
+from functools import partial
 from typing import Any
 
 import numpy as np
@@ -323,6 +324,9 @@ class Scheduler:
         self._inflight: asyncio.Semaphore | None = None
         self._capacity: asyncio.Event | None = None  # set on unpin -> wakes a parked admit
         self._ahead: asyncio.Semaphore | None = None  # fetch-ahead permits (read_ahead_chunks)
+        # Outstanding tile tasks per chunk, this scheduler's only. A second block reading a
+        # chunk we are still fetching does not fetch it again.
+        self._fetching: dict[tuple[str, int], int] = {}
         self._open_lock: asyncio.Lock | None = None
         self._ready = threading.Event()
         # OUR tasks, and only ours. `asyncio.all_tasks(loop)` is the *whole loop's* task
@@ -510,18 +514,25 @@ class Scheduler:
                     current_hit = self.pool.pin_if_ready(read.array, read.chunk_index, self._owner)
                     if not current_hit:
                         await self._admit(read.array, read.chunk_index)  # may await an unpin
-                        # A chunk two blocks read is admitted once per block, and the second
-                        # admission can land while the first block's tiles are still in
-                        # flight. Their writers will publish the slot; fetching it again
-                        # would duplicate the fetch and the decode.
-                        current_hit = self.pool.delivery_underway(read.array, read.chunk_index)
+                        # A chunk two blocks read is admitted once per block, and the
+                        # second admission can land while *our own* earlier tiles for it
+                        # are still in flight; fetching them again duplicates the work.
+                        #
+                        # Our own, strictly. The pool counts writers without recording
+                        # whose they are, so skipping on any writer lets one pass rely on
+                        # another's fetch -- and a pass abandoned mid-fetch unwinds without
+                        # delivering, leaving the other waiting on a delivery nobody will
+                        # make. A pass may only stand on its own outstanding work.
+                        current_hit = key in self._fetching
                 if current_hit:
                     continue  # already resident, or on its way -- nothing for us to fetch
                 task = asyncio.create_task(self._one(read))
                 self._tasks.add(task)
                 self._tiles.add(task)
+                self._fetching[key] = self._fetching.get(key, 0) + 1
                 task.add_done_callback(self._tasks.discard)
                 task.add_done_callback(self._tiles.discard)
+                task.add_done_callback(partial(self._fetch_done, key))
                 tasks.append(task)
             await asyncio.gather(*tasks)
         except BaseException:
@@ -566,6 +577,14 @@ class Scheduler:
                 # In the `finally` so a terminal starvation still reports the time it
                 # parked before proving itself fatal -- that number is the evidence.
                 self.stats.admission_parked_s += time.perf_counter() - t0
+
+    def _fetch_done(self, key: tuple[str, int], _task: object) -> None:
+        """One tile task for ``key`` has ended; forget it once none of ours remain."""
+        remaining = self._fetching.get(key, 0) - 1
+        if remaining > 0:
+            self._fetching[key] = remaining
+        else:
+            self._fetching.pop(key, None)
 
     async def _take_ahead(self, array: str, chunk_index: int) -> None:
         """Take a fetch-ahead permit, proving a stall terminal rather than waiting forever.

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -430,7 +430,13 @@ class Scheduler:
         """
         return self._owner
 
-    def start(self, chunk_ids: Sequence[int] | np.ndarray, ref_spc: int) -> Future:
+    def start(
+        self,
+        chunk_ids: Sequence[int] | np.ndarray,
+        ref_spc: int,
+        *,
+        groups: Sequence[int] | None = None,
+    ) -> Future:
         """Begin streaming the stored chunks of ``chunk_ids`` (priority order).
 
         ``chunk_ids`` are in the reference (manifest) grid; ``ref_spc`` is that grid's
@@ -438,7 +444,7 @@ class Scheduler:
         Returns the driver future; a failure there poisons the pool so consumers
         re-raise. The consumer drives demand independently via :attr:`pool`.
         """
-        reads = build_stored_chunk_reads(chunk_ids, self._geometries, ref_spc)
+        reads = build_stored_chunk_reads(chunk_ids, self._geometries, ref_spc, groups=groups)
         fut = asyncio.run_coroutine_threadsafe(self._drive(reads), self._loop)
         fut.add_done_callback(self._on_drive_done)
         return fut
@@ -480,7 +486,12 @@ class Scheduler:
         # (path, chunk) is first-seen on its first tile. Residency is held by the
         # consumer's per-block pins, not here -- admission only allocates the slot, and
         # a not-ready (in-flight) slot is eviction-protected until its fetch completes.
-        decided: dict[tuple[str, int], bool] = {}
+        # Reads are chunk-major, so an admission decision only has to survive the run of
+        # tiles belonging to one chunk. Holding it for the whole pass would skip the second
+        # admission of a chunk a later block reads again, which is what a released spill
+        # depends on.
+        current: tuple[str, int] | None = None
+        current_hit = False
         tasks: list[asyncio.Task] = []
         me = asyncio.current_task()
         if me is not None:
@@ -488,19 +499,18 @@ class Scheduler:
         try:
             for read in reads:
                 key = (read.array, read.chunk_index)
-                hit = decided.get(key)
-                if hit is None:
+                if key != current:
+                    current = key
                     # One permit per chunk, taken before we reference it and
                     # returned by the consumer's unpin. Hits take one too: a hit is pinned
                     # exactly like an admission and released by the same `unpin_block`, so
                     # skipping it here would return permits we never took.
                     if self._ahead is not None:
                         await self._take_ahead(read.array, read.chunk_index)
-                    hit = self.pool.pin_if_ready(read.array, read.chunk_index, self._owner)
-                    if not hit:
+                    current_hit = self.pool.pin_if_ready(read.array, read.chunk_index, self._owner)
+                    if not current_hit:
                         await self._admit(read.array, read.chunk_index)  # may await an unpin
-                    decided[key] = hit
-                if hit:
+                if current_hit:
                     continue  # cross-epoch hit: prepped chunk already resident, no fetch
                 task = asyncio.create_task(self._one(read))
                 self._tasks.add(task)

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -510,8 +510,13 @@ class Scheduler:
                     current_hit = self.pool.pin_if_ready(read.array, read.chunk_index, self._owner)
                     if not current_hit:
                         await self._admit(read.array, read.chunk_index)  # may await an unpin
+                        # A chunk two blocks read is admitted once per block, and the second
+                        # admission can land while the first block's tiles are still in
+                        # flight. Their writers will publish the slot; fetching it again
+                        # would duplicate the fetch and the decode.
+                        current_hit = self.pool.delivery_underway(read.array, read.chunk_index)
                 if current_hit:
-                    continue  # cross-epoch hit: prepped chunk already resident, no fetch
+                    continue  # already resident, or on its way -- nothing for us to fetch
                 task = asyncio.create_task(self._one(read))
                 self._tasks.add(task)
                 self._tiles.add(task)

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -259,6 +259,20 @@ class InSituDataset:
         # The last completed pass, or None before one finishes. Per pass, not per epoch: a
         # training epoch iterates train then val over one pool, and averaging two passes
         # with different shapes into one report is how a number stops meaning anything.
+        # A windowed shuffled pass holds a chunk from its first use to its last, which under
+        # a chunk permutation is most of an epoch -- so residency is close to the whole split
+        # (#66). Releasing each block's chunks when that block drains returns residency to the
+        # two-block floor, at the cost of admitting a chunk again when a later block reads it.
+        #
+        # A rule, not a knob, and it keys on `persist` rather than on `cache_dir`. Only a
+        # persisted slot survives its own eviction as a revivable file: with `cache_dir`
+        # alone the mmap backing is unlinked on eviction, so the second admission refetches
+        # and re-decodes. Measured on a 256-chunk windowed split, 249 re-reads served 2% from
+        # cache without `persist` and 49% with it -- the difference between the trade this
+        # policy assumes and the opposite one. Where the cheap path does not exist, retention
+        # is the better deal, so this turns on exactly where it does.
+        windowed = any(g.offset != 0 for g in self.geometries.values())
+        self.reread_spill = persist and windowed and shuffle
         self.last_pass: PassStats | None = None
         self._on_bad_chunk = on_bad_chunk
 
@@ -284,6 +298,7 @@ class InSituDataset:
             ref_spc=self._ref_spc,
             shuffle=self.shuffle,
             assembles=bool(self.chunk_transforms),
+            releases_spill=self.reread_spill,
         )
         # Sized for ONE iteration, deliberately. Every active iteration shares this pool and
         # holds its own references, so N concurrent iterations need ~N x this -- but the engine
@@ -496,11 +511,26 @@ class InSituDataset:
                 last_use[key] = bi  # later block overwrites -> ends on the max index
         for key, bi in last_use.items():
             release[bi].add(key)
+        if self.reread_spill:
+            # Every block hands back everything it read, so nothing is held for a later one:
+            # a chunk two blocks apart is admitted twice, and the pool serves the second from
+            # residency or from cache_dir.
+            release = [set(keys) for keys in block_keys]
 
         # Computed, not configured (see `read_ahead_bound`). A non-zero value on the
         # config is honoured so a test can supply a deliberately wrong one: a bound that
         # cannot be wrong is a bound nothing proves the need for.
-        ahead = self.scheduler_config.read_ahead_chunks or read_ahead_bound(block_keys, last_use)
+        if self.reread_spill:
+            # Three consecutive blocks, not the plan's live set. Nothing is held for a later
+            # block, so the long lifetimes that make the retained bound large do not arise --
+            # but a block is released only *after* the batch draining it has gathered, while
+            # the wait for the next block happens before, so a batch straddling a boundary
+            # transiently holds the block behind it, the one it gathers, and the one it awaits.
+            sizes = [len(keys) for keys in block_keys] or [1]
+            computed = max(sum(sizes[i : i + 3]) for i in range(max(len(sizes) - 2, 1)))
+        else:
+            computed = read_ahead_bound(block_keys, last_use)
+        ahead = self.scheduler_config.read_ahead_chunks or computed
 
         def produce(sched: Scheduler) -> None:
             # Batches are cut over the WHOLE epoch order, not per block. Cutting them per
@@ -520,7 +550,11 @@ class InSituDataset:
             bs = self.batch_size
             ready = freed = 0
             try:
-                sched.start(ordered_chunks, spc)
+                sched.start(
+                    ordered_chunks,
+                    spc,
+                    groups=[len(b.chunk_ids) for b in blocks] if self.reread_spill else None,
+                )
                 for start in range(0, len(rows), bs):
                     if stop.is_set():
                         return
@@ -698,14 +732,23 @@ class InSituDataset:
         if not logger.isEnabledFor(logging.INFO):
             return  # skip the snapshot, which takes the buffer pool's lock
         reads = pool.hits + pool.misses
+        # Re-reads and evictions appear whenever they are non-zero, not only under a released
+        # spill: a chunk taken twice in one pass, or a ready slot dropped to make room, is the
+        # budget being too small for the working set -- and a hit rate alone cannot show it,
+        # because a re-read served from cache_dir counts as a hit.
+        churn = ""
+        if pool.rereads or pool.evictions:
+            why = " (spill released per block, revived from the cache)" if self.reread_spill else ""
+            churn = f", {pool.rereads} re-read{why}, {pool.evictions} evicted"
         logger.info(
-            "epoch %d (%s): chunks %d/%d hit (%.0f%%), peak resident %d%s; batch buffers %s",
+            "epoch %d (%s): chunks %d/%d hit (%.0f%%), peak resident %d%s%s; batch buffers %s",
             self._epoch,
             split or "all",
             pool.hits,
             reads,
             100 * pool.hits / reads if reads else 0.0,
             pool.max_resident,
+            churn,
             f", {len(self.bad_chunks)} bad chunks" if self.bad_chunks else "",
             pool.buffer_stats().summary(),
         )

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -336,6 +336,7 @@ class InSituDataset:
             chunk_transforms=self.chunk_transforms,
             backing_dir=cache_dir,
             budget_bytes=self.cache_budget_bytes,
+            iteration_bytes=working_set,
             persist=persist,
             readonly_cache=readonly_cache,
             reset_stale_cache=reset_stale_cache,

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -259,18 +259,14 @@ class InSituDataset:
         # The last completed pass, or None before one finishes. Per pass, not per epoch: a
         # training epoch iterates train then val over one pool, and averaging two passes
         # with different shapes into one report is how a number stops meaning anything.
-        # A windowed shuffled pass holds a chunk from its first use to its last, which under
-        # a chunk permutation is most of an epoch -- so residency is close to the whole split
-        # (#66). Releasing each block's chunks when that block drains returns residency to the
-        # two-block floor, at the cost of admitting a chunk again when a later block reads it.
+        # Release each block's chunks as that block drains, and admit a chunk again when a
+        # later block reads it: residency is the three-block floor rather than the split a
+        # windowed shuffled pass would otherwise hold (#66).
         #
-        # A rule, not a knob, and it keys on `persist` rather than on `cache_dir`. Only a
-        # persisted slot survives its own eviction as a revivable file: with `cache_dir`
-        # alone the mmap backing is unlinked on eviction, so the second admission refetches
-        # and re-decodes. Measured on a 256-chunk windowed split, 249 re-reads served 2% from
-        # cache without `persist` and 49% with it -- the difference between the trade this
-        # policy assumes and the opposite one. Where the cheap path does not exist, retention
-        # is the better deal, so this turns on exactly where it does.
+        # A rule, not a knob, and it asks for `persist` because that is what makes the second
+        # admission cheap: a persisted slot survives its own eviction as a revivable file, so
+        # the re-read is a local read of decoded bytes. Retention is the better trade
+        # wherever that is not true, which is every other configuration.
         windowed = any(g.offset != 0 for g in self.geometries.values())
         self.reread_spill = persist and windowed and shuffle
         self.last_pass: PassStats | None = None

--- a/src/insitubatch/summary.py
+++ b/src/insitubatch/summary.py
@@ -166,13 +166,12 @@ def working_set_bytes(
     spill into a chunk owned by any other block.
 
     ``releases_spill`` says the pass hands each block's chunks back as that block drains
-    (:attr:`InSituDataset.reread_spill`), so nothing is held for a later block and the split
-    no longer has to be resident. The floor is then three blocks rather than two: a block is
-    released only after the batch draining it has gathered, while the wait for the next block
-    happens before, so a batch on a boundary transiently holds the block behind it, the one it
-    gathers, and the one it awaits. The floor must match what the pass will actually hold --
-    under-provisioning starves it mid-epoch, which fails like a hang rather than like a
-    shortage.
+    (:attr:`InSituDataset.reread_spill`), so the floor is three blocks and the split itself
+    is not charged. Three because a block is released only after the batch draining it has
+    gathered, while the wait for the next block happens before: a batch on a boundary holds
+    the block behind it, the one it gathers, and the one it awaits. The floor must match what
+    the pass will actually hold -- under-provisioning starves it mid-epoch, which fails like
+    a hang rather than like a shortage.
 
     Charged with :func:`~insitubatch.pool.slot_charge_bytes`, which is what the pool will
     actually charge -- sizing from the assembled shape while the pool charges stored tiles

--- a/src/insitubatch/summary.py
+++ b/src/insitubatch/summary.py
@@ -156,6 +156,7 @@ def working_set_bytes(
     ref_spc: int,
     shuffle: bool,
     assembles: bool,
+    releases_spill: bool = False,
 ) -> int:
     """The residency floor: what must be co-resident for one iteration to make progress.
 
@@ -163,6 +164,15 @@ def working_set_bytes(
     across a whole block. Windows widen it (a windowed read crosses chunk boundaries), and
     shuffle plus windows widen it to the whole split, because a shuffled windowed read can
     spill into a chunk owned by any other block.
+
+    ``releases_spill`` says the pass hands each block's chunks back as that block drains
+    (:attr:`InSituDataset.reread_spill`), so nothing is held for a later block and the split
+    no longer has to be resident. The floor is then three blocks rather than two: a block is
+    released only after the batch draining it has gathered, while the wait for the next block
+    happens before, so a batch on a boundary transiently holds the block behind it, the one it
+    gathers, and the one it awaits. The floor must match what the pass will actually hold --
+    under-provisioning starves it mid-epoch, which fails like a hang rather than like a
+    shortage.
 
     Charged with :func:`~insitubatch.pool.slot_charge_bytes`, which is what the pool will
     actually charge -- sizing from the assembled shape while the pool charges stored tiles
@@ -195,14 +205,15 @@ def working_set_bytes(
             return 1 if g.offset % spc0 == 0 else 2
 
         per_anchor_all_vars = sum(chunks_per_anchor(g) * bytes_per_chunk(g, o) for g, o in pairs)
-        working_set = 2 * block_chunks * per_anchor_all_vars
-        if windowed and shuffle:
+        blocks_resident = 3 if releases_spill else 2
+        working_set = blocks_resident * block_chunks * per_anchor_all_vars
+        if windowed and shuffle and not releases_spill:
             # Shuffle permutes chunk order, so a windowed read can spill into chunks owned by
-            # any other block: a chunk admitted early may be needed late. Until bounded
-            # residency (re-fetch the spill) lands, hold the whole split resident -- decode-
-            # once, the accepted memory cost of windows (spill to NVMe via cache_dir on large
-            # splits). Only `.train` shuffles (eval views are sequential and spill only
-            # locally), so size to the train split.
+            # any other block: a chunk admitted early may be needed late. Holding the whole
+            # split resident is decode-once, the memory cost of windows when the spill is
+            # retained; `releases_spill` is the other trade and skips this clamp entirely.
+            # Only `.train` shuffles (eval views are sequential and spill only locally), so
+            # size to the train split.
             #
             # Counted once per *array*, not once per view. The pool keys slots by
             # `(path, chunk)` and the planner collapses several windowed views of one array
@@ -403,6 +414,7 @@ def describe(ds: InSituDataset, *, iterations: int = 1) -> DatasetReport:
         ref_spc=ds._ref_spc,
         shuffle=ds.shuffle,
         assembles=assembles,
+        releases_spill=ds.reread_spill,
     )
     inflight = cfg["max_inflight"] * max(v["stored_chunk_bytes"] for v in variables.values())
     batch_bytes = sum(

--- a/tests/test_reread_spill.py
+++ b/tests/test_reread_spill.py
@@ -189,58 +189,46 @@ def test_a_re_read_is_served_from_the_cache_rather_than_refetched(windowed, tmp_
     assert hit_rate > 0.3, f"re-reads must come from the cache, not the store: {hit_rate:.0%}"
 
 
-# -- the predicate that stops a second block refetching tiles already on their way ------
+# -- a pass may only stand on its own outstanding fetches --------------------
 
 
-def _pool_with_one_chunk():
-    from insitubatch.pool import ChunkPool
+def test_a_pass_does_not_skip_a_fetch_on_another_passs_writer(write_zarr) -> None:
+    """Two iterations share a pool, and one may be abandoned at any moment.
+
+    Skipping a fetch because *some* writer holds the slot reads a shared counter as if it
+    were a promise. It is not: a pass abandoned mid-fetch unwinds without delivering, and
+    the slot is left FILLING with nothing coming -- while the other pass, having skipped,
+    waits on it forever. `ChunkPool` records how many writers a slot has and not whose they
+    are, so the only sound basis for skipping is a scheduler's own outstanding work.
+
+    Driven through the pool directly: the window is a cancellation between one pass's write
+    starting and its delivery, and racing a real scheduler into it is exactly the flakiness
+    these tests avoid.
+    """
+    from insitubatch.pool import ChunkPool, SlotState
     from insitubatch.types import ArrayGeometry
 
     geom = ArrayGeometry(path="t2m", shape=(32, 4, 4), chunks=(4, 4, 4), dtype=np.dtype("f4"))
-    return ChunkPool({"t2m": geom}), geom
+    pool = ChunkPool({"t2m": geom})
+    abandoned, live = pool.new_owner(), pool.new_owner()
 
+    assert pool.try_admit("t2m", 3, abandoned)
+    writing = pool.tile_write("t2m", 3, ())
+    writing.__enter__()  # the abandoned pass's tile task is in flight
+    assert pool.try_admit("t2m", 3, live)  # the live pass references the same chunk
+    writing.__exit__(None, None, None)  # cancelled: unwinds without delivering
+    pool.release_owner(abandoned)  # its teardown, after `Scheduler.close` drained it
 
-def test_delivery_underway_is_false_for_a_slot_nobody_has_admitted() -> None:
-    pool, _ = _pool_with_one_chunk()
-    assert pool.delivery_underway("t2m", 3) is False
+    slot = pool._slots.get(("t2m", 3))
+    assert slot is not None and slot.state is SlotState.FILLING, (
+        "the live pass still references it, so it is not reclaimed"
+    )
+    assert slot.writers == 0 and slot.pending > 0, "nothing is coming for this slot"
+    assert not pool.is_ready("t2m", 3)
 
-
-def test_delivery_underway_is_true_while_a_writer_holds_the_slot() -> None:
-    """The case the policy needs: block i's tiles are in flight when block i+1 admits."""
-    pool, geom = _pool_with_one_chunk()
-    owner = pool.new_owner()
-    assert pool.try_admit("t2m", 3, owner)
-    with pool.tile_write("t2m", 3, ()):
-        assert pool.delivery_underway("t2m", 3) is True
-
-
-def test_delivery_underway_is_true_once_the_slot_is_ready() -> None:
-    pool, geom = _pool_with_one_chunk()
-    owner = pool.new_owner()
-    assert pool.try_admit("t2m", 3, owner)
-    pool.deliver_tile("t2m", 3, (), np.zeros(geom.tile_shape(), dtype="f4"))
-    assert pool.delivery_underway("t2m", 3) is True
-
-
-def test_an_abandoned_partial_is_not_underway(caplog) -> None:
-    """The control, and the one that would hang if it were wrong.
-
-    A slot left FILLING by a cancelled pass has no writer and will never complete on its
-    own. Reporting it as underway would make the next pass skip the fetch and then wait
-    for a delivery nobody is going to make.
-    """
-    pool, _ = _pool_with_one_chunk()
-    owner = pool.new_owner()
-    assert pool.try_admit("t2m", 3, owner)  # allocated, never written
-
-    assert pool.delivery_underway("t2m", 3) is False
-
-
-def test_a_failed_slot_is_not_underway() -> None:
-    """A poisoned slot is dropped so a later pass can refetch; it is not a delivery."""
-    pool, _ = _pool_with_one_chunk()
-    owner = pool.new_owner()
-    assert pool.try_admit("t2m", 3, owner)
-    pool.fail("t2m", 3, RuntimeError("bad chunk"))
-
-    assert pool.delivery_underway("t2m", 3) is False
+    # The live pass must therefore be the one to fill it. Nothing on the pool may tell it
+    # that a delivery is on the way, because none is.
+    assert not hasattr(pool, "delivery_underway"), (
+        "a pool-wide 'a writer holds this' query cannot answer 'will it be delivered' -- "
+        "the writer may belong to a pass that is being torn down"
+    )

--- a/tests/test_reread_spill.py
+++ b/tests/test_reread_spill.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import logging
 
+import numpy as np
 import pytest
 
 from insitubatch import obstore_store, open_geometries, split_by_chunk
@@ -186,3 +187,60 @@ def test_a_re_read_is_served_from_the_cache_rather_than_refetched(windowed, tmp_
 
     assert rereads > 0, "the fixture must actually re-read, or this asserts nothing"
     assert hit_rate > 0.3, f"re-reads must come from the cache, not the store: {hit_rate:.0%}"
+
+
+# -- the predicate that stops a second block refetching tiles already on their way ------
+
+
+def _pool_with_one_chunk():
+    from insitubatch.pool import ChunkPool
+    from insitubatch.types import ArrayGeometry
+
+    geom = ArrayGeometry(path="t2m", shape=(32, 4, 4), chunks=(4, 4, 4), dtype=np.dtype("f4"))
+    return ChunkPool({"t2m": geom}), geom
+
+
+def test_delivery_underway_is_false_for_a_slot_nobody_has_admitted() -> None:
+    pool, _ = _pool_with_one_chunk()
+    assert pool.delivery_underway("t2m", 3) is False
+
+
+def test_delivery_underway_is_true_while_a_writer_holds_the_slot() -> None:
+    """The case the policy needs: block i's tiles are in flight when block i+1 admits."""
+    pool, geom = _pool_with_one_chunk()
+    owner = pool.new_owner()
+    assert pool.try_admit("t2m", 3, owner)
+    with pool.tile_write("t2m", 3, ()):
+        assert pool.delivery_underway("t2m", 3) is True
+
+
+def test_delivery_underway_is_true_once_the_slot_is_ready() -> None:
+    pool, geom = _pool_with_one_chunk()
+    owner = pool.new_owner()
+    assert pool.try_admit("t2m", 3, owner)
+    pool.deliver_tile("t2m", 3, (), np.zeros(geom.tile_shape(), dtype="f4"))
+    assert pool.delivery_underway("t2m", 3) is True
+
+
+def test_an_abandoned_partial_is_not_underway(caplog) -> None:
+    """The control, and the one that would hang if it were wrong.
+
+    A slot left FILLING by a cancelled pass has no writer and will never complete on its
+    own. Reporting it as underway would make the next pass skip the fetch and then wait
+    for a delivery nobody is going to make.
+    """
+    pool, _ = _pool_with_one_chunk()
+    owner = pool.new_owner()
+    assert pool.try_admit("t2m", 3, owner)  # allocated, never written
+
+    assert pool.delivery_underway("t2m", 3) is False
+
+
+def test_a_failed_slot_is_not_underway() -> None:
+    """A poisoned slot is dropped so a later pass can refetch; it is not a delivery."""
+    pool, _ = _pool_with_one_chunk()
+    owner = pool.new_owner()
+    assert pool.try_admit("t2m", 3, owner)
+    pool.fail("t2m", 3, RuntimeError("bad chunk"))
+
+    assert pool.delivery_underway("t2m", 3) is False

--- a/tests/test_reread_spill.py
+++ b/tests/test_reread_spill.py
@@ -1,0 +1,188 @@
+"""A windowed shuffled pass releases its spill per block, and says that it did.
+
+Under retention a chunk is held from its first use to its last. With a chunk permutation
+those are most of an epoch apart, so a windowed shuffled pass keeps close to the whole
+split resident (#66) -- measured at 46-56% of the split, and 97% for a four-lead
+configuration.
+
+Releasing each block's chunks when that block drains returns residency to the three-block
+floor. The cost is admitting a chunk again when a later block reads it, which is only a good
+trade when that second admission is served from already-decoded bytes -- hence the rule
+rather than a knob.
+
+The rule keys on `persist`, not on `cache_dir`. Only a persisted slot survives its own
+eviction as a revivable file; with `cache_dir` alone the backing is unlinked when the slot is
+evicted, so the re-read refetches and re-decodes. Measured on the 256-chunk windowed split
+below, the same 249 re-reads were served 2% from cache without `persist` and 49% with it.
+
+The re-read count is not decoration. A re-read served from the cache counts as a *hit*, so
+the hit rate alone cannot distinguish "the working set fits" from "the budget is churning";
+these tests pin that the number is reported.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from insitubatch import obstore_store, open_geometries, split_by_chunk
+from insitubatch.source import InSituDataset
+
+N, SPC = 256, 4
+
+
+@pytest.fixture
+def windowed(write_zarr):
+    url, _ = write_zarr(n=N, spc=SPC, inner=(4, 4))
+    geometries = open_geometries(obstore_store(url))
+    base = geometries["t2m"]
+    geoms = {"now": base, "next": base.shift(SPC * 3)}  # a lead several chunks away
+    manifest = split_by_chunk(base, fractions=(1.0, 0.0, 0.0))
+    return url, geoms, manifest
+
+
+def _drain(ds: InSituDataset) -> int:
+    ds.set_epoch(0)
+    return sum(int(b.arrays["now"].shape[0]) for b in ds.train)
+
+
+def _dataset(windowed, **kw) -> InSituDataset:
+    url, geoms, manifest = windowed
+    return InSituDataset(
+        obstore_store(url),
+        manifest,
+        geometries=geoms,
+        batch_size=8,
+        block_chunks=2,
+        shuffle=True,
+        seed=0,
+        **kw,
+    )
+
+
+def test_the_rule_needs_a_persisted_cache(windowed, tmp_path) -> None:
+    """Releasing early is the better trade only when the re-read is a local revive.
+
+    `cache_dir` on its own is not enough and the middle case is the point: it gives the pool
+    an mmap tier, but an evicted slot's backing is unlinked, so a re-read pays the fetch and
+    the decode again -- the opposite of the trade this policy assumes.
+    """
+    assert _dataset(windowed).reread_spill is False
+    assert _dataset(windowed, cache_dir=str(tmp_path / "a")).reread_spill is False
+    assert _dataset(windowed, cache_dir=str(tmp_path / "b"), persist=True).reread_spill is True
+
+
+def test_an_unwindowed_pass_keeps_retaining(windowed, tmp_path, write_zarr) -> None:
+    """The control: without offsets there is no spill, so nothing changes.
+
+    A chunk belongs to one block, is released when that block drains, and is never read
+    again -- the policy would be a no-op, and turning it on would only cost the dedup.
+    """
+    url, _ = write_zarr(n=N, spc=SPC, inner=(4, 4))
+    geometries = open_geometries(obstore_store(url))
+    manifest = split_by_chunk(geometries["t2m"], fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(
+        obstore_store(url),
+        manifest,
+        geometries=geometries,
+        batch_size=8,
+        block_chunks=2,
+        shuffle=True,
+        cache_dir=str(tmp_path / "c"),
+        persist=True,
+    )
+
+    assert ds.reread_spill is False
+
+
+def test_releasing_per_block_holds_far_less(windowed, tmp_path) -> None:
+    """The point of the change: peak residency, retained versus released."""
+    retained = _dataset(windowed)
+    retained_samples = _drain(retained)
+    retained_peak = retained._pool.max_resident
+    retained.close()
+
+    released = _dataset(windowed, cache_dir=str(tmp_path / "c"), persist=True)
+    released_samples = _drain(released)
+    released_peak = released._pool.max_resident
+    released.close()
+
+    # Fewer than N: a windowed view drops the edge anchors whose lead runs off the array.
+    # What matters is that the policy does not change which samples arrive.
+    assert retained_samples == released_samples > 0
+
+    assert released_peak < retained_peak, (
+        f"released {released_peak} vs retained {retained_peak}: releasing per block must "
+        "hold less, or the policy is buying nothing"
+    )
+
+
+def test_the_epoch_line_reports_re_reads_and_evictions(windowed, tmp_path, caplog) -> None:
+    """A re-read from the cache counts as a hit, so the hit rate alone hides the churn."""
+    ds = _dataset(windowed, cache_dir=str(tmp_path / "c"), persist=True)
+    with caplog.at_level(logging.INFO, logger="insitubatch"):
+        _drain(ds)
+    ds.close()
+
+    lines = [r.message for r in caplog.records if "chunks" in r.message and "hit" in r.message]
+    assert lines, "the per-epoch summary must be emitted"
+    assert any("re-read" in line for line in lines), (
+        f"re-reads must be visible when the spill is released: {lines}"
+    )
+
+
+def test_retained_passes_report_no_re_reads(windowed, caplog) -> None:
+    """The control: without the policy a chunk is taken once, so the count stays silent.
+
+    If this ever prints a re-read, either the plan stopped deduplicating or a chunk is
+    being admitted twice for a reason nobody asked for.
+    """
+    ds = _dataset(windowed)
+    with caplog.at_level(logging.INFO, logger="insitubatch"):
+        _drain(ds)
+    ds.close()
+
+    assert not any("re-read" in r.message for r in caplog.records)
+
+
+def test_the_floor_drops_from_the_split_to_three_blocks(windowed, tmp_path) -> None:
+    """The point of the change, in the number a caller is actually sized by.
+
+    Releasing costs nothing if the budget still has to hold the split: a released chunk is
+    only *evictable*, and with a floor sized for retention nothing is ever evicted. So the
+    floor has to know the policy, and this is the assertion that it does.
+    """
+
+    def floor_chunks(ds: InSituDataset) -> int:
+        return ds.describe()["memory"]["residency_bytes"] // ds.geometries["now"].chunk_bytes
+
+    retained = _dataset(windowed)
+    released = _dataset(windowed, cache_dir=str(tmp_path / "c"), persist=True)
+    try:
+        split_chunks = len(retained.manifest.chunks["train"])
+        assert floor_chunks(retained) >= split_chunks, "retention holds the split, by design"
+        assert floor_chunks(released) <= 3 * released.block_chunks * 2, (
+            "a released spill is sized by three blocks across two views, not by the split"
+        )
+    finally:
+        retained.close()
+        released.close()
+
+
+def test_a_re_read_is_served_from_the_cache_rather_than_refetched(windowed, tmp_path) -> None:
+    """The premise of the trade, asserted rather than assumed.
+
+    A re-read that refetches and re-decodes is strictly worse than having retained the
+    chunk, so the policy is only sound while the cache answers. The control is the same
+    pass with `cache_dir` but no `persist`: identical re-read count, almost none of it
+    served.
+    """
+    served = _dataset(windowed, cache_dir=str(tmp_path / "p"), persist=True)
+    _drain(served)
+    hit_rate = served._pool.hits / max(served._pool.hits + served._pool.misses, 1)
+    rereads = served._pool.rereads
+    served.close()
+
+    assert rereads > 0, "the fixture must actually re-read, or this asserts nothing"
+    assert hit_rate > 0.3, f"re-reads must come from the cache, not the store: {hit_rate:.0%}"

--- a/tests/test_residency.py
+++ b/tests/test_residency.py
@@ -170,16 +170,25 @@ def test_slow_consumer_is_not_mistaken_for_starvation(small_store, run_by) -> No
         assert run_by(DEADLINE, lambda: drain(sched)) == geom.n_chunks
 
 
-def test_starvation_names_concurrent_iterations_as_the_cause(small_store, run_by) -> None:
-    """Under-sizing for concurrent iterations must say so, not just "raise the budget".
+def test_a_second_iteration_the_budget_cannot_hold_is_refused_at_the_boundary(
+    small_store, run_by
+) -> None:
+    """Under-sizing for concurrent iterations must fail at the start, and say why.
 
-    Sizing for one iteration is the deliberate default (the engine cannot know how many
-    you intend to run), so the *diagnostic* is what has to carry the cost. Every resident
-    chunk here is legitimately referenced -- by one of two iterations -- which is exactly
-    the case a caller cannot infer from "every one of them pinned or in flight".
+    Sizing for one iteration is the deliberate default -- the engine cannot know how many
+    you intend to run -- so the *diagnostic* is what has to carry the cost. Every resident
+    chunk in this case is legitimately referenced, by one of two iterations, which is
+    exactly what a caller cannot infer from "every one of them pinned or in flight".
 
-    Guards the number too: reporting a count means it has to be the count of distinct
-    owners, not of pins or of resident chunks.
+    Refused when the second iteration starts, rather than left to starve mid-epoch. The
+    arithmetic is complete at that point: N iterations need N floors, and the budget either
+    covers it or does not. Waiting for the stall instead makes the outcome depend on how
+    the two interleave -- the same configuration then succeeds and fails on consecutive
+    runs, which is worse to debug than either result on its own.
+
+    `Scheduler._starvation` is not replaced by this and keeps its own tests: it catches
+    what the arithmetic cannot predict, such as a floor that under-estimates a windowed or
+    non-uniformly chunked pass.
     """
     geoms = open_geometries(obstore_store(small_store))
     geom = geoms["t2m"]
@@ -206,12 +215,35 @@ def test_starvation_names_concurrent_iterations_as_the_cause(small_store, run_by
             for it in (a, b):
                 it.close()
 
-    with pytest.raises(RuntimeError, match="residency budget exhausted") as exc:
+    with pytest.raises(RuntimeError, match="cannot hold 2 concurrent iterations") as exc:
         run_by(DEADLINE, interleave)
 
     msg = str(exc.value)
-    assert "2 iterations are sharing this pool" in msg, (
-        "the diagnostic must name concurrent iterations as the cause -- every chunk is "
-        f"legitimately referenced, so 'raise the budget' alone is not actionable: {msg}"
-    )
     assert "zip(ds.train, ds.val)" in msg, "point at the pattern that produces this"
+    assert "cache_budget_bytes=" in msg, (
+        f"naming the budget to pass is what makes this actionable rather than a refusal: {msg}"
+    )
+
+
+def test_one_iteration_at_a_time_is_never_refused(small_store) -> None:
+    """The control: the check must count *concurrent* iterations, not passes ever made.
+
+    An owner is released at its pass's teardown, so iterating the splits one after another
+    -- the ordinary training epoch -- never has two live at once however many it runs.
+    """
+    geoms = open_geometries(obstore_store(small_store))
+    geom = geoms["t2m"]
+    manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(
+        obstore_store(small_store),
+        manifest,
+        shuffle=False,
+        batch_size=geom.sample_chunk_size,
+        block_chunks=2,
+    )
+    try:
+        for epoch in range(3):
+            ds.set_epoch(epoch)
+            assert sum(int(b.arrays["t2m"].shape[0]) for b in ds.train) > 0
+    finally:
+        ds.close()


### PR DESCRIPTION
## Summary

Closes #66.

A windowed view reads `anchor + offset` and shuffle permutes chunk order, so a chunk one block
reads can be needed again most of an epoch later. Held from first use to last, residency was
close to the whole train split rather than two blocks.

With `persist=True` each block hands its chunks back as it drains, and a later block re-admits
them from the on-disk cache.

| offsets | policy | floor (chunks) | peak resident | re-reads | samples |
|---|---|---|---|---|---|
| `{0, 12}` | retain | 259 | 256 | 0 | 1012 |
| `{0, 12}` | **release** | **12** | **12** | 249 | 1012 |
| `{0, 24, 240}` | retain | 316 | 256 | 0 | 784 |
| `{0, 24, 240}` | **release** | **18** | **18** | 331 | 784 |

256-chunk split, `block_chunks=2`, two views of one array. Same samples delivered either way.

## Three parts, none of which works alone

* **plan** — dedup scoped to a block (`groups=`), so a chunk two blocks apart is admitted twice;
  the driver decides admission per chunk-run rather than once per pass.
* **consumer** — releases every key its block read, not only those at their last use; the
  read-ahead bound becomes three consecutive blocks (a batch on a boundary transiently holds the
  block behind it, the one it gathers, and the one it awaits).
* **floor** — `working_set_bytes` learns the policy. This one is easy to miss: a released chunk
  is only *evictable*, so with a floor still sized for retention nothing is ever evicted and
  releasing changes no number at all. That was the state of the parked spike.

## Two things measurement corrected

**The rule keys on `persist`, not `cache_dir`.** Only a persisted slot survives its own eviction
as a revivable file; with `cache_dir` alone the backing is unlinked on eviction, so the re-read
pays the fetch *and* the decode again — strictly worse than having retained the chunk. Same
fixture, same 249 re-reads:

```
persist=False   hits  10/501  (2%)   cache files   12
persist=True    hits 246/502  (49%)  cache files  256
```

The first draft of this keyed on `cache_dir` and logged "served from cache_dir", which would
have shipped a claim that was false in exactly the configuration it described.

**Why #66 was blocked, and no longer is.** The parked spike deadlocked because the driver planned
a block from its chunk ids while the consumer released the keys its rows read, and those
disagreed on 66 of 77 blocks. #68/#69 fixed that: block membership now comes from the builder, so
the planner's clamp and the consumer's edge-anchor drop agree. Verified before building on it —
across 11 geometries (plain, leads of 1/one-chunk/three-chunk, history+lead, sparse leads,
one-sample chunks, fat chunks, ragged tail, wide blocks, negative-only, a lead past the split):
**0 surplus permits, 0 shortfall, every block.**

## For reviewers

The `releases_spill` argument on `working_set_bytes` is the part worth a second look — it changes
a floor that raises at construction when a budget is below it, so getting it too low starves a
pass mid-epoch, which fails in the shape of a hang. It is three blocks rather than two for the
boundary reason above.

`docs/tuning.md` gains a section: what the trade is, why it is a rule and not a knob, and how to
read the churn line. The per-epoch summary reports re-reads and evictions whenever non-zero,
because a hit rate cannot show this — a re-read served from the cache counts as a hit.

Tests: 7 in `tests/test_reread_spill.py`, including the two controls that matter — an unwindowed
pass must not enable the policy (it would buy nothing and cost the dedup), and a retained pass
must report no re-reads (if it ever does, either the plan stopped deduplicating or a chunk is
being admitted twice for no reason).

## Author attestation

- [ ] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

Left unticked deliberately: it asserts that a human reviewed every change and verified the
claims above, which is yours to assert and not mine to assert on your behalf.

## Checklist

- [x] Tests added or updated
- [x] `ruff check`, `ruff format --check`, `mypy`, `pytest -q` (651 passed + tf's 2 in its own
      process) and `mkdocs build --strict` green locally
- [x] Docstrings for the changed surface (`working_set_bytes`, `Scheduler.start`,
      `build_stored_chunk_reads`)
- [x] User-facing behaviour documented in `docs/tuning.md`
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] No load-bearing invariant is broken
- [ ] Touches `ChunkPool` / the scheduler / cross-thread readiness → 3.13t run passes (CI)
