### PR TITLE
fix: answer an idle consumer before reading the batch queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **A loop with no training step could be told its training step was the bottleneck.**
+  `bottleneck()` read the batch queue before asking whether the caller's loop body did any
+  work, so a `for batch in ds.train: pass` whose queue happened to look fed was answered with
+  "the loader kept up and your training step is the constraint" -- advice to tune a knob that
+  is not there. The `consumer_idle` branch below it was guarded by the premise that such a
+  loop *cannot* keep the queue fed; on a free-threaded build it can, because a GIL-releasing
+  `chunk_transform` runs alongside the consumer. It presented as a test that passed and
+  failed on identical code, with a 19-microsecond loop body reported as the constraint. The
+  idle case is known before the queue is consulted, so it is answered first, and the verdict
+  no longer depends on how the producer threads interleave.
+
 - **A windowed, shuffled pass held close to the whole train split resident (#66).** A windowed
   view reads `anchor + offset` and shuffle permutes chunk order, so a chunk one block reads can
   be needed again most of an epoch later; held from first use to last, residency was the split

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -470,12 +470,16 @@ Note `wait fetch` **rises** as the pass gets faster (14.06s at `max_inflight=1`,
 total is task-seconds against a 1.1s wall. Read the ratios between stages, never any stage
 against the clock.
 
+The rows are in precedence order: a loop body that does essentially nothing is answered
+first, because "the loader kept up, so your training step is the constraint" is only an
+answer where a training step exists.
+
 | what the report shows | limiting stage | what to do |
 |---|---|---|
+| `consumer_s` is a few % of wall | *the dominant producer stage, reported not diagnosed* | your loop has no real training step, so read this as a throughput measurement rather than a starved pipeline |
 | batch queue **fed** (`fed_frac` high) | `consumer` | nothing — the loader kept up and your training step is the constraint. This is the goal |
 | queue empty, `fetch_wait_s` dominant | `store` | raise `max_inflight`; check the store is in-region and on the fast backend |
 | as above, **and `inflight_peak == max_inflight`** | `store` | same, but re-measure: if throughput stops improving the network is the floor, not a knob left unturned |
-| queue empty but `consumer_s` is a few % of wall | *reported, not diagnosed* | your loop has no real training step, so the queue cannot stay fed; read throughput instead |
 | queue empty, `decode_s` / `assemble_s` dominant | `decode` | raise `decode_threads`; check the `chunk_transform` is vectorized numpy that releases the GIL |
 | queue empty, `admission_parked_s` dominant | `residency` | raise `cache_budget_bytes`, or lower `batch_size` / `block_chunks` / concurrent iterations |
 | queue empty, `gather_s` / `batch_transform_s` dominant | `gather` | check the gather run length in `describe()`, and any `batch_transform` |

--- a/src/insitubatch/runtime.py
+++ b/src/insitubatch/runtime.py
@@ -179,10 +179,13 @@ class PassStats:
 def bottleneck(stats: PassStats) -> tuple[Stage, str]:
     """Which stage limited this pass, and what to do about it.
 
-    The rule reads the batch queue first, because a full queue settles the question: every
-    producer stage kept up and the consumer is the constraint, which is the state you want.
-    Only once the queue is *repeatedly* empty is there a producer stage to accuse, and then
-    the accusation comes from which one spent the time -- not from which one feels slow.
+    A caller whose loop body does essentially nothing is answered first: with no training
+    step there is no "the consumer is the constraint" to reach, whatever the queue looks
+    like. Otherwise the rule reads the batch queue, because a full queue settles the
+    question: every producer stage kept up and the consumer is the constraint, which is the
+    state you want. Only once the queue is *repeatedly* empty is there a producer stage to
+    accuse, and then the accusation comes from which one spent the time -- not from which
+    one feels slow.
 
     Returns ``("unknown", ...)`` rather than guessing when the evidence does not separate
     the candidates: no samples, or no stage clearly dominant. A confident wrong answer here
@@ -192,16 +195,13 @@ def bottleneck(stats: PassStats) -> tuple[Stage, str]:
     if not d.batch_queue_samples:
         return "unknown", "no consumer samples: the pass ended before any batch was taken."
     saturated = d.inflight_peak >= d.max_inflight > 0
-    if d.fed_frac >= FULL_ENOUGH:
-        return (
-            "consumer",
-            "the batch queue stayed fed, so the loader kept up and your training step is "
-            "the constraint. This is the desired steady state -- nothing to tune here.",
-        )
     if stats.consumer_idle:
-        # Not a hedge: with no training step the queue *cannot* stay fed, so its depth
-        # carries no signal and the starvation thresholds below would fire on every such
-        # loop. Name what limits raw throughput and say plainly what the number means.
+        # Asked before the queue, because "the loader kept up, so your training step is the
+        # constraint" is only an answer where a training step exists. A loop with no body
+        # takes batches as fast as they are produced; whether the queue still reads as fed
+        # is then a matter of how the producer threads interleave, and the starvation
+        # thresholds below would fire on every such loop besides. Name what limits raw
+        # throughput and say plainly what the number means.
         top, why = _dominant(t, saturated)
         share = t.consumer_s / stats.wall_s if stats.wall_s else 0.0
         return top, (
@@ -209,6 +209,12 @@ def bottleneck(stats: PassStats) -> tuple[Stage, str]:
             f"({share:.0%}), so the loader is nearly the whole program and the batch queue "
             "cannot stay fed however fast it gets -- read this as a throughput measurement, "
             f"not a starved pipeline. What limits that throughput is: {why}"
+        )
+    if d.fed_frac >= FULL_ENOUGH:
+        return (
+            "consumer",
+            "the batch queue stayed fed, so the loader kept up and your training step is "
+            "the constraint. This is the desired steady state -- nothing to tune here.",
         )
     if d.starved_frac < STARVED_ENOUGH:
         return (

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -67,6 +67,62 @@ def test_a_fed_queue_blames_the_consumer():
     assert "desired steady state" in why
 
 
+def test_a_fed_queue_does_not_blame_a_loop_body_that_does_nothing():
+    """`for batch in ds.train: pass` has no training step to be the constraint.
+
+    The fed-queue verdict reads a full queue as "the loader kept up, so your training step
+    is the constraint". That is the right reading only when there *is* a training step. A
+    loop with no body takes batches as fast as they are produced, and whether the queue
+    still looks fed is a matter of how the producer threads happen to interleave -- on a
+    free-threaded build a GIL-releasing transform runs alongside the consumer and the queue
+    can stay fed with a loop body of 19 microseconds.
+
+    Telling that caller to look at their training step sends them to tune a knob they do
+    not have, and the verdict flips run to run on identical code. An idle consumer is known
+    before the queue is consulted, so it is answered first.
+    """
+    stats = _stats(
+        wall_s=0.41,
+        depths={
+            "batch_queue_capacity": 2,
+            "batch_queue_samples": 10,
+            "batch_queue_full_enough": 9,  # fed, by the accident of interleaving
+            "batch_queue_empty": 1,
+        },
+        times={"assemble_s": 0.37, "decode_s": 0.011, "consumer_s": 0.000019},
+    )
+    assert stats.consumer_idle, "the fixture must be the no-training-step case"
+
+    stage, why = bottleneck(stats)
+
+    assert stage == "decode", why
+    assert "training step is the constraint" not in why
+
+
+def test_a_fed_queue_still_blames_a_consumer_that_is_doing_work():
+    """The control: a real training step keeps the fed-queue verdict.
+
+    Without this, answering the idle case first could quietly swallow the state the whole
+    rule exists to recognise -- the loader keeping up with a caller who is genuinely busy.
+    """
+    stats = _stats(
+        wall_s=1.0,
+        depths={
+            "batch_queue_capacity": 2,
+            "batch_queue_samples": 100,
+            "batch_queue_full_enough": 90,
+            "batch_queue_empty": 2,
+        },
+        times={"assemble_s": 0.05, "consumer_s": 0.8},
+    )
+    assert not stats.consumer_idle
+
+    stage, why = bottleneck(stats)
+
+    assert stage == "consumer"
+    assert "desired steady state" in why
+
+
 def test_rare_starvation_is_noise_not_a_bottleneck():
     stats = _stats(
         depths={"batch_queue_capacity": 2, "batch_queue_samples": 100, "batch_queue_empty": 5},


### PR DESCRIPTION
## Summary

Fixes the `test-freethreaded` flake on #73, which turned out to be a real wrong diagnosis
rather than a fragile test.

`bottleneck()` read the batch queue before asking whether the caller's loop body did any work:

```python
if d.fed_frac >= FULL_ENOUGH:
    return "consumer", "...the loader kept up and your training step is the constraint..."
if stats.consumer_idle:
    # "with no training step the queue *cannot* stay fed, so its depth carries no signal"
```

That comment is the premise, and it is not always true. On a free-threaded build a
GIL-releasing `chunk_transform` runs alongside the consumer, so a `for batch in ds.train: pass`
loop can leave the queue looking fed — and then gets told its *training step* is the
constraint. CI reported exactly that, with a **19-microsecond** loop body:

```
StageTimes(assemble_s=0.371, decode_s=0.011, consumer_s=0.000019)
assert 'consumer' == 'decode'
```

Wall was 0.41 s. The advice sends someone to tune a knob they do not have, which is the
failure the rule's own docstring says costs more than an admission.

Whether the loop body did work is known before the queue is consulted, so it is asked first.

## Not just a flake

It re-ran green, and I could not reproduce it locally in 200+ attempts (isolation, whole file,
whole suite, free-threaded, 8 cores). That is the point: the verdict depended on how the
producer threads happened to interleave, so the same code gave different answers. The test
was right to fail; it just could not be relied on to.

The new tests construct `PassStats` directly, so neither the bug nor the fix depends on timing.
`test_a_fed_queue_does_not_blame_a_loop_body_that_does_nothing` fails on `main` with the same
`'consumer' == 'decode'`.

## For reviewers

The reorder makes the fed-queue verdict unreachable for an idle consumer, which is the whole
change — so the control test matters more than the fix:
`test_a_fed_queue_still_blames_a_consumer_that_is_doing_work` pins that a caller who is
genuinely busy still gets `consumer` and "the desired steady state". Without it, answering the
idle case first could quietly swallow the state the rule exists to recognise.

`docs/tuning.md`'s table had the same false premise ("your loop has no real training step, so
the queue cannot stay fed") and implied the wrong precedence. Its rows are now in precedence
order with that row first, and it no longer claims the queue cannot stay fed.

Verified on the build that flaked: `tests/test_runtime.py` green under 3.13t with
`PYTHON_GIL=0`, and the originally-failing test 10/10.

## Author attestation

- [ ] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

Left unticked deliberately: it asserts that a human reviewed every change and verified the
claims above, which is yours to assert and not mine to assert on your behalf.

## Checklist

- [x] Tests added — a failing test plus the control, both timing-free
- [x] `ruff check`, `ruff format --check`, `mypy`, `pytest -q` (655 passed) and
      `mkdocs build --strict` green locally
- [x] User-facing behaviour documented in `docs/tuning.md`
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] No load-bearing invariant is broken
