### PR TITLE
fix: refuse an advection run that cannot be scored, at setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- **A windowed split could hold chunks and draw nothing, and only an empty iterator said so.**
+  A windowed view reads `anchor + offset`, so anchors whose window runs off the array are
+  dropped; a split lying entirely in that tail keeps its chunks and yields no batches. That is
+  a different cause from a split that rounded to zero chunks, with the same symptom, and the
+  chunk counts in `describe()` could not tell them apart. The report now carries
+  `drawable_samples` per split, `print_summary()` shows it beside the chunk count on windowed
+  runs, and a split with chunks but nothing to draw is a `split-yields-nothing` warning naming
+  the offsets responsible. A split asked to be empty is not a finding and is not warned about.
+
+- **`examples/advection` trained a whole epoch before finding it had nothing to score (#71).**
+  `--n-steps 192` on the default 10% split gives the val split no chunks; `--n-steps 256` gives
+  it a chunk whose every anchor the 24-step target drops. Either way the run built the store,
+  trained, validated, and only then raised from `evaluate` -- discarding all of it to report a
+  fact its arguments had already fixed. Both are now refused at setup, from the engine's own
+  `drawable_samples`, and the message names the smallest sample-axis length that works, solved
+  against the same split and window arithmetic rather than quoted as a constant.
+
 - **A loop with no training step could be told its training step was the bottleneck.**
   `bottleneck()` read the batch queue before asking whether the caller's loop body did any
   work, so a `for batch in ds.train: pass` whose queue happened to look fed was answered with

--- a/docs/tuning.md
+++ b/docs/tuning.md
@@ -293,6 +293,21 @@ tiles — so for anything but a single-variable run, ask
 [`describe()`](api.md#insitubatch.InSituDataset.describe), which reports the number the
 engine will actually use rather than one you assembled by hand.
 
+### A windowed split can hold chunks and still draw nothing
+
+A windowed view reads `anchor + offset`, so anchors whose window runs off the array are
+dropped. A split lying entirely in that tail keeps its chunks and yields no batches — the same
+symptom as a split that rounded to zero chunks, and a different cause. `describe()` reports
+both numbers, and `print_summary()` shows them side by side whenever the views are windowed:
+
+```
+splits (chunks)  train 5 (232 drawable)  val 1 (0 drawable)  test 0 (0 drawable)
+```
+
+A split with chunks but nothing drawable is a `split-yields-nothing` warning, naming the
+offsets responsible. A split you asked to be empty — `fractions=(1.0, 0.0, 0.0)` — is not a
+finding and is not warned about.
+
 ### Two iterations at once are refused, not left to stall
 
 Every active iteration holds its own references, so N of them need N floors. The budget is

--- a/examples/advection/data.py
+++ b/examples/advection/data.py
@@ -29,6 +29,7 @@ import zarr
 from zarr.abc.store import Store
 
 from insitubatch import (
+    ArrayGeometry,
     Batch,
     InSituDataset,
     arraylake_store,
@@ -37,6 +38,7 @@ from insitubatch import (
     open_geometries,
     split_by_chunk,
 )
+from insitubatch.summary import drawable_samples
 
 from .._logging import add_log_level, configure_logging
 
@@ -213,6 +215,64 @@ def _synthetic_ready(
         return False
 
 
+def _minimum_samples(
+    geom: ArrayGeometry, fractions: tuple[float, float, float], horizon: int
+) -> int:
+    """The smallest sample-axis length for which train *and* val can both be drawn.
+
+    Solved against the same `split_by_chunk` and `drawable_samples` the run will use, rather
+    than quoted as a constant, so it stays true if either changes. Pure integer work on a
+    stand-in geometry -- no store is opened.
+    """
+    step = geom.sample_chunk_size
+    for n in range(step, step * 64 + 1, step):
+        trial = ArrayGeometry(
+            path=geom.path, shape=(n, *geom.shape[1:]), chunks=geom.chunks, dtype=geom.dtype
+        )
+        views = {"now": trial, "target": trial.shift(horizon)}
+        drawable = drawable_samples(views, split_by_chunk(trial, fractions=fractions))
+        if all(drawable[name] > 0 for name in ("train", "val")):
+            return n
+    return 0  # nothing in range works -- the caller reports what it has instead
+
+
+def _require_drawable_splits(
+    ds: InSituDataset, geom: ArrayGeometry, horizon: int, fractions: tuple[float, float, float]
+) -> None:
+    """Refuse a geometry whose train or val view is empty, before any training runs.
+
+    Both are known from the arguments, so neither is worth an epoch to discover: the run
+    would train, validate, and only then reach `evaluate` with no batches to score.
+
+    The counts come from :func:`~insitubatch.summary.drawable_samples`, which is what the
+    engine itself reports -- a split can hold chunks and still draw nothing, because a
+    windowed target drops the anchors whose horizon runs off the array.
+    """
+    report = ds.describe()["config"]
+    drawable, chunks = report["drawable_samples"], report["split_chunks"]
+    empty = [name for name in ("train", "val") if not drawable[name]]
+    if not empty:
+        return
+    counts = ", ".join(
+        f"{name}={chunks[name]} chunk(s)/{drawable[name]} drawable samples"
+        for name in ("train", "val")
+    )
+    need = _minimum_samples(geom, fractions, horizon)
+    remedy = (
+        f"Use at least {need} samples on the sample axis (--n-steps for the synthetic store, "
+        f"--sample-range for a real one); you have {geom.n_samples}."
+        if need
+        else "Widen the sample axis (--n-steps / --sample-range) or change the split fractions."
+    )
+    raise ValueError(
+        f"the {' and '.join(empty)} split has nothing to draw, so this run could train but "
+        f"never be scored. {geom.n_samples} samples over chunks of {geom.sample_chunk_size} is "
+        f"{geom.n_chunks} chunk(s); split {fractions} gives {counts}. A {horizon}-step target "
+        f"also drops the last {horizon} anchors, which can empty a split that did get chunks. "
+        f"{remedy}"
+    )
+
+
 def forecast_dataset(
     store: Store,
     *,
@@ -240,10 +300,9 @@ def forecast_dataset(
     opened = open_geometries(store, variables=list(variables))
     geoms = {label: opened[var] for label, var in zip(LABELS, variables, strict=True)}
     geoms["target"] = opened[variables[0]].shift(horizon)
-    manifest = split_by_chunk(
-        opened[variables[0]], fractions=(0.8, 0.1, 0.1), sample_range=sample_range
-    )
-    return InSituDataset(
+    fractions = (0.8, 0.1, 0.1)
+    manifest = split_by_chunk(opened[variables[0]], fractions=fractions, sample_range=sample_range)
+    ds = InSituDataset(
         store,
         manifest,
         geometries=geoms,
@@ -252,6 +311,8 @@ def forecast_dataset(
         cache_dir=cache_dir,
         max_inflight=max_inflight,
     )
+    _require_drawable_splits(ds, opened[variables[0]], horizon, fractions)
+    return ds
 
 
 def inputs_and_targets(batch: Batch) -> tuple[np.ndarray, np.ndarray, np.ndarray]:

--- a/src/insitubatch/summary.py
+++ b/src/insitubatch/summary.py
@@ -26,7 +26,7 @@ import numpy as np
 
 from .pool import slot_charge_bytes
 from .shuffle import shuffle_quality
-from .split import SplitManifest
+from .split import SplitManifest, valid_anchor_range
 from .transforms import transform_scope, unwrap_transform
 from .types import ArrayGeometry, SplitName
 
@@ -105,6 +105,7 @@ class ConfigReport(TypedDict):
     samples_per_chunk: int
     n_chunks: dict[str, int]
     split_chunks: dict[str, int]
+    drawable_samples: dict[str, int]
     shuffle_quality: float | None
 
 
@@ -289,6 +290,27 @@ def _variable_report(
     )
 
 
+def drawable_samples(geoms: dict[str, ArrayGeometry], manifest: SplitManifest) -> dict[str, int]:
+    """How many anchors each split can actually draw, per split name.
+
+    A split's chunk count is not the answer when the views are windowed: a variable reads
+    ``anchor + offset``, so anchors whose window runs off the array are dropped, and a split
+    lying entirely in that tail keeps its chunks and yields nothing. The two are different
+    failures with the same symptom -- an iterator that produces no batches -- and only this
+    number separates them.
+    """
+    ref = next(iter(geoms.values()))
+    lo, hi = valid_anchor_range([g.offset for g in geoms.values()], ref.n_samples)
+    out: dict[str, int] = {}
+    for name, ids in manifest.chunks.items():
+        total = 0
+        for cid in ids:
+            span = ref.samples_in_chunk(cid)
+            total += max(0, min(hi, span.stop) - max(lo, span.start))
+        out[name] = total
+    return out
+
+
 def _notes(variables: dict[str, VariableReport], cfg: ConfigReport) -> list[Note]:
     """Say when a layout is a problem, and why. This is the point of the report.
 
@@ -346,6 +368,24 @@ def _notes(variables: dict[str, VariableReport], cfg: ConfigReport) -> list[Note
                 )
             )
 
+    for name, drawable in cfg["drawable_samples"].items():
+        if drawable or not cfg["split_chunks"][name]:
+            continue  # a split asked to be empty is not a finding; one that cannot draw is
+        globals_.append(
+            Note(
+                code="split-yields-nothing",
+                severity="warn",
+                subject=name,
+                message=(
+                    f"the {name} split holds {cfg['split_chunks'][name]} chunk(s) but can "
+                    f"draw no samples: every anchor in it is dropped by the window "
+                    f"{sorted(set(cfg['offsets'].values()))}, which reaches past the array. "
+                    "Iterating it yields nothing. Widen the split, or move it away from the "
+                    "array's edge."
+                ),
+            )
+        )
+
     if cfg["block_chunks"] != cfg["block_chunks_requested"]:
         globals_.append(
             Note(
@@ -400,6 +440,7 @@ def describe(ds: InSituDataset, *, iterations: int = 1) -> DatasetReport:
         samples_per_chunk=ds._ref_spc,
         n_chunks={label: v["n_chunks"] for label, v in variables.items()},
         split_chunks={name: len(ids) for name, ids in ds.manifest.chunks.items()},
+        drawable_samples=drawable_samples(ds.geometries, ds.manifest),
         shuffle_quality=quality,
     )
 
@@ -523,7 +564,10 @@ def print_summary(report: DatasetReport, file: TextIO | None = None) -> None:
         f"   shuffle pool {cfg['block_chunks'] * spc} samples"
         f" for a {cfg['batch_size']}-sample batch"
     )
-    splits = "  ".join(f"{k} {n}" for k, n in cfg["split_chunks"].items())
+    splits = "  ".join(
+        f"{k} {n}" + (f" ({cfg['drawable_samples'][k]} drawable)" if cfg["windowed"] else "")
+        for k, n in cfg["split_chunks"].items()
+    )
     out.append(f"  splits (chunks)  {splits}")
     cache = cfg["cache_dir"] or "heap"
     # read-only is worth a line of its own: it changes what the run *does* (serves only what

--- a/tests/test_advection.py
+++ b/tests/test_advection.py
@@ -8,6 +8,8 @@ driven advection that windowed, multi-variable, no-reshard sampling makes availa
 
 from __future__ import annotations
 
+import re
+
 import numpy as np
 import pytest
 
@@ -108,3 +110,55 @@ def test_tf_beats_persistence(synth_store) -> None:
 
     model_rmse, persistence_rmse = train(_dataset(synth_store), epochs=8)
     assert model_rmse < persistence_rmse
+
+
+# -- a store too small to be scored is refused before it is trained on -------
+
+
+@pytest.mark.parametrize(
+    "n_steps,why",
+    [
+        (192, "the 10% split rounds to zero chunks"),
+        (256, "the split gets a chunk, but the horizon drops every anchor in it"),
+    ],
+    ids=["no-chunks", "no-drawable-anchors"],
+)
+def test_a_store_too_small_to_score_is_refused_at_setup(tmp_path, n_steps, why) -> None:
+    """Both ways a small store runs out of evaluation data, caught before training.
+
+    Neither is worth an epoch to discover: the run would train, validate, and only then
+    reach `evaluate` with nothing to score, having kept none of it. Both are decided by the
+    arguments, so both are answered from them.
+    """
+    url = f"file://{tmp_path}/small.zarr"
+    make_advection_store(url, n_steps=n_steps, size=16, seed=0)
+
+    with pytest.raises(ValueError, match="the val split has nothing to draw") as exc:
+        forecast_dataset(url, batch_size=8)
+
+    msg = str(exc.value)
+    assert f"{n_steps} samples" in msg, why
+    assert "Use at least" in msg, "naming the size that works is what makes it actionable"
+
+
+def test_the_size_the_refusal_names_actually_works(tmp_path) -> None:
+    """The control, and the one that keeps the advice honest.
+
+    A remedy nobody checked is how a clear error message becomes a second wrong turn. The
+    number is computed against the same split and window arithmetic the run uses, so this
+    pins that the two agree.
+    """
+    url = f"file://{tmp_path}/small.zarr"
+    make_advection_store(url, n_steps=192, size=16, seed=0)
+    with pytest.raises(ValueError) as exc:
+        forecast_dataset(url, batch_size=8)
+    named = int(re.search(r"Use at least (\d+) samples", str(exc.value)).group(1))
+
+    bigger = f"file://{tmp_path}/big.zarr"
+    make_advection_store(bigger, n_steps=named, size=16, seed=0)
+    ds = forecast_dataset(bigger, batch_size=8)
+    try:
+        ds.set_epoch(0)
+        assert sum(int(b.arrays["t2m"].shape[0]) for b in ds.val) > 0
+    finally:
+        ds.close()

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -458,3 +458,80 @@ def test_the_windowed_clamp_reaches_past_the_split_edges():
         )
 
     assert floor(far) > floor(near), "a wider reach touches more chunks and must be sized for"
+
+
+# -- a split that holds chunks and can still draw nothing --------------------
+
+
+def _windowed_report(write_zarr, *, n, spc, horizon, fractions=(0.8, 0.1, 0.1)):
+    url, _ = write_zarr(n=n, spc=spc, inner=(4, 4))
+    base = open_geometries(obstore_store(url))["t2m"]
+    geoms = {"now": base, "target": base.shift(horizon)}
+    ds = InSituDataset(
+        obstore_store(url),
+        split_by_chunk(base, fractions=fractions),
+        geometries=geoms,
+        batch_size=4,
+    )
+    try:
+        return ds.describe()
+    finally:
+        ds.close()
+
+
+def test_drawable_samples_counts_anchors_not_chunks(write_zarr) -> None:
+    """A windowed split can hold chunks and draw nothing, which chunk counts cannot show.
+
+    The target reads `anchor + horizon`, so anchors within `horizon` of the array's end are
+    dropped. A split lying entirely in that tail keeps its chunks and yields no batches --
+    the same symptom as a split that rounded to zero chunks, and a different cause.
+    """
+    report = _windowed_report(write_zarr, n=256, spc=48, horizon=24)
+    cfg = report["config"]
+
+    assert cfg["split_chunks"]["val"] == 1, "the split does have a chunk"
+    assert cfg["drawable_samples"]["val"] == 0, "and cannot draw a single anchor from it"
+    assert cfg["drawable_samples"]["train"] > 0
+
+
+def test_a_split_that_cannot_draw_is_a_warning(write_zarr) -> None:
+    report = _windowed_report(write_zarr, n=256, spc=48, horizon=24)
+
+    notes = [n for n in report["notes"] if n["code"] == "split-yields-nothing"]
+    assert [n["subject"] for n in notes] == ["val"]
+    assert notes[0]["severity"] == "warn"
+    assert "dropped by the window" in notes[0]["message"]
+
+
+def test_a_split_asked_to_be_empty_is_not_a_warning(write_zarr) -> None:
+    """The control: `fractions=(1.0, 0.0, 0.0)` is an ordinary request, not a finding.
+
+    Warning about it would fire on the most common configuration in the examples and teach
+    everyone to skip the notes section.
+    """
+    report = _windowed_report(write_zarr, n=256, spc=48, horizon=24, fractions=(1.0, 0.0, 0.0))
+
+    assert report["config"]["split_chunks"]["val"] == 0
+    assert not [n for n in report["notes"] if n["code"] == "split-yields-nothing"]
+
+
+def test_an_unwindowed_split_draws_every_sample_it_holds(write_zarr) -> None:
+    """The other control: with no window nothing is dropped, so chunks and anchors agree."""
+    url, _ = write_zarr(n=256, spc=48, inner=(4, 4))
+    base = open_geometries(obstore_store(url))["t2m"]
+    ds = InSituDataset(
+        obstore_store(url),
+        split_by_chunk(base, fractions=(0.8, 0.1, 0.1)),
+        geometries={"t2m": base},
+        batch_size=4,
+    )
+    try:
+        report = ds.describe()
+        cfg = report["config"]
+        assert not [n for n in report["notes"] if n["code"] == "split-yields-nothing"]
+    finally:
+        ds.close()
+
+    for name in cfg["split_chunks"]:
+        expected = sum(len(base.samples_in_chunk(c)) for c in ds.manifest.chunks[name])
+        assert cfg["drawable_samples"][name] == expected, name


### PR DESCRIPTION
## Summary

Closes #71.

`examples/advection` built its store, trained a full epoch, validated, and only then raised
from `evaluate` with nothing to score — discarding all of it to report a fact its arguments had
already fixed.

**The issue's premise was half right.** It said a 10% split rounds to zero chunks. Measuring
found two distinct causes with the same symptom:

| `--n-steps` | val chunks | drawable anchors | |
|---|---|---|---|
| 192 | **0** | 0 | the 10% split rounds away |
| 256 | 1 | **0** | the split is fine; the 24-step target drops every anchor in it |
| 288 | 1 | 8 | works |

At 256 nothing rounds to zero — the split lies entirely in the tail the window reaches past
(#25's silent edge-anchor drop). A chunk count cannot tell the two apart, which is why this
could not be fixed by counting chunks in the example.

## The diagnosis belongs in the engine

`describe()` now reports `drawable_samples` per split, and `print_summary()` shows it beside
the chunk count whenever the views are windowed:

```
splits (chunks)  train 5 (232 drawable)  val 1 (0 drawable)  test 0 (0 drawable)
```

A split holding chunks it cannot draw from is a `split-yields-nothing` warning naming the
offsets responsible. A split *asked* to be empty stays silent — warning on
`fractions=(1.0, 0.0, 0.0)` would fire on most of the examples and teach everyone to skip the
notes section.

The example reads those numbers rather than deriving its own, so there is one definition of
"can this split be drawn from".

## The advice is checked, not asserted

The refusal names the smallest sample-axis length that works, solved against the same
`split_by_chunk` and `drawable_samples` the run uses rather than quoted as a constant:

```
the val split has nothing to draw, so this run could train but never be scored. 256 samples
over chunks of 48 is 6 chunk(s); split (0.8, 0.1, 0.1) gives train=5 chunk(s)/232 drawable
samples, val=1 chunk(s)/0 drawable samples. A 24-step target also drops the last 24 anchors,
which can empty a split that did get chunks. Use at least 288 samples on the sample axis
(--n-steps for the synthetic store, --sample-range for a real one); you have 256.
```

`test_the_size_the_refusal_names_actually_works` builds a store at the named size and drains
its val split. A remedy nobody checked is how a clear error message becomes a second wrong
turn — and the number does adapt: `--sample-chunk 16` yields 128, which also works.

Corroboration worth noting: `tests/test_advection.py`'s fixture already used `n_steps=288`,
which is exactly what the solver returns for the defaults.

## For reviewers

The check runs after `InSituDataset` is constructed (it reads `describe()`) but before any
batch is drawn or any epoch trained — construction is pure geometry. It sits in
`forecast_dataset`, so every source path gets it, not just the synthetic one; for `wb2` and
`arraylake` the remedy is `--sample-range`, which the message says.

The controls are the interesting tests: an unwindowed run must have drawable == every sample
it holds, and a deliberately-empty split must produce no warning.

## Author attestation

- [x] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

Left unticked deliberately: it asserts that a human reviewed every change and verified the
claims above, which is yours to assert and not mine to assert on your behalf.

## Checklist

- [x] Tests added — 4 on the report and its notes, 3 on the example
- [x] `ruff check`, `ruff format --check`, `mypy`, `pytest -q` (662 passed) and
      `mkdocs build --strict` green locally
- [x] Docstrings for the new public surface (`drawable_samples`)
- [x] User-facing behaviour documented in `docs/tuning.md`
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] No load-bearing invariant is broken
