### PR TITLE
fix: end a chunk's admission run at a block boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- **A released spill could unpin a chunk out from under the block that still needed it (#79).**
+  The driver decides admission once per *run* of tiles naming one chunk, since reads are
+  chunk-major. Under release-and-re-read the plan emits a chunk once per block that reads it --
+  and when a chunk is the last read of one block and the first of the next, those two emissions
+  are adjacent and the run-detection merged them. One reference was taken where the consumer
+  would release two, so the first block's release dropped the refcount to zero and the second
+  block's wait could never be satisfied. It presented as `read-ahead permits exhausted`, because
+  the block that never drained never handed its permits back.
+
+  It needed a lead landing exactly on the next block's opening chunk, so it was narrow but not
+  rare: 4 of 96 cells in a residency matrix over GCS, including a single-iteration one. The plan
+  now returns the read-index where each block begins, and crossing one ends the current run
+  whatever chunk it names -- the boundaries come from whoever laid them down rather than being
+  inferred from the reads, which is not possible here: two adjacent runs of one chunk are
+  indistinguishable from one.
+
 - **A windowed split could hold chunks and draw nothing, and only an empty iterator said so.**
   A windowed view reads `anchor + offset`, so anchors whose window runs off the array are
   dropped; a split lying entirely in that tail keeps its chunks and yields no batches. That is

--- a/src/insitubatch/plan.py
+++ b/src/insitubatch/plan.py
@@ -11,10 +11,27 @@ gather straight from those tiles by ``(chunk_id, within)`` draw rows.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 import numpy as np
 
 from .types import ArrayGeometry, StoredChunkRead
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkReadPlan:
+    """What to fetch, in order, and where each shuffle-block's reads begin.
+
+    ``block_starts`` is empty when the reads are deduplicated over the whole pass; with
+    ``groups`` it holds one index per block. A driver that admits per chunk-run needs these
+    to know where one block's claims end and the next one's begin.
+    """
+
+    reads: list[StoredChunkRead]
+    block_starts: list[int]
+
+    def __len__(self) -> int:
+        return len(self.reads)
 
 
 def build_stored_chunk_reads(
@@ -23,7 +40,7 @@ def build_stored_chunk_reads(
     ref_spc: int,
     *,
     groups: Sequence[int] | None = None,
-) -> list[StoredChunkRead]:
+) -> ChunkReadPlan:
     """Expand outer chunk ids into deduped stored-chunk reads, in priority order.
 
     There is no gather map: the scheduler delivers tiles into per-outer-chunk slots
@@ -50,16 +67,25 @@ def build_stored_chunk_reads(
     anchor chunk expands to the (offset-shifted) chunks each variable needs. With every
     ``offset == 0`` and a uniform chunk size this is exactly ``anchor chunk -> itself``.
     ``groups`` scopes that dedup to consecutive runs of ``chunk_ids`` -- the consumer's
-    shuffle-blocks -- rather than the whole pass. A chunk that two blocks read is then
-    admitted once *per block*, which is what lets the consumer release it when its block
-    drains and have it re-admitted later; the pool serves that second admission from
-    residency or from ``cache_dir``, and re-reads it only if neither holds it.
+    shuffle-blocks -- rather than the whole pass, and the returned ``block_starts`` say
+    where each block's reads begin. A chunk that two blocks read is then admitted once *per
+    block*, which is what lets the consumer release it when its block drains and have it
+    re-admitted later; the pool serves that second admission from residency or from
+    ``cache_dir``, and re-reads it only if neither holds it.
 
     Per block rather than per anchor, deliberately: the consumer releases each of a block's
     keys once, so admitting a key twice inside one block would leave a reference nobody
     returns -- and a slot pinned forever is a starved pass, not a slow one.
+
+    The boundaries are returned rather than left to be recovered from the reads, because
+    they cannot be: the driver decides admission once per *run* of tiles belonging to one
+    chunk, and a chunk that ends one block and opens the next produces two adjacent runs
+    that are indistinguishable from one. Merging them takes a single reference where the
+    consumer will release two, and the first release unpins the chunk out from under the
+    second block.
     """
     reads: list[StoredChunkRead] = []
+    block_starts: list[int] = []
     seen: set[StoredChunkRead] = set()
     boundaries: set[int] = set()
     if groups:
@@ -70,6 +96,7 @@ def build_stored_chunk_reads(
     for i, cid in enumerate(chunk_ids):
         if i in boundaries:
             seen.clear()  # a new block admits what it reads
+            block_starts.append(len(reads))
         for geom in geometries.values():
             for read_cid in _read_chunks(geom, int(cid), ref_spc):
                 for inner in geom.inner_coords():
@@ -77,7 +104,7 @@ def build_stored_chunk_reads(
                     if read not in seen:
                         seen.add(read)
                         reads.append(read)
-    return reads
+    return ChunkReadPlan(reads, block_starts)
 
 
 def _read_chunks(geom: ArrayGeometry, anchor_chunk: int, ref_spc: int) -> range:

--- a/src/insitubatch/scheduler.py
+++ b/src/insitubatch/scheduler.py
@@ -73,7 +73,7 @@ from zarr.core.buffer import default_buffer_prototype
 from zarr.core.chunk_utils import ChunkTransform
 from zarr.core.sync import _get_loop
 
-from .plan import build_stored_chunk_reads
+from .plan import ChunkReadPlan, build_stored_chunk_reads
 from .pool import ChunkPool
 from .runtime import StatsCollector
 from .store import _storage_chunks
@@ -448,8 +448,8 @@ class Scheduler:
         Returns the driver future; a failure there poisons the pool so consumers
         re-raise. The consumer drives demand independently via :attr:`pool`.
         """
-        reads = build_stored_chunk_reads(chunk_ids, self._geometries, ref_spc, groups=groups)
-        fut = asyncio.run_coroutine_threadsafe(self._drive(reads), self._loop)
+        plan = build_stored_chunk_reads(chunk_ids, self._geometries, ref_spc, groups=groups)
+        fut = asyncio.run_coroutine_threadsafe(self._drive(plan), self._loop)
         fut.add_done_callback(self._on_drive_done)
         return fut
 
@@ -483,7 +483,7 @@ class Scheduler:
 
     # -- async internals ----------------------------------------------------
 
-    async def _drive(self, reads: list[StoredChunkRead]) -> None:
+    async def _drive(self, plan: ChunkReadPlan) -> None:
         await self._ensure_arrays()
         # Per (path, chunk): decided[k] = True if it was a cache hit (skip its tiles),
         # False if a miss we admitted (fetch its tiles). reads are chunk-major so a
@@ -492,7 +492,11 @@ class Scheduler:
         # a not-ready (in-flight) slot is eviction-protected until its fetch completes.
         # Reads are chunk-major, so an admission decision is scoped to the run of tiles
         # belonging to one chunk. A released spill admits a chunk once per block that reads
-        # it, and each of those admissions is its own decision.
+        # it, and each of those admissions is its own decision -- including when the same
+        # chunk ends one block and opens the next, where the two runs are adjacent and
+        # otherwise indistinguishable from one. `block_starts` is where the plan says a
+        # block begins; crossing one ends the current run whatever chunk it names.
+        reads, block_starts = plan.reads, set(plan.block_starts)
         current: tuple[str, int] | None = None
         current_hit = False
         tasks: list[asyncio.Task] = []
@@ -500,8 +504,10 @@ class Scheduler:
         if me is not None:
             self._tasks.add(me)  # so _shutdown can cancel the driver itself
         try:
-            for read in reads:
+            for index, read in enumerate(reads):
                 key = (read.array, read.chunk_index)
+                if index in block_starts:
+                    current = None  # a new block claims what it reads, on its own reference
                 if key != current:
                     current = key
                     # One permit per chunk, taken before we reference it and

--- a/tests/test_block_structure.py
+++ b/tests/test_block_structure.py
@@ -151,10 +151,8 @@ class Pass:
 
     def declared(self, bi: int) -> set[Key]:
         """The slots the *driver* plans for block ``bi`` -- expanded from its chunk ids."""
-        reads = build_stored_chunk_reads(
-            self.blocks[bi].chunk_ids, self.ds.geometries, self.ref_spc
-        )
-        return {(r.array, r.chunk_index) for r in reads}
+        plan = build_stored_chunk_reads(self.blocks[bi].chunk_ids, self.ds.geometries, self.ref_spc)
+        return {(r.array, r.chunk_index) for r in plan.reads}
 
     def awaited(self, bi: int) -> set[Key]:
         """The slots the *consumer* pins and releases for block ``bi``."""
@@ -346,7 +344,7 @@ def test_every_drawn_chunk_is_planned_exactly_once(build_pass, case: Case) -> No
     assert len(ordered) == len(set(ordered)), "a chunk is planned by more than one block"
     planned = {
         (r.array, r.chunk_index)
-        for r in build_stored_chunk_reads(ordered, p.ds.geometries, p.ref_spc)
+        for r in build_stored_chunk_reads(ordered, p.ds.geometries, p.ref_spc).reads
     }
     assert _reference_read_keys(p.order.rows, p.ds.geometries, p.ref_spc) <= planned
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -75,7 +75,7 @@ def test_build_stored_chunk_reads_expands_and_dedups(tiled_store):
     url, _ = tiled_store
     geoms = open_geometries(obstore_store(url))
     ref_spc = geoms["spatial"].sample_chunk_size
-    reads = build_stored_chunk_reads([0, 1, 0], geoms, ref_spc)  # repeat 0 -> must dedup
+    reads = build_stored_chunk_reads([0, 1, 0], geoms, ref_spc).reads  # repeat 0 -> must dedup
 
     # spatial expands to its inner grid (3x2=6), single_inner to 1; x2 outer chunks.
     per_outer = sum(g.n_inner_chunks(0) for g in geoms.values())
@@ -99,7 +99,9 @@ def test_pool_aliased_labels_decode_once(tiled_store):
     base = open_geometries(obstore_store(url), variables=[array])[array]  # base.name == array
     geoms = {"now": base, "next": base}  # two labels, one underlying array
     tiles = asyncio.run(_decode_tiles(url, array))
-    reads = build_stored_chunk_reads(range(base.n_chunks), {array: base}, base.sample_chunk_size)
+    reads = build_stored_chunk_reads(
+        range(base.n_chunks), {array: base}, base.sample_chunk_size
+    ).reads
 
     pool = ChunkPool(geoms)
     owner = pool.new_owner()
@@ -127,7 +129,7 @@ def test_pool_scatter_reconstructs_array(tiled_store, var):
     geoms = open_geometries(obstore_store(url), variables=[var])
     geom = geoms[var]
     tiles = asyncio.run(_decode_tiles(url, var))
-    reads = build_stored_chunk_reads(range(geom.n_chunks), geoms, geom.sample_chunk_size)
+    reads = build_stored_chunk_reads(range(geom.n_chunks), geoms, geom.sample_chunk_size).reads
 
     pool = ChunkPool(geoms)
     owner = pool.new_owner()

--- a/tests/test_reread_spill.py
+++ b/tests/test_reread_spill.py
@@ -23,14 +23,18 @@ these tests pin that the number is reported.
 from __future__ import annotations
 
 import logging
+import tempfile
 
 import numpy as np
 import pytest
 
 from insitubatch import obstore_store, open_geometries, split_by_chunk
+from insitubatch.plan import build_stored_chunk_reads
 from insitubatch.source import InSituDataset
+from insitubatch.types import SplitName
 
 N, SPC = 256, 4
+_TMP = tempfile.mkdtemp()
 
 
 @pytest.fixture
@@ -232,3 +236,94 @@ def test_a_pass_does_not_skip_a_fetch_on_another_passs_writer(write_zarr) -> Non
         "a pool-wide 'a writer holds this' query cannot answer 'will it be delivered' -- "
         "the writer may belong to a pass that is being torn down"
     )
+
+
+# -- a block boundary is an admission boundary -------------------------------
+
+
+def test_a_chunk_ending_one_block_and_starting_the_next_is_admitted_twice(
+    write_zarr, tmp_path
+) -> None:
+    """The driver's per-chunk admission must not merge across a block boundary.
+
+    Reads are chunk-major, so `_drive` decides admission once per run of tiles belonging to
+    one chunk. Under a released spill the plan deliberately emits a chunk once per block that
+    reads it -- and when a chunk is the *last* read of one block and the *first* of the next,
+    those two emissions are adjacent. Merged, they take one permit and one reference where the
+    consumer will release two: the first block's release unpins the chunk out from under the
+    second, whose wait can then never be satisfied.
+
+    The geometry is the one that produces the collision: a lead of exactly three chunks with
+    two-chunk blocks, so a block's spill lands on the chunk the next block opens with. Counted
+    from the plan rather than driven, so it does not depend on how the threads interleave.
+    """
+    url, _ = write_zarr(n=800, spc=8, inner=(4, 4))
+    base = open_geometries(obstore_store(url))["t2m"]
+    manifest = split_by_chunk(base, fractions=(0.8, 0.1, 0.1))
+    ds = InSituDataset(
+        obstore_store(url),
+        manifest,
+        geometries={"now": base, "next": base.shift(24)},
+        batch_size=16,
+        block_chunks=2,
+        shuffle=True,
+        seed=0,
+        cache_dir=str(tmp_path / "c"),
+        persist=True,
+    )
+    try:
+        assert ds.reread_spill, "the fixture must be the released-spill case"
+        ds.set_epoch(0)
+        spc = ds._ref_spc
+        blocks = ds._blocks(ds._draw_order(SplitName.TRAIN, True), spc)
+        plan = build_stored_chunk_reads(
+            [int(c) for b in blocks for c in b.chunk_ids],
+            ds.geometries,
+            spc,
+            groups=[len(b.chunk_ids) for b in blocks],
+        )
+        # Count admissions the way `_drive` does: one per run of tiles naming the same
+        # chunk, with a run ended by a block boundary whatever chunk it names.
+        starts, runs, prev = set(plan.block_starts), 0, None
+        for index, r in enumerate(plan.reads):
+            key = (r.array, r.chunk_index)
+            if index in starts:
+                prev = None
+            if key != prev:
+                runs += 1
+                prev = key
+        owed = sum(len(b.read_keys) for b in blocks)
+        assert runs == owed, (
+            f"the driver sees {runs} chunk-runs but the consumer releases {owed} keys: "
+            f"{owed - runs} admission(s) merged across a block boundary"
+        )
+    finally:
+        ds.close()
+
+
+def test_a_lead_landing_on_the_next_blocks_first_chunk_still_drains(write_zarr, tmp_path) -> None:
+    """The same geometry, end to end: it must deliver every sample rather than wedge.
+
+    Reported rather than hung (the fetch-ahead wait is bounded), but a run that stops is a
+    run that stops.
+    """
+    url, _ = write_zarr(n=800, spc=8, inner=(4, 4))
+    base = open_geometries(obstore_store(url))["t2m"]
+    manifest = split_by_chunk(base, fractions=(0.8, 0.1, 0.1))
+    ds = InSituDataset(
+        obstore_store(url),
+        manifest,
+        geometries={"now": base, "next": base.shift(24)},
+        batch_size=16,
+        block_chunks=2,
+        shuffle=True,
+        seed=0,
+        cache_dir=str(tmp_path / "c"),
+        persist=True,
+    )
+    try:
+        ds.set_epoch(0)
+        drawn = sum(int(b.arrays["now"].shape[0]) for b in ds.train)
+        assert drawn == 640
+    finally:
+        ds.close()

--- a/tests/test_zarr_indexing_parity.py
+++ b/tests/test_zarr_indexing_parity.py
@@ -156,7 +156,7 @@ def test_planner_matches_zarr_indexing_per_anchor(geom: ArrayGeometry, ref_spc: 
 def test_build_stored_chunk_reads_matches_zarr_indexing(geom: ArrayGeometry, ref_spc: int) -> None:
     """The full planner entry point resolves the same stored-chunk set over all anchors."""
     anchors = list(range(_n_ref_chunks(geom, ref_spc)))
-    got = {r.coords for r in build_stored_chunk_reads(anchors, {geom.path: geom}, ref_spc)}
+    got = {r.coords for r in build_stored_chunk_reads(anchors, {geom.path: geom}, ref_spc).reads}
     expected: set[tuple[int, ...]] = set()
     for anchor in anchors:
         expected |= _planner_chunk_coords(geom, anchor, ref_spc)
@@ -200,7 +200,7 @@ def test_scattered_sample_read_amplification() -> None:
     # ...but the cost is IO, not indices: serving those picks reads every touched
     # chunk whole -- a strict superset of the samples actually wanted.
     geom = ArrayGeometry("a", (n, inner), (spc, inner), f4)
-    reads = build_stored_chunk_reads(sorted(touched), {geom.path: geom}, spc)
+    reads = build_stored_chunk_reads(sorted(touched), {geom.path: geom}, spc).reads
     read_samples: set[int] = set()
     for r in reads:
         read_samples |= set(geom.samples_in_chunk(r.chunk_index))


### PR DESCRIPTION
## Summary

Closes #79. Found by re-running the residency matrix on main after #73 landed.

The driver decides admission once per *run* of tiles naming one chunk — reads are chunk-major,
so that is normally exactly right. Under release-and-re-read the plan deliberately emits a chunk
**once per block that reads it**, and when a chunk is the last read of one block and the first
of the next, those two emissions are adjacent. Run-detection merged them.

One reference taken, two releases owed. The first block's release dropped the refcount to zero
and the second block's wait could never be satisfied:

```
take-permit
pin_if_ready False   refs={}
try_admit    True    refs={1: 1}     <- admitted ONCE, for block 9
FETCH spawned x2
deliver x2
unpin_one            refs now={}     <- block 9 releases it
consumer-wait ENTER  refs={}         <- block 10 waits on it, forever
```

It surfaced as `read-ahead permits exhausted`, because the block that never drained never handed
its permits back — which is why raising the bound, the budget, or both changed nothing.

## Ruled out first, by experiment

* the duplicate-fetch skip (`key in self._fetching`) — disabling it reproduces identically
* the budget — `4x` the floor, or an explicit 48 chunks, still fails
* the bound — `read_ahead_chunks=40` still fails
* plan/consumer divergence (#68) — the sets are exactly equal for this geometry
* the consumer over-holding — replaying its frontiers, it peaks at 4 against a bound of 12

Then counted it directly: **158 reads, 157 chunk-runs, 158 keys the consumer releases — one
admission missing.**

## The fix

`build_stored_chunk_reads` returns a `ChunkReadPlan`: the reads, plus the read-index where each
block begins. `_drive` ends the current run when it crosses one, whatever chunk it names.

The boundaries come from the code that laid them down rather than being recovered from the
reads — for the same reason as #68, and it is not a stylistic preference here: two adjacent runs
of one chunk are *indistinguishable* from one run, so there is nothing to recover them from.

## Verification

* the offset x `block_chunks` sweep that isolated it (`spc=8`, leads reaching 1–5 chunks,
  `block_chunks` 2/3/4/6) — **20/20 clean**, was 1 failure
* all **4** previously-failing cells of the 96-cell GCS matrix now drain
* full suite 658 passed, mypy and ruff clean

Two tests: one counts admissions against what the consumer will release, from the plan alone, so
it does not depend on thread interleaving; the other drains the reproducing geometry end to end.
Both fail on `main`.

## For reviewers

The `ChunkReadPlan` return type touches the call sites in `tests/test_pool.py`,
`tests/test_zarr_indexing_parity.py` and `tests/test_block_structure.py` — all mechanical
(`.reads`). I did not give it an `__iter__`, which would have avoided that churn, because a
plan that is both a sequence and a record of its own boundaries is two ways to use one object.

## Author attestation

- [x] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

Left unticked deliberately: it asserts that a human reviewed every change and verified the
claims above, which is yours to assert and not mine to assert on your behalf.

## Checklist

- [x] Tests added — a counted test and an end-to-end one, both failing on `main`
- [x] `ruff check`, `ruff format --check`, `mypy`, `pytest -q` (658 passed) green locally
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] No load-bearing invariant is broken
- [ ] Touches the scheduler → 3.13t run passes (CI)
