### PR TITLE
fix: a pass reports its own counters, not the pool's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- **A pass's report described the pool, not the pass (#81).** Every counter behind `PassStats`
+  and the per-epoch line -- hits, misses, residency peak, re-reads, evictions -- lived on the
+  `ChunkPool`, which several iterations hold at once, and `reset_epoch_counters()` ran at each
+  pass's *start*. So with `zip(ds.train, ds.val)` the second pass zeroed the first's totals
+  mid-flight and then reported the union under its own split's name: a `val` pass whose true
+  residency peak is 4 reported 35, and a `train` split that misses 102 chunks alone reported 29.
+  Those are the numbers someone sizing a budget acts on.
+
+  Each iteration now carries its own `PassCounters`, minted with its owner and dropped with it,
+  and the report reads those. The pool keeps its totals -- a genuinely different question, and
+  the only one an eviction or a peak co-residency belongs to -- but they are cumulative now
+  rather than reset by whichever pass started last.
+
 - **A released spill could unpin a chunk out from under the block that still needed it (#79).**
   The driver decides admission once per *run* of tiles naming one chunk, since reads are
   chunk-major. Under release-and-re-read the plan emits a chunk once per block that reads it --

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -464,15 +464,14 @@ class _TileWrite:
 
 @dataclass(slots=True)
 class PassCounters:
-    """One iteration's own view of the pool, so a report is about the pass that made it.
+    """One iteration's own view of the pool: what *this* pass hit, missed, held and evicted.
 
-    The pool's totals answer a different question -- what the *pool* did, across every
-    iteration sharing it -- and both are worth having. What is not worth having is one
-    labelled as the other: with two iterations live, pool totals attributed to a split are
-    the union of both passes' work under one pass's name (#81).
+    Minted with an owner and dropped with it, so the figures a pass reports are the figures it
+    made. The pool's totals answer the neighbouring question -- what the pool did, across every
+    iteration sharing it -- and both are worth having under their own names.
 
-    ``max_resident`` here is how many chunks this owner held at once, not how many the pool
-    did. Those differ precisely when it matters.
+    ``max_resident`` is how many chunks this owner held at once, not how many the pool did.
+    Several iterations share a pool, so those differ exactly when there is more than one.
     """
 
     hits: int = 0
@@ -1363,12 +1362,10 @@ class ChunkPool:
     def reset_epoch_counters(self) -> None:
         """Zero the batch-buffer counters at a pass boundary.
 
-        The chunk counters are deliberately *not* reset: they are the pool's running
-        totals, and a pool is shared by every iteration open on it. Zeroing them at one
-        pass's start threw away what another pass had accumulated, which is how a pass came
-        to report a number belonging to neither (#81). A pass's own figures come from its
-        :class:`PassCounters`, minted with its owner and dropped with it; these are the
-        pool's, and they only mean anything cumulatively.
+        The chunk counters are deliberately *not* reset here: they are the pool's running
+        totals, and a pool is shared by every iteration open on it, so they mean something
+        only cumulatively. A pass's own figures come from its :class:`PassCounters`, minted
+        with its owner and dropped with it.
 
         ``manifest_entries`` is load-time state and deliberately survives.
         """

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -77,7 +77,7 @@ import threading
 import time
 from collections import OrderedDict
 from collections.abc import Collection, Iterator, Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from pathlib import Path
 from typing import cast
@@ -462,6 +462,36 @@ class _TileWrite:
         self.pool._advance(self.array, self.chunk_index)
 
 
+@dataclass(slots=True)
+class PassCounters:
+    """One iteration's own view of the pool, so a report is about the pass that made it.
+
+    The pool's totals answer a different question -- what the *pool* did, across every
+    iteration sharing it -- and both are worth having. What is not worth having is one
+    labelled as the other: with two iterations live, pool totals attributed to a split are
+    the union of both passes' work under one pass's name (#81).
+
+    ``max_resident`` here is how many chunks this owner held at once, not how many the pool
+    did. Those differ precisely when it matters.
+    """
+
+    hits: int = 0
+    misses: int = 0
+    rereads: int = 0
+    evictions: int = 0
+    revive_mismatch: int = 0
+    revive_missing: int = 0
+    resident: int = 0  # live count of chunks this owner references
+    resident_bytes: int = 0
+    max_resident: int = 0
+    max_resident_bytes: int = 0
+    seen: set[tuple[str, int]] = field(default_factory=set)
+
+    def _note_resident(self) -> None:
+        self.max_resident = max(self.max_resident, self.resident)
+        self.max_resident_bytes = max(self.max_resident_bytes, self.resident_bytes)
+
+
 class ChunkPool:
     """Byte-budgeted pool of outer-chunk slots, keyed ``(array, chunk_index)``.
 
@@ -602,7 +632,6 @@ class ChunkPool:
         self.revive_missing = 0  # persisted entry whose .npy was unreadable/gone
         self.evictions = 0  # ready slots dropped to make room -- the cost side of a small budget
         self.rereads = 0  # chunks admitted again in the same pass after being released
-        self._seen_this_pass: set[tuple[str, int]] = set()  # for rereads; cleared per pass
         self.manifest_entries = 0
         # Cross-run persistence: keep slot files past close, write a manifest of completed
         # entries, and revive them on reopen. Requires a dir to keep the files in. The dir
@@ -687,6 +716,9 @@ class ChunkPool:
         # that starves before it can pin anything is exactly the case the starvation
         # diagnostic has to name, and counting pin-holders would miss it.
         self._owners: set[int] = set()
+        # Per-iteration counters, minted with the owner and dropped with it. A pass reads
+        # its own before teardown; nothing else may.
+        self._per_owner: dict[int, PassCounters] = {}
         self._cv = threading.Condition(threading.Lock())
         self._error: BaseException | None = None  # global poison (driver death)
         self.max_resident = 0  # peak distinct outer chunk positions held at once
@@ -882,7 +914,15 @@ class ChunkPool:
             self._refuse_if_budget_cannot_hold(len(self._owners) + 1)
             self._owner_seq += 1
             self._owners.add(self._owner_seq)
+            self._per_owner[self._owner_seq] = PassCounters()
             return self._owner_seq
+
+    def counters(self, owner: int) -> PassCounters:
+        """This owner's counters. Read before its :meth:`release_owner`, which drops them."""
+        return self._per_owner.get(owner, PassCounters())
+
+    def _count(self, owner: int) -> PassCounters:  # call under the lock
+        return self._per_owner.setdefault(owner, PassCounters())
 
     def _refuse_if_budget_cannot_hold(self, iterations: int) -> None:  # call under the lock
         """Raise when the budget cannot hold ``iterations`` working sets at once.
@@ -1023,7 +1063,7 @@ class ChunkPool:
 
     # -- admission / pinning / eviction -------------------------------------
 
-    def _note_touch(self, key: tuple[str, int]) -> None:  # call under the lock
+    def _note_touch(self, key: tuple[str, int], owner: int) -> None:  # call under the lock
         """Count a chunk this pass has already taken once as a re-read.
 
         Called from every path that *takes* a chunk for this pass -- "already resident",
@@ -1035,10 +1075,12 @@ class ChunkPool:
         spill it is the number a reader needs to judge the trade: a re-read of a persisted
         slot is a local read of decoded bytes; one that is not is a refetch.
         """
-        if key in self._seen_this_pass:
+        counters = self._count(owner)
+        if key in counters.seen:
             self.rereads += 1
+            counters.rereads += 1
         else:
-            self._seen_this_pass.add(key)
+            counters.seen.add(key)
 
     def try_admit(self, array: str, chunk_index: int, owner: int) -> bool:
         """Reserve + allocate + reference one outer-chunk slot, evicting ready-LRU for room.
@@ -1076,7 +1118,7 @@ class ChunkPool:
                 # Already resident (in-flight, or a ready cross-epoch hit) -> incref and
                 # reuse. A FAILED slot is NOT reusable: it quiesces and is dropped, so a
                 # later epoch refetches instead of re-raising a stale error forever.
-                self._note_touch(key)
+                self._note_touch(key, owner)
                 self._pin(key, owner)  # the pin IS this owner's claim (see wait_ready)
                 self._cv.notify_all()  # a ready hit may now satisfy a waiter
                 return True
@@ -1084,16 +1126,18 @@ class ChunkPool:
                 # A read-only opener never allocates: the cache is its whole supply. A miss
                 # is the `readonly_cache` contract turning out to be false, so say so --
                 # raising is what makes it a contract rather than a silent slow path.
-                if not self._revive(key):
+                if not self._revive(key, owner):
                     raise self._readonly_miss(array, chunk_index)
                 self.hits += 1  # revived from disk -> no fetch (as in pin_if_ready)
-                self._note_touch(key)
+                self._count(owner).hits += 1
+                self._note_touch(key, owner)
                 self._pin(key, owner)
                 self._cv.notify_all()
                 return True
-            if not self._make_room(nbytes):
+            if not self._make_room(nbytes, owner):
                 return False
             self.misses += 1  # a fresh slot allocated to fetch -> a cache miss
+            self._count(owner).misses += 1
             scratch = (
                 np.empty(src.slot_shape(chunk_index), dtype=src.dtype)
                 if self._reshapes[array]
@@ -1118,7 +1162,13 @@ class ChunkPool:
                 scratch=scratch,
             )
             self._bytes += nbytes
-            self._note_touch(key)
+            # A consumer may have pinned this key before it was allocated (`pin_keys`), and
+            # charged 0 bytes for it then. Now that the slot exists, charge every holder.
+            for held_by in self._pinned.get(key, {}):
+                held = self._count(held_by)
+                held.resident_bytes += nbytes
+                held._note_resident()
+            self._note_touch(key, owner)
             self._pin(key, owner)
             self.max_resident = max(self.max_resident, len(self._positions()))
             self.max_resident_bytes = max(self.max_resident_bytes, self._bytes)
@@ -1144,15 +1194,18 @@ class ChunkPool:
         with self._cv:
             key = (array, chunk_index)
             slot = self._slots.get(key)
-            if not (slot is not None and slot.state is SlotState.READY) and not self._revive(key):
+            if not (slot is not None and slot.state is SlotState.READY) and not self._revive(
+                key, owner
+            ):
                 return False
             self.hits += 1  # resident (cross-epoch) or revived (cross-run) -> no fetch
-            self._note_touch(key)
+            self._count(owner).hits += 1
+            self._note_touch(key, owner)
             self._pin(key, owner)  # the pin IS this owner's claim; publish it
             self._cv.notify_all()
             return True
 
-    def _revive(self, key: tuple[str, int]) -> bool:  # call under the lock
+    def _revive(self, key: tuple[str, int], owner: int) -> bool:  # call under the lock
         """Bring a persisted on-disk chunk back as a ready slot (a cross-run hit).
 
         Returns ``True`` iff the slot is now resident + ready. Validates the stored
@@ -1174,6 +1227,7 @@ class ChunkPool:
             data = np.lib.format.open_memmap(self._dir / fname, mode="r")
         except (OSError, ValueError) as exc:
             self.revive_missing += 1
+            self._count(owner).revive_missing += 1
             logger.debug("cache: persisted %s unreadable (%s); refetching", key, exc)
             self._persisted.pop(key, None)
             return False
@@ -1182,6 +1236,7 @@ class ChunkPool:
         want_dtype = geom.dtype if geom is not None else None
         if geom is None or data.shape != want_shape or data.dtype != want_dtype:
             self.revive_mismatch += 1
+            self._count(owner).revive_mismatch += 1
             logger.debug(
                 "cache: persisted %s shape/dtype %s/%s != current %s/%s; refetching",
                 key,
@@ -1194,7 +1249,7 @@ class ChunkPool:
             self._persisted.pop(key, None)
             return False
         nbytes = int(data.nbytes)
-        if not self._make_room(nbytes):
+        if not self._make_room(nbytes, owner):
             del data
             return False
         # A revived chunk enters the SAME lifecycle at a later state rather than being a
@@ -1297,28 +1352,37 @@ class ChunkPool:
             ]:
                 self._drop(key)  # an abandoned partial can never be a valid cache entry
             self._owners.discard(owner)  # this iteration is done; it no longer counts
+            self._per_owner.pop(owner, None)
             self._cv.notify_all()  # freed budget may unpark an admission
 
     def reset_epoch_counters(self) -> None:
-        """Zero the per-epoch observability counters at a pass boundary.
+        """Zero the batch-buffer counters at a pass boundary.
 
-        Split out of the old ``unpin_all``: releasing references and resetting counters
-        are unrelated jobs on different clocks (one belongs to an iteration's teardown,
-        the other to a pass's start), and bundling them is why the reset used to force a
-        global unpin. ``manifest_entries`` is load-time state and deliberately survives.
+        The chunk counters are deliberately *not* reset: they are the pool's running
+        totals, and a pool is shared by every iteration open on it. Zeroing them at one
+        pass's start threw away what another pass had accumulated, which is how a pass came
+        to report a number belonging to neither (#81). A pass's own figures come from its
+        :class:`PassCounters`, minted with its owner and dropped with it; these are the
+        pool's, and they only mean anything cumulatively.
+
+        ``manifest_entries`` is load-time state and deliberately survives.
         """
         with self._cv:
-            self.hits = self.misses = 0
-            self.max_resident = self.max_resident_bytes = 0  # peaks are per-pass too
-            self.revive_mismatch = self.revive_missing = 0
-            self.evictions = self.rereads = 0
-            self._seen_this_pass.clear()
-            self._buffers.reset_counters()  # batch outputs too -- same epoch boundary
+            self._buffers.reset_counters()
 
     def _pin(self, key: tuple[str, int], owner: int) -> None:  # call under the lock
         owners = self._pinned.setdefault(key, {})
+        first = owners.get(owner, 0) == 0
         owners[owner] = owners.get(owner, 0) + 1
-        if key in self._slots:
+        slot = self._slots.get(key)
+        if first:
+            # This owner's residency, which is what its own report is about. A second
+            # reference to a chunk it already holds costs it nothing more.
+            counters = self._count(owner)
+            counters.resident += 1
+            counters.resident_bytes += slot.nbytes if slot is not None else 0
+            counters._note_resident()
+        if slot is not None:
             self._slots.move_to_end(key)  # MRU (the slot may not be allocated yet)
 
     def _unpin_one(self, key: tuple[str, int], owner: int) -> None:  # call under the lock
@@ -1328,12 +1392,17 @@ class ChunkPool:
         n = owners.get(owner, 0)
         if n <= 1:
             owners.pop(owner, None)
+            if n == 1:
+                slot = self._slots.get(key)
+                counters = self._count(owner)
+                counters.resident -= 1
+                counters.resident_bytes -= slot.nbytes if slot is not None else 0
         else:
             owners[owner] = n - 1
         if not owners:
             self._pinned.pop(key, None)
 
-    def _make_room(self, nbytes: int) -> bool:  # call under the lock
+    def _make_room(self, nbytes: int, owner: int) -> bool:  # call under the lock
         if self._budget is None:
             return True
         while self._bytes + nbytes > self._budget:
@@ -1343,6 +1412,7 @@ class ChunkPool:
             if victim is None:  # everything resident is in-flight or pinned -> no room
                 return False
             self.evictions += 1
+            self._count(owner).evictions += 1
             self._drop(victim)
         return True
 

--- a/src/insitubatch/pool.py
+++ b/src/insitubatch/pool.py
@@ -485,6 +485,11 @@ class PassCounters:
     resident_bytes: int = 0
     max_resident: int = 0
     max_resident_bytes: int = 0
+    # Chunks this pass has taken once already, so a second take is a re-read. Per chunk and
+    # per live iteration -- the most expensive structure here, for a statistic (#82). It is
+    # derivable rather than discoverable: under a released spill a chunk is admitted once per
+    # block that reads it, so re-reads over the drained blocks are the sum of the block key
+    # counts less the size of their union, both of which the plan already holds.
     seen: set[tuple[str, int]] = field(default_factory=set)
 
     def _note_resident(self) -> None:

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -633,9 +633,8 @@ class InSituDataset:
                             out_q.get(timeout=0.05)
                     producer.join(timeout=10)  # publishes the producer's stage timers
                     pool = sched.pool
-                    # This pass's own counters, not the pool's: with a second iteration live
-                    # the pool's totals are both passes' work, and labelling them with one
-                    # split's name says something false about both (#81).
+                    # This pass's own counters. The pool's totals cover every iteration
+                    # sharing it, and this line names a single split.
                     mine = pool.counters(owner)
                     self.resident_peak = mine.max_resident  # peak residency this pass
                     self.cache_hits = mine.hits

--- a/src/insitubatch/source.py
+++ b/src/insitubatch/source.py
@@ -40,7 +40,7 @@ import numpy as np
 from zarr.abc.store import Store
 
 from .buffers import HostAllocator
-from .pool import ChunkPool, output_geometry, validate_scopes
+from .pool import ChunkPool, PassCounters, output_geometry, validate_scopes
 from .runtime import Depths, PassStats, StatsCollector, format_pass
 from .scheduler import Scheduler, SchedulerConfig
 from .shuffle import DrawOrder, block_shuffled_order, sequential_order
@@ -633,9 +633,13 @@ class InSituDataset:
                             out_q.get(timeout=0.05)
                     producer.join(timeout=10)  # publishes the producer's stage timers
                     pool = sched.pool
-                    self.resident_peak = pool.max_resident  # peak residency this epoch
-                    self.cache_hits = pool.hits
-                    self.cache_misses = pool.misses
+                    # This pass's own counters, not the pool's: with a second iteration live
+                    # the pool's totals are both passes' work, and labelling them with one
+                    # split's name says something false about both (#81).
+                    mine = pool.counters(owner)
+                    self.resident_peak = mine.max_resident  # peak residency this pass
+                    self.cache_hits = mine.hits
+                    self.cache_misses = mine.misses
                     self.bad_chunks = list(sched.bad_chunks)  # tiles NaN-filled this epoch
                     # Was unreachable before: it lives on the Scheduler, which is created inside
                     # this method and torn down with the pass, so unlike the three above nothing
@@ -651,24 +655,24 @@ class InSituDataset:
                         max_inflight=self.scheduler_config.max_inflight,
                         decode_queue_peak=stats.decode_queue_peak,
                         decode_threads=sched.decode_threads,
-                        resident_peak=pool.max_resident,
-                        resident_peak_bytes=pool.max_resident_bytes,
+                        resident_peak=mine.max_resident,
+                        resident_peak_bytes=mine.max_resident_bytes,
                         budget_bytes=pool.budget_bytes,
                     )
-                    self._log_epoch_summary(pool, split)
+                    self._log_epoch_summary(mine, pool, split)
                     # Persistence was asked for but served nothing, and the cache *was*
                     # consulted (entries existed and every revive failed) -> almost certainly
                     # a stale cache_dir or changed data/transforms. Loud once per epoch; a
                     # plain miss (no persisted entry for a chunk) is silent (normal).
-                    failed_revives = pool.revive_mismatch + pool.revive_missing
-                    if self._persist and pool.hits == 0 and failed_revives:
+                    failed_revives = mine.revive_mismatch + mine.revive_missing
+                    if self._persist and mine.hits == 0 and failed_revives:
                         logger.warning(
                             "persist=True but 0 of %d persisted chunks were served this epoch "
                             "(%d shape/dtype mismatches, %d missing/unreadable) -- stale cache_dir "
                             "or changed data/transforms?",
                             pool.manifest_entries,
-                            pool.revive_mismatch,
-                            pool.revive_missing,
+                            mine.revive_mismatch,
+                            mine.revive_missing,
                         )
         finally:
             # Drop this pass's references (and any partial its cancelled fetches
@@ -707,7 +711,9 @@ class InSituDataset:
                 logger.info("%s", format_pass(self.last_pass))
             self._pool.release_owner(owner)
 
-    def _log_epoch_summary(self, pool: ChunkPool, split: SplitName | None) -> None:
+    def _log_epoch_summary(
+        self, mine: PassCounters, pool: ChunkPool, split: SplitName | None
+    ) -> None:
         """One INFO line per epoch *per split*: what the chunk cache and the batch buffers did.
 
         Tagged with the split because a training run iterates more than one of them per epoch
@@ -728,23 +734,23 @@ class InSituDataset:
         """
         if not logger.isEnabledFor(logging.INFO):
             return  # skip the snapshot, which takes the buffer pool's lock
-        reads = pool.hits + pool.misses
+        reads = mine.hits + mine.misses
         # Re-reads and evictions appear whenever they are non-zero, not only under a released
         # spill: a chunk taken twice in one pass, or a ready slot dropped to make room, is the
         # budget being too small for the working set -- and a hit rate alone cannot show it,
         # because a re-read served from cache_dir counts as a hit.
         churn = ""
-        if pool.rereads or pool.evictions:
+        if mine.rereads or mine.evictions:
             why = " (spill released per block, revived from the cache)" if self.reread_spill else ""
-            churn = f", {pool.rereads} re-read{why}, {pool.evictions} evicted"
+            churn = f", {mine.rereads} re-read{why}, {mine.evictions} evicted"
         logger.info(
             "epoch %d (%s): chunks %d/%d hit (%.0f%%), peak resident %d%s%s; batch buffers %s",
             self._epoch,
             split or "all",
-            pool.hits,
+            mine.hits,
             reads,
-            100 * pool.hits / reads if reads else 0.0,
-            pool.max_resident,
+            100 * mine.hits / reads if reads else 0.0,
+            mine.max_resident,
             churn,
             f", {len(self.bad_chunks)} bad chunks" if self.bad_chunks else "",
             pool.buffer_stats().summary(),

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -8,6 +8,7 @@ assert "store-bound" is testing the fixture. The integration tests below check t
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import time
 from dataclasses import replace
@@ -529,3 +530,72 @@ def test_a_saturated_inflight_budget_says_the_store_may_be_the_floor():
     stage, why = bottleneck(stats)
     assert stage == "store"
     assert "the store or the network is the floor" in why
+
+
+# -- a pass's report is about that pass --------------------------------------
+
+
+def test_concurrent_passes_report_their_own_residency(write_zarr) -> None:
+    """Two iterations share a pool; neither may report the other's work as its own.
+
+    Every counter behind `PassStats` used to live on the `ChunkPool`, which several
+    iterations hold at once, and the reset that made them per-epoch ran at each pass's
+    *start* -- so the second pass zeroed the first's totals mid-flight and then reported the
+    union under its own split's name. Measured before the fix: a `val` pass whose true
+    residency peak is 4 reported 35, the pool's.
+
+    The interleaving is what makes it a shared pool, so the assertion is on attribution
+    rather than on an exact count: a pass can never hold more than it alone touched.
+    """
+    url, _ = write_zarr(n=512, spc=4, inner=(8, 8))
+    geometries = open_geometries(obstore_store(url))
+    manifest = split_by_chunk(geometries["t2m"], fractions=(0.8, 0.1, 0.1))
+
+    def solo(split: str) -> tuple[int, int]:
+        ds = InSituDataset(
+            obstore_store(url), manifest, geometries=geometries, batch_size=8, block_chunks=2
+        )
+        try:
+            ds.set_epoch(0)
+            for _batch in getattr(ds, split):
+                pass
+            assert ds.last_pass is not None
+            return ds.last_pass.cache_misses, ds.last_pass.depths.resident_peak
+        finally:
+            ds.close()
+
+    val_misses, val_peak = solo("val")
+
+    ds = InSituDataset(
+        obstore_store(url),
+        manifest,
+        geometries=geometries,
+        batch_size=8,
+        block_chunks=2,
+        cache_budget_bytes=200 * geometries["t2m"].chunk_bytes,
+    )
+    try:
+        ds.set_epoch(0)
+        train, val = iter(ds.train), iter(ds.val)
+        with contextlib.suppress(StopIteration):
+            while True:
+                next(train)
+                next(val)
+        train.close()
+        val.close()
+        assert ds.last_pass is not None
+        zipped = ds.last_pass
+        pool = ds._pool
+    finally:
+        ds.close()
+
+    assert zipped.depths.resident_peak <= max(val_peak, 4) * 2, (
+        f"a pass reporting {zipped.depths.resident_peak} where it alone holds ~{val_peak} is "
+        "reporting the pool"
+    )
+    assert zipped.depths.resident_peak < pool.max_resident, (
+        "with two passes live the pool holds more than either of them; a pass reporting the "
+        "pool's peak is the defect"
+    )
+    assert zipped.cache_misses <= pool.misses
+    assert val_misses > 0


### PR DESCRIPTION
## Summary

Closes #81.

`PassStats` and the per-epoch line read hits, misses, residency peaks, re-reads and evictions
off the `ChunkPool`. Several iterations hold one pool, and `reset_epoch_counters()` ran at each
pass's **start** — so the second pass zeroed the first's totals mid-flight and then reported the
union under its own split's name.

| | hits | misses | residency peak |
|---|---|---|---|
| `ds.train` alone | 0 | **102** | **4** |
| `ds.val` alone | 0 | 13 | 4 |
| zipped, reported as `split='train'` — **before** | 0 | **29** | **35** |
| zipped, each pass — **after** | 0 | val 13, train 22 | **4** and **4** |

After the fix the val pass reports exactly what it reports when run alone (13 chunks, peak 4),
and the train figure is its partial run — the zip ends when val is exhausted. The pool's own
peak for the same run is 37, which is the pool's answer to a different question.

## What changed

Each iteration carries a `PassCounters`, minted with its owner in `new_owner` and dropped in
`release_owner`; the report reads those. Residency is counted where a reference is taken and
dropped, so it measures what *that owner* held rather than what the pool did — including the
awkward case where a consumer pins a key before it is allocated, which now charges its bytes to
everyone already holding it once the slot exists.

The pool keeps its totals. Peak co-residency and evictions genuinely belong to the pool, and
losing them would be a different mistake. But they are **cumulative** now: resetting them at one
pass's start is what made them mean nothing, and nothing in the reporting path reads them any
more, so `reset_epoch_counters` is left holding only the batch-buffer reset.

`_seen_this_pass` is deleted as *pool-wide* state — it decided a per-pass statistic, so one
iteration's take made another's first take look like a re-read. It is **not** gone as a cost:
the same set now lives on each `PassCounters`, measured at the same 150 B/chunk, and there is
one per live iteration rather than one per pool. Correct now, and strictly more memory (see
"Known cost" below).

## Known cost, not fixed here

`PassCounters.seen` is 150 B/chunk **per live iteration** — the same per-chunk set as before,
replicated rather than removed. It exists only to decide whether a take is a re-read, and it is
the single most expensive structure per chunk in #82's tally for something that is purely a
statistic.

It is derivable rather than discoverable: under a released spill a chunk is admitted once per
block that reads it, so re-reads over the drained blocks are
`sum(|block.read_keys|) - |union of them|` — a property of the plan and how far the pass got,
computable from structures that already exist. That would take the set to a plain int. Left out
of this PR because it is a separate change to a separate question, and this one is about
attribution; raised so the trade is on the record rather than discovered later.

## For reviewers

The residency accounting is the part worth a second look: `_pin`/`_unpin_one` maintain a live
count and byte total per owner, and the peak is taken on every increase. The 0→1 transition is
what counts, so a second reference to a chunk an owner already holds costs it nothing more,
which is the intended reading of "what this pass held".

Not fixed here, and worth knowing: the **batch-buffer** counters in the same epoch line
(`N lent, M allocated`) have exactly this shape — `BatchBuffers` is shared and its stats are
reset per pass. Scoping those needs the owner threaded through `gather`, which is a wider change
than this one; I left it and would rather it were its own issue than a silent half-fix here.

## Author attestation

- [x] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

Left unticked deliberately: it asserts that a human reviewed every change and verified the
claims above, which is yours to assert and not mine to assert on your behalf.

## Checklist

- [x] Tests added — a concurrent-pass attribution test
- [x] `ruff check`, `ruff format --check`, `mypy`, `pytest -q` (659 passed) green locally
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] No load-bearing invariant is broken
- [ ] Touches `ChunkPool` → 3.13t run passes (CI)
