### PR TITLE
fix: place a JAX batch on JAX's default device, not the host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+- **A JAX run on a GPU box trained on the CPU, at exact values, with nothing raised.**
+  `to_jax` was `jnp.from_dlpack(array)`, which imports a *host* buffer and therefore commits
+  its result to `cpu:0` — and `jax.jit` does not move a committed array. So every JAX user
+  with a GPU got a pipeline that was correct, silent, and entirely on the wrong device;
+  measured on an L4, `to_jax` returned `cpu:0` with `jax.devices() == [CudaDevice(id=0)]`, and
+  `jit(x * 2)` on that array stayed on the CPU. Nothing in the docs said so, because the
+  adapter had no device story at all: `device=` exists on `as_torch`/`to_torch` only, and
+  `to_jax` took no such argument.
+
+  The batch is now placed on `jax.devices()[0]`, which is where every other jax
+  array-creation path puts one — `jnp.from_dlpack` was the anomaly, not the fix. Pass
+  `device=` to choose another. On a CPU-only build the put is a **pass-through that still
+  aliases** the exported buffer, so it costs nothing there, and the transfer needs no new
+  machinery on GPU: JAX keeps the source referenced across an async `device_put`, so the
+  pool's liveness poll already defers reclaim (DESIGN.md, "the pool is sound for every
+  adapter"). This does not make JAX own its transfer the way `to_torch(device=)` does —
+  JAX cannot consume pinned host memory ([jax#22346](https://github.com/jax-ml/jax/issues/22346))
+  and exposes no event to gate recycling on, so pinning stays torch-only.
+
+- **`--extra jax` on a CUDA box installed a JAX that could not see the GPU.** Bare
+  `jax>=0.4.30` resolves to the CPU wheel, so the one command a GPU user would run left them
+  on the CPU before `to_jax` was even reached. A new **`jax-cuda`** extra pins `jax[cuda12]`.
+  It is a separate extra rather than a change to `jax` so `--extra jax` stays resolvable on
+  any machine, which CI depends on; one framework per environment still applies.
+
 - **The batch-buffer figures in the epoch line were the pool's, printed under one split's name
   (#84).** One buffer pool serves every iteration open on a dataset, and its counters were reset
   at each pass's *start* -- so with `zip(ds.train, ds.val)` a pass that drew 7 batches reported

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -109,7 +109,8 @@ Extras, one at a time (see the framework caveat below):
 
 ```bash
 uv sync --extra torch      # torch handoff (frameworks.as_torch)
-uv sync --extra jax        # JAX handoff (frameworks.to_jax)
+uv sync --extra jax        # JAX handoff (frameworks.to_jax) -- CPU wheel
+uv sync --extra jax-cuda   # the same, on a CUDA box (jax[cuda12])
 uv sync --extra tf         # TF handoff (frameworks.as_tf_dataset)
 uv sync --extra bench      # benchmark suite (xbatcher baseline + plotly + py-spy)
 uv sync --extra docs       # MkDocs site

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,7 +124,8 @@ uv run python -m examples.wb2_dataloader \
 ```bash
 uv sync                  # core engine + dev tools
 uv sync --extra torch    # torch handoff (frameworks.as_torch)
-uv sync --extra jax      # JAX handoff (frameworks.to_jax)
+uv sync --extra jax      # JAX handoff (frameworks.to_jax) -- CPU wheel
+uv sync --extra jax-cuda # the same, on a CUDA box (jax[cuda12])
 uv sync --extra tf       # TF handoff (frameworks.as_tf_dataset)
 uv sync --extra bench    # benchmark suite (xbatcher baseline + plotly)
 uv sync --extra gpu      # CUDA box only: cupy + kvikio zero-copy path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,16 @@ jax = [
     "flax>=0.8",
     "optax>=0.2",
 ]
+# JAX on an NVIDIA GPU. Bare `jax` resolves to the *CPU* wheel, so `--extra jax` on a CUDA
+# box yields a JAX that cannot see the GPU at all -- silently, since nothing fails. This
+# pins the CUDA build instead; it is a separate extra rather than a change to `jax` so that
+# `--extra jax` stays resolvable everywhere, which CI depends on. One framework per
+# environment still applies.
+jax-cuda = [
+    "jax[cuda12]>=0.4.30",
+    "flax>=0.8",
+    "optax>=0.2",
+]
 tf = [
     "tensorflow>=2.16",
 ]

--- a/src/insitubatch/frameworks.py
+++ b/src/insitubatch/frameworks.py
@@ -244,19 +244,34 @@ def to_torch(batch: Batch, device: str | torch.device | None = None) -> dict[str
     return out
 
 
-def to_jax(batch: Batch) -> dict[str, Any]:
-    """Convert a numpy ``Batch`` to a dict of ``jax.Array`` (DLPack).
+def to_jax(batch: Batch, device: Any | None = None) -> dict[str, Any]:
+    """Convert a numpy ``Batch`` to a dict of ``jax.Array`` (DLPack), on JAX's default device.
 
     Zero-copy only when the batch buffer sits on a 128-byte boundary: XLA:CPU requires that
     alignment and silently falls back to a copy otherwise. numpy guarantees only 16, so with
     today's per-batch ``np.empty`` roughly half of batches are copied (measured 20/40 —
     ``bench/probe_batch_buffers.py --arms jax``). Correct either way, just not free.
+
+    ``jnp.from_dlpack`` imports a *host* buffer, so its result is committed to ``cpu:0`` --
+    and ``jax.jit`` does not move a committed array. Returning that directly meant a GPU run
+    trained on the CPU at full correctness with nothing raised to say so, so the batch is
+    placed on ``jax.devices()[0]`` here, which is where every other jax array-creation path
+    puts it. Pass ``device`` to choose another. On a CPU-only build the put is a
+    pass-through that still aliases the exported buffer, so it costs nothing there.
+
+    The transfer is asynchronous -- JAX documents it so -- but JAX keeps the source
+    *referenced* across it, so the pool's liveness poll cannot reclaim a buffer mid-DMA
+    (``bench/probe_batch_buffers.py --arms all`` is what keeps that honest; see DESIGN.md).
+    Unlike :func:`to_torch` this adapter does not *own* the transfer: JAX cannot consume
+    pinned host memory (jax#22346) and exposes no event to gate recycling on.
     """
     try:
+        import jax
         import jax.numpy as jnp
     except ImportError as exc:  # pragma: no cover - jax-less installs
         raise _missing("JAX", "jax") from exc
-    return {k: jnp.from_dlpack(v) for k, v in batch.arrays.items()}
+    target = jax.devices()[0] if device is None else device
+    return {k: jax.device_put(jnp.from_dlpack(v), target) for k, v in batch.arrays.items()}
 
 
 def to_tf(batch: Batch) -> dict[str, Any]:

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -31,3 +31,39 @@ def test_to_jax_roundtrip(write_zarr) -> None:
         seen.append(np.asarray(arrays["t2m"]))
 
     np.testing.assert_array_equal(np.concatenate(seen, axis=0), srcs["t2m"])
+
+
+def test_to_jax_lands_on_the_default_device(write_zarr) -> None:
+    """A batch must arrive where every other jax array-creation path puts one.
+
+    ``jnp.from_dlpack`` imports a host buffer and so commits the result to ``cpu:0``. Since
+    ``jax.jit`` will not move a committed array, returning that unchanged meant a GPU run
+    trained on the CPU -- correct values, full speed of the wrong device, nothing raised. The
+    assertion is against ``jax.devices()[0]`` rather than a literal, so it is meaningful on a
+    CUDA box and still guards the contract on a CPU-only one.
+    """
+    url, srcs = write_zarr(n=40, spc=8)
+    geom = open_geometries(obstore_store(url))["t2m"]
+    manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(obstore_store(url), manifest, shuffle=False, batch_size=8, block_chunks=2)
+    ds.set_epoch(0)
+
+    default = jax.devices()[0]
+    for batch in ds.train:
+        for name, arr in to_jax(batch).items():
+            assert list(arr.devices()) == [default], f"{name} on {list(arr.devices())}"
+
+
+def test_to_jax_honours_an_explicit_device(write_zarr) -> None:
+    """``device=`` overrides the default, and the values survive the transfer."""
+    url, srcs = write_zarr(n=16, spc=8)
+    geom = open_geometries(obstore_store(url))["t2m"]
+    manifest = split_by_chunk(geom, fractions=(1.0, 0.0, 0.0))
+    ds = InSituDataset(obstore_store(url), manifest, shuffle=False, batch_size=8, block_chunks=2)
+    ds.set_epoch(0)
+
+    target = jax.devices("cpu")[0]
+    batch = next(iter(ds.train))
+    arrays = to_jax(batch, device=target)
+    assert list(arrays["t2m"].devices()) == [target]
+    np.testing.assert_array_equal(np.asarray(arrays["t2m"]), batch.arrays["t2m"])

--- a/uv.lock
+++ b/uv.lock
@@ -1375,6 +1375,11 @@ jax = [
     { name = "jax" },
     { name = "optax" },
 ]
+jax-cuda = [
+    { name = "flax" },
+    { name = "jax", extra = ["cuda12"] },
+    { name = "optax" },
+]
 tf = [
     { name = "tensorflow" },
 ]
@@ -1403,11 +1408,13 @@ requires-dist = [
     { name = "cloudpickle", marker = "extra == 'cache'", specifier = ">=3" },
     { name = "cupy-cuda12x", marker = "extra == 'gpu'", specifier = ">=13.0" },
     { name = "flax", marker = "extra == 'jax'", specifier = ">=0.8" },
+    { name = "flax", marker = "extra == 'jax-cuda'", specifier = ">=0.8" },
     { name = "gcsfs", marker = "extra == 'bench'", specifier = ">=2024.6" },
     { name = "gcsfs", marker = "extra == 'gcsfs'", specifier = ">=2024.6" },
     { name = "icechunk", marker = "extra == 'astronomy'", specifier = ">=0.2" },
     { name = "icechunk", marker = "extra == 'icechunk'", specifier = ">=0.2" },
     { name = "jax", marker = "extra == 'jax'", specifier = ">=0.4.30" },
+    { name = "jax", extras = ["cuda12"], marker = "extra == 'jax-cuda'", specifier = ">=0.4.30" },
     { name = "kerchunk", marker = "extra == 'astronomy'", specifier = ">=0.2.10" },
     { name = "kvikio-cu12", marker = "extra == 'gpu'", specifier = ">=24.10" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
@@ -1416,6 +1423,7 @@ requires-dist = [
     { name = "obspec-utils", marker = "extra == 'astronomy'", specifier = ">=0.9" },
     { name = "obstore", specifier = ">=0.3" },
     { name = "optax", marker = "extra == 'jax'", specifier = ">=0.2" },
+    { name = "optax", marker = "extra == 'jax-cuda'", specifier = ">=0.2" },
     { name = "plotly", marker = "extra == 'bench'", specifier = ">=5.20" },
     { name = "psutil", marker = "extra == 'bench'", specifier = ">=5.9" },
     { name = "py-spy", marker = "extra == 'bench'", specifier = ">=0.4" },
@@ -1431,7 +1439,7 @@ requires-dist = [
     { name = "zarr", specifier = ">=3.3" },
     { name = "zarr", marker = "extra == 'astronomy'", specifier = ">=3.3" },
 ]
-provides-extras = ["torch", "jax", "tf", "gpu", "virtual", "cache", "bench", "docs", "icechunk", "gcsfs", "arraylake", "astronomy"]
+provides-extras = ["torch", "jax", "jax-cuda", "tf", "gpu", "virtual", "cache", "bench", "docs", "icechunk", "gcsfs", "arraylake", "astronomy"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1457,6 +1465,57 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d2/73/eb91d98fcadfa2cbcfdd4e417ab116e47eb20882acc5ee678e47c35d6b57/jax-0.10.2.tar.gz", hash = "sha256:bf77428a8c2e6904c4f46d5ab12aa5cfc6cad2179f07f7e4c0fc75ac86ef0639", size = 2775110, upload-time = "2026-06-17T23:44:57.818Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/82/5ab5211079a151b6f661529369c0c8e98ec64cabf5c0cf22a0a05af124d8/jax-0.10.2-py3-none-any.whl", hash = "sha256:724d73c4678d8b06f6a6ab4db1b8a2fea8cd4f1e2c2564f99601634ec7b8d1c6", size = 3219515, upload-time = "2026-06-17T23:42:41.259Z" },
+]
+
+[package.optional-dependencies]
+cuda12 = [
+    { name = "jax-cuda12-plugin", extra = ["with-cuda"] },
+    { name = "jaxlib" },
+]
+
+[[package]]
+name = "jax-cuda12-pjrt"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/b0/e1d392ee24ecd53caa202194746cb12058befde5882d1f3307922829783f/jax_cuda12_pjrt-0.10.2-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b6f2d66548ee1ee910a836b5fe3d0ebbe1da04a62d0f468ba4822189036a32b3", size = 169847949, upload-time = "2026-06-17T23:42:44.729Z" },
+    { url = "https://files.pythonhosted.org/packages/77/00/326facd192b7dc0731e43b30f5ada5ef235e2a3325a151d94ed3db041536/jax_cuda12_pjrt-0.10.2-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:806d1fd29038b6acf5a2b289dd62192abea977ee26aef60ea295b1d28a23acf8", size = 174364763, upload-time = "2026-06-17T23:42:49.931Z" },
+]
+
+[[package]]
+name = "jax-cuda12-plugin"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jax-cuda12-pjrt" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/4a/382ec14e57d774148b079c3d251fc9b9e1ed7f92dd2327823f35e0a968a7/jax_cuda12_plugin-0.10.2-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:767a1482dbf652688403c4e22ff01470e1add13c48f9d817169fd8f7440afce5", size = 8093630, upload-time = "2026-06-17T23:42:57.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/25/19ee8936b00ca74a12bfaebd4703695cee2407f954a6e4e67cdd7f82b7bf/jax_cuda12_plugin-0.10.2-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:4eb6e8e0992fd9897db2468da33f276ae414ec84dc436804124404430502eeac", size = 8141521, upload-time = "2026-06-17T23:42:58.483Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/a9c4ea148d31843764383b26fd66b38cfedad9a6dbf08db634a23d9312c3/jax_cuda12_plugin-0.10.2-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:69776ac849112f4fc2d6fa616f8772106daff38fcdb825c4e39f47e878f27610", size = 8093605, upload-time = "2026-06-17T23:43:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/92/07/3098ae537e68d76bbc98ed61d53e9856f63f4f1bd64f8aeb4d432dad1290/jax_cuda12_plugin-0.10.2-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:948a988927cb10843b501a215181ccb1daed3fa70531b2f1ae0842fe1c08b05e", size = 8141236, upload-time = "2026-06-17T23:43:01.55Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0c/ff1e1975ef108cb2e45deacf5dea812822efaf3210af075f464abd40399c/jax_cuda12_plugin-0.10.2-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:febd9d3f488d182090758936042ad647a60470923715b48a385bc312cb943c63", size = 8108408, upload-time = "2026-06-17T23:43:03.398Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c2/04c70eb73beb4df23f49b72d159ca74ee31cccb1be95cdab7491a5ebd259/jax_cuda12_plugin-0.10.2-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:1f1e20fba0aaa3f28ab0a3273754c8c098fa40b74bf4dac5b76c9f2a70425487", size = 8151184, upload-time = "2026-06-17T23:43:05.106Z" },
+    { url = "https://files.pythonhosted.org/packages/95/34/5d5b2993f6b7bbfe781920671de61036faffa5a8bf3740b4ca23d790b6f9/jax_cuda12_plugin-0.10.2-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:4946ec57ddb795e2da8288ceb1ceddd58c2a204a0f7765af89eae486a1d3ace7", size = 8094107, upload-time = "2026-06-17T23:43:06.546Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ac/85bc07d7a0766c7999f9bdfcf7f7cb2487fd0eb5d6bbe2bd41a3a54cd379/jax_cuda12_plugin-0.10.2-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:0c7a0204155585cc1c4fcb30c66b7f881b38e57e1f0d8e97d48e1654bf0d27f8", size = 8141889, upload-time = "2026-06-17T23:43:08.018Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/7d/9fa25e24b96ab06217e1e3dd311a80f3534076bb1b19d46cbc8cf9aa55b9/jax_cuda12_plugin-0.10.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:c26a7dd5e71c9edf203b95480f02ec4ad60c9c7e11e38b7310b1fd1dd03ba116", size = 8108639, upload-time = "2026-06-17T23:43:09.651Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c2/98fa02ba204f5dc88680128129fbc7cd833d5b5ddae2734af93ef85db853/jax_cuda12_plugin-0.10.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:c539b052056e8181082fa2635f17e098b3f625d87da53ba35470a2c13480801d", size = 8151505, upload-time = "2026-06-17T23:43:11.023Z" },
+]
+
+[package.optional-dependencies]
+with-cuda = [
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -2283,12 +2342,51 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cublas-cu12"
+version = "12.9.2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/a2/c96163a0fff1839c0c9548bbdeae7b853b867009e33b9b9264adc238b1cf/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:5572131a59c3eebeeb1c4c8144f772d49372c20124916e072a0e3fc30df421d5", size = 575012079, upload-time = "2026-04-08T18:51:47.303Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c0/0a517bfe63ccd3b92eb254d264e28fca3c7cab75d07daea315250fb1bf73/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:e4f53a8ca8c5d6e8c492d0d0a3d565ecb59a751b19cfdaa4f6da0ab2104c1702", size = 581240110, upload-time = "2026-04-08T18:52:31.532Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cccl-cu12"
+version = "12.9.27"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/7e/82e49956b046bdc506c789235c587d9b3ef58b8bc1782258c1e247229647/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7898b38aa68beaa234d48f0868273702342a196d6e2e9d0ef058dca2390ebea", size = 3152245, upload-time = "2025-05-01T19:32:04.802Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2a/d4cd8506d2044e082f8cd921be57392e6a9b5ccd3ffdf050362430a3d5d5/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37869e17ce2e1ecec6eddf1927cca0f8c34e64fd848d40453df559091e2d7117", size = 3152243, upload-time = "2025-05-01T19:32:13.955Z" },
+]
+
+[[package]]
 name = "nvidia-cuda-cupti"
 version = "13.0.85"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
     { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.9.79"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/78/351b5c8cdbd9a6b4fb0d6ee73fb176dcdc1b6b6ad47c2ffff5ae8ca4a1f7/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:791853b030602c6a11d08b5578edfb957cadea06e9d3b26adbf8d036135a4afe", size = 10077166, upload-time = "2025-06-05T20:01:01.385Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/2e/b84e32197e33f39907b455b83395a017e697c07a449a2b15fd07fc1c9981/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:096bcf334f13e1984ba36685ad4c1d6347db214de03dbb6eebb237b41d9d934f", size = 10814997, upload-time = "2025-06-05T20:01:10.168Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvcc-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/48/b54a06168a2190572a312bfe4ce443687773eb61367ced31e064953dd2f7/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:5d6a0d32fdc7ea39917c20065614ae93add6f577d840233237ff08e9a38f58f0", size = 40546229, upload-time = "2025-06-05T20:01:53.357Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/8cc072436787104bbbcbde1f76ab4a0d89e68f7cebc758dd2ad7913a43d0/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:44e1eca4d08926193a558d2434b1bf83d57b4d5743e0c431c0c83d51da1df62b", size = 39411138, upload-time = "2025-06-05T20:01:43.182Z" },
 ]
 
 [[package]]
@@ -2301,12 +2399,42 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4", size = 89568129, upload-time = "2025-06-05T20:02:41.973Z" },
+    { url = "https://files.pythonhosted.org/packages/64/eb/c2295044b8f3b3b08860e2f6a912b702fc92568a167259df5dddb78f325e/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead", size = 44528905, upload-time = "2025-06-05T20:02:29.754Z" },
+]
+
+[[package]]
 name = "nvidia-cuda-runtime"
 version = "13.0.96"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
     { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.9.79"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/e0/0279bd94539fda525e0c8538db29b72a5a8495b0c12173113471d28bce78/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83469a846206f2a733db0c42e223589ab62fd2fabac4432d2f8802de4bded0a4", size = 3515012, upload-time = "2025-06-05T20:00:35.519Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3", size = 3493179, upload-time = "2025-06-05T20:00:53.735Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.26.0.51"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/ae/412ef5533642e63f360db552235337d28c00ddc1dfca807a6ddae95e939c/nvidia_cudnn_cu12-9.26.0.51-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:24458a34856d6b5e83aa9b7041e92a789f0ef390f4d881529fb986df6aecca60", size = 776301552, upload-time = "2026-09-10T16:44:35.71Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d2/ac670e921b185ba348a7ba7dd490ef2aad9c3e1918a87553567be86e37f3/nvidia_cudnn_cu12-9.26.0.51-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ce8603d4ea88d134be5a92c5e0833d513bea1ce0ee4bbc5d649fcb8718d51cbf", size = 770488318, upload-time = "2026-09-10T16:47:14.978Z" },
 ]
 
 [[package]]
@@ -2331,6 +2459,18 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
     { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.4.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/2b/76445b0af890da61b501fde30650a1a4bd910607261b209cccb5235d3daa/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1a28c9b12260a1aa7a8fd12f5ebd82d027963d635ba82ff39a1acfa7c4c0fbcf", size = 200822453, upload-time = "2025-06-05T20:05:27.889Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f4/61e6996dd20481ee834f57a8e9dca28b1869366a135e0d42e2aa8493bdd4/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c67884f2a7d276b4b80eb56a79322a95df592ae5e765cf1243693365ccab4e28", size = 200877592, upload-time = "2025-06-05T20:05:45.862Z" },
 ]
 
 [[package]]
@@ -2366,6 +2506,20 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.5.82"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/99/686ff9bf3a82a531c62b1a5c614476e8dfa24a9d89067aeedf3592ee4538/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:62efa83e4ace59a4c734d052bb72158e888aa7b770e1a5f601682f16fe5b4fd2", size = 337869834, upload-time = "2025-06-05T20:06:53.125Z" },
+    { url = "https://files.pythonhosted.org/packages/33/40/79b0c64d44d6c166c0964ec1d803d067f4a145cca23e23925fd351d0e642/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:15da72d1340d29b5b3cf3fd100e3cd53421dde36002eda6ed93811af63c40d88", size = 338117415, upload-time = "2025-06-05T20:07:16.809Z" },
+]
+
+[[package]]
 name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2378,12 +2532,33 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.10.65"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/6f/8710fbd17cdd1d0fc3fea7d36d5b65ce1933611c31e1861da330206b253a/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:221c73e7482dd93eda44e65ce567c031c07e2f93f6fa0ecd3ba876a195023e83", size = 366359408, upload-time = "2025-06-05T20:07:42.501Z" },
+    { url = "https://files.pythonhosted.org/packages/12/46/b0fd4b04f86577921feb97d8e2cf028afe04f614d17fb5013de9282c9216/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:73060ce019ac064a057267c585bf1fd5a353734151f87472ff02b2c5c9984e78", size = 366465088, upload-time = "2025-06-05T20:08:20.413Z" },
+]
+
+[[package]]
 name = "nvidia-cusparselt-cu13"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
     { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.31.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/85/b073e54c993cd9f79faa955d7c9bd7356da408935483aebc3cbb53a922ec/nvidia_nccl_cu12-2.31.2-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:f208de397e431631eab0eca946444404a495d43a007535baa333d7de9e510ca2", size = 342026203, upload-time = "2026-08-11T23:23:40.509Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/36/104de52d6368f5b7f886e8fd252e0a438fe73a215e59b1b47f93a80ae2ea/nvidia_nccl_cu12-2.31.2-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:f9b1dc3c2a7e20176054144ebb3b32fea83b40402ee5d7ac7045cd11ecc956c0", size = 342105414, upload-time = "2026-08-11T23:24:24.167Z" },
 ]
 
 [[package]]
@@ -2402,6 +2577,27 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
     { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.9.86"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/0c/c75bbfb967457a0b7670b8ad267bfc4fffdf341c074e0a80db06c24ccfd4/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9", size = 39748338, upload-time = "2025-06-05T20:10:25.613Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bc/2dcba8e70cf3115b400fef54f213bcd6715a3195eba000f8330f11e40c45/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca", size = 39514880, upload-time = "2025-06-05T20:10:04.89Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu12"
+version = "3.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-cccl-cu12" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/a1/9ca9cc3338217311cee21f7ba795dad4f38b7a279a6da7d3d549258f60b1/nvidia_nvshmem_cu12-3.7.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:98495de30994f1401a12cc8158ffacbeada44579f54185d75665381468056faa", size = 229963056, upload-time = "2026-07-17T19:23:44.067Z" },
+    { url = "https://files.pythonhosted.org/packages/63/03/cde130e3ff706784f9efd47204f299b15113ea08203e98a556603dac245d/nvidia_nvshmem_cu12-3.7.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02b6d3482d90ea8ba214bc400362297f573257763990a98c9846ec5c786a7227", size = 230171132, upload-time = "2026-07-17T19:25:07.092Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #88.

`to_jax` was `jnp.from_dlpack(array)`. That imports a **host** buffer, so the result is
committed to `cpu:0` — and `jax.jit` does not move a committed array. Every JAX user with a
GPU therefore got a pipeline that was correct, silent, and entirely on the wrong device.

Measured on the L4 (`jax[cuda12]`, jax 0.11.1, `jax.devices() == [CudaDevice(id=0)]`):

| | before | after |
|---|---|---|
| `to_jax(batch)["t2m"].devices()` | `[CpuDevice(id=0)]` | `[CudaDevice(id=0)]` |
| `jax.jit(lambda x: x*2)(arr).devices()` | `{CpuDevice(id=0)}` | `{CudaDevice(id=0)}` |
| values vs store | exact | exact |

The batch is now placed on `jax.devices()[0]` — where every other jax array-creation path
puts one, so `from_dlpack` was the anomaly rather than this being a new policy. `device=`
overrides it.

**Why this needs no new machinery.** On a CPU-only build the put is a pass-through that still
aliases the exported buffer (verified: mutating the host array after `device_put` is still
visible through the result), so it costs nothing there. On GPU, `device_put` is
documented-async, but JAX keeps the source *referenced* across the transfer, so the pool's
existing liveness poll defers reclaim — this is the property DESIGN.md already establishes
under "the pool is sound for every adapter". It does **not** make JAX own its transfer the
way `to_torch(device=)` does; JAX cannot consume pinned host memory
([jax#22346](https://github.com/jax-ml/jax/issues/22346)) and exposes no event to gate
recycling on, so **pinning stays torch-only** and that reasoning is unchanged.

Second, smaller fix: bare `jax>=0.4.30` resolves to the **CPU wheel**, so `--extra jax` on a
CUDA box installed a JAX that could not see the GPU at all — before `to_jax` was even
reached. A new **`jax-cuda`** extra pins `jax[cuda12]`, kept separate so `--extra jax` stays
resolvable on any machine (CI depends on that).

## For reviewers

**The thing I would most value a second look at is the regression test's reach.** It asserts
against `jax.devices()[0]` rather than a literal, which makes it meaningful on a CUDA box and
still a contract guard on a CPU one — but it follows that **on CI it would not have caught
this defect**, because CI has no GPU runner and `devices()[0]` is `cpu:0` there. The test
passed before this change on CPU and failed before it on the L4. I verified the failing-then-
passing transition manually on the GPU box in both a `jax[cuda12]` venv and a CPU-only one
(3 passed in each); I could not make CI prove it. If you want a stronger guard, the honest
options are a GPU runner or asserting the narrower property that `to_jax` never returns an
array committed to a device other than the default — neither of which I have added here.

I am confident in the safety argument, because it is not new: it is the referenced-source
property DESIGN.md:624-690 already relies on for the existing zero-copy path, and
`bench/probe_batch_buffers.py --arms all` plus `test_probe_jax_arm_runs_without_a_gpu` are the
standing instruments for it. I did not touch `ChunkPool`, the scheduler, or any cross-thread
readiness path.

One behaviour change worth noting explicitly: `to_jax` is no longer guaranteed to hand back a
host array. Anyone relying on that (`np.asarray` on the result still works, and copies from
device) would see a transfer they did not before. I think that is the right default given the
alternative is silently training on the wrong device, but it is a judgement call rather than a
pure bug fix.

## Author attestation

- [ ] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

**Left unchecked deliberately** — this description and the code were drafted by an assistant,
and that box is the human author's to tick.

## Checklist

- [x] Tests added or updated — with the reach caveat described above: the new tests fail
      before this change on a CUDA box and pass on a CPU-only one, so they do not reproduce
      the bug in CI
- [x] `ruff check`, `ruff format --check`, `mypy` and `pytest -q` green locally
      (668 passed, 9 skipped), and `mkdocs build --strict` too
- [x] Docstrings and API docs for any new or changed public surface (`to_jax` flows into
      `docs/api.md` via mkdocstrings)
- [x] User-facing behavior documented in `docs/*.md` (`jax-cuda` added to the extras lists in
      `docs/index.md` and `docs/contributing.md`)
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] No load-bearing invariant is broken — `Batch` is still numpy, the hot path is untouched,
      and this is adapter-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGUS3Yz9ip4hggAQfnnuFk