### PR TITLE
release: 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.0 — 2026-09-11
 
 ### Upgrading
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "insitubatch"
-version = "0.1.0"
+version = "0.2.0"
 description = "Train in place on n-dimensional cloud tensors: the data-loader orchestration layer on top of solved async IO (obstore / zarr v3 / icechunk)."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1323,7 +1323,7 @@ wheels = [
 
 [[package]]
 name = "insitubatch"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Replaces #86, which predated the README rewrite and now conflicts on all four of its files.
Redone on top of `main` rather than rebased, since the cut itself is three lines.

## Summary

- `pyproject.toml` — `version = "0.2.0"`
- `CHANGELOG.md` — `## Unreleased` becomes `## 0.2.0 — 2026-09-11`
- `uv.lock` — follows the version

The changelog grouping and its `### Upgrading` preamble landed separately in #90, so there is
nothing else to do here.

**#86's README hunk is deliberately not carried over.** It added a clause about `persist=True`
releasing each block and re-reading from cache to a Status paragraph that no longer exists;
that behaviour now has its own account in the README's Caching section, stated more fully than
the clause managed.

## Verified against the release process, not assumed

Run through the checklist in `docs/contributing.md` (added in #90):

- **The three maturity statements agree** — classifier `Development Status :: 4 - Beta`,
  README `Status: Beta`, DESIGN.md `Maturity: Beta`. They were two steps apart before #90.
- **Five gates green** plus `mkdocs build --strict` — 668 passed, 9 skipped.
- **The artifact was opened, not assumed.** The wheel carries `py.typed`, the
  `insitubatch-check-transform` console script and LICENSE. The sdist's only prose is
  `README.md` — which is what PyPI renders — and METADATA embeds the rewritten one
  (22,090 bytes, with the stale "alpha, but validated" text confirmed gone), with
  `Project-URL: Changelog` pointing at the file.
- **The wheel installs into a clean venv**: `insitubatch.__version__ == "0.2.0"`, the public
  API imports (`InSituDataset`, `DrawOrder`, `to_jax`, `applies`, `icechunk_store`), and the
  console script runs.
- **GPU gate** cleared earlier on an L4: the CUDA-gated buffer-lifetime tests ran green with
  the instrument validated first, and persistence RMSE held at 0.884 across CPU and CUDA legs.

## For reviewers

The only judgement call is the one already made in #90 — that Beta is claimed on
instrumentation rather than on an absence of bugs. This PR just makes the version match.

Please close #86 when this merges.

## Author attestation

- [ ] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

**Left unchecked deliberately** — that box is the human author's to tick.

## Checklist

- [x] `ruff check`, `ruff format --check`, `mypy`, `pytest -q` and `mkdocs build --strict`
      green locally
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md` — n/a, this PR *is* the heading
      rename; every entry it covers already has one
- [x] No load-bearing invariant is broken — no source change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGUS3Yz9ip4hggAQfnnuFk