### PR TITLE
examples: train in place on a deep-chunked cloud archive (dynamical.org NOAA GFS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+- **A worked example on a deep-chunked cloud archive, where the memory bill is the lesson
+  (`examples/dynamical/`).** dynamical.org publishes ML-shaped weather Zarr with no published
+  path into a training loop, and the first thing a reader tries — pointing the README
+  quickstart at one — fails three ways before a byte moves: the stores are Icechunk rather
+  than plain Zarr, `variables=` stops being optional at 25 to 146 arrays per store, and the
+  quickstart's `block_chunks=16` is sized to a 63 MiB chunk where NOAA GFS analysis has a
+  6.87 GiB one. Nothing raises; `print_summary()` truthfully reports the 860 GiB of estimated
+  peak that three variables at those defaults ask for. The example is single-variable because
+  the geometry prices the second one at another 13.7 GiB, and it says so rather than quietly
+  picking a small store that would have hidden it.
+
 ## 0.2.0 — 2026-09-11
 
 ### Upgrading

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,6 +12,7 @@ has an offline synthetic `--source` so you can run it with no network or cloud c
 |---|---|---|---|
 | [`advection/`](#advection-a-24-hour-forecast-in-three-frameworks) | Weather — WeatherBench2 ERA5 (`gs://`, anonymous), Arraylake/Icechunk, or synthetic | Input at *t*, target at *t+24 h* as **offset views of one array** | Windowed multi-offset sampling; one dataset → **torch, JAX and TF** |
 | [`microscopy/`](#microscopy-cell-segmentation-over-z) | Bio-imaging — IDR OME-NGFF `(T,C,Z,Y,X)` on `s3://idr` | Samples a **middle** axis (`sample_axis=2`); two co-registered variables chunked **1 vs 30 planes** deep | Arbitrary sample axis + per-variable chunk size — the engine is not weather-specific |
+| [`dynamical/`](#dynamical-downscaling-on-a-deep-chunked-archive) | Weather — dynamical.org's NOAA GFS analysis, an Icechunk repo on `s3://dynamical-noaa-gfs` | **1440 samples inside one stored chunk**, which assembles to 6.87 GiB resident | Decode-once at its most valuable, and what a shard's size costs a loader |
 | [`hubble/`](#hubble-denoising-real-telescope-frames-from-fits) | Astronomy — Hubble WFC3/IR frames of M16 on MAST's `s3://stpubdata` | **FITS, not zarr** — indexed as virtual byte-range references; one frame *is* one chunk | Training in place over an archival format; streaming value without decode amortization |
 | [`sdss/`](#sdss-reconstructing-galaxy-spectra-streamed-in-place) | Astronomy — SDSS DR17 `spPlate` spectra, or our **public reference stores** | **FITS binary-image tables** re-chunked by byte arithmetic; two layouts from the same bytes | Both regimes from one dataset: many-fibers-per-chunk *decode amortization* vs one-fiber-per-chunk *archive-scale streaming* |
 | [WB2 pair](#the-weatherbench2-cold-start-pair) | Weather — WeatherBench2 ERA5 | The same task on **two engines** | The cold-start / memory trade-off vs an xbatcher worker stack |
@@ -68,6 +69,32 @@ The task is per-plane foreground segmentation and the baseline is a global **Ots
 threshold — the segmentation analogue of persistence. Otsu reads each pixel's intensity
 alone, so a smooth autofluorescence haze gradient defeats it; a tiny CNN that reads the
 neighbourhood beats it. Each run prints held-out foreground IoU, model vs Otsu.
+
+## dynamical — downscaling on a deep-chunked archive
+
+The deep-chunk showcase: the geometry where fetch-and-decode-once is worth the most.
+[`dynamical/`](https://github.com/emfdavid/insitubatch/blob/main/examples/dynamical/data.py)
+reads surface solar irradiance from [dynamical.org](https://dynamical.org)'s public NOAA GFS
+analysis, where one stored chunk holds **1440 consecutive hourly global fields**. One fetch and
+one decode serve all of them.
+
+```bash
+uv sync --extra torch
+uv run python -m examples.dynamical.train_torch                  # synthetic irradiance (offline)
+uv sync --extra torch --extra icechunk
+uv run python -m examples.dynamical.train_torch --source gfs     # the real GFS archive (streamed)
+```
+
+The task is spatial downscaling over a European window, and the baseline is bilinear
+upsampling — everything the coarse field gives you with no model, and a data fingerprint
+besides. Each run prints held-out RMSE in W/m², model vs bilinear.
+
+The example reads **one variable**, because the geometry prices the second one. A stored chunk
+is 878.9 MiB and assembles to 6.87 GiB resident, the residency floor is two blocks of them, so
+a variable costs ~13.7 GiB whatever the batch size — and a shrinking `chunk_transform` cannot
+buy it back, since the pool holds the source tiles until the fill completes. `--print-summary`
+reports the whole budget before a byte moves; on the defaults `--source gfs` estimates
+19.78 GiB of peak. This is the case the [memory model](tuning.md) is for.
 
 ## hubble — denoising real telescope frames from FITS
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -105,6 +105,51 @@ prints the held-out foreground IoU, model vs Otsu.
 Only `train_torch.py` ships here — framework-neutrality is the advection example's job; this
 example's job is to prove the *geometry* generalizes.
 
+## dynamical/ — downscaling on a deep-chunked archive (1440 samples per chunk)
+
+The **deep-chunk** showcase: the geometry where decode-once is worth the most.
+[`dynamical/`](dynamical/data.py) reads surface solar irradiance from
+[dynamical.org](https://dynamical.org)'s public NOAA GFS analysis — an Icechunk repository whose
+stored chunk holds **1440 consecutive hourly fields**. One fetch and one decode serve every one
+of them; a per-sample `__getitem__` would re-read the same object 1440 times.
+
+```bash
+uv sync --extra torch
+uv run python -m examples.dynamical.train_torch                     # synthetic irradiance (offline)
+uv sync --extra torch --extra icechunk
+uv run python -m examples.dynamical.train_torch --source gfs        # the real GFS archive (streamed)
+```
+
+The task is **spatial downscaling** over a European window: the field is block-averaged to a
+coarse grid and the model must put the fine structure back. The baseline is **bilinear
+upsampling** — everything the coarse field gives you for free — and it doubles as a data
+fingerprint, since its RMSE depends only on the data the loader handed over. On the synthetic
+store the sub-grid structure is a deterministic function of the smooth field, so a CNN beats
+bilinear by construction; on the real archive the claim is "same pipeline, real data, no
+reshard", not SOTA downscaling. Each run prints held-out RMSE in W/m², model vs bilinear.
+
+**The example is single-variable by necessity, and that is the lesson.** A stored chunk here is
+878.9 MiB and assembles to **6.87 GiB resident**; the residency floor is two blocks of them, so
+each variable costs ~13.7 GiB however small the batch. A *shrinking* `chunk_transform` does not
+help — the pool holds the source tiles until the fill completes, so the charge is the larger of
+the two and peak goes up. `--print-summary` reports all of it before a byte moves, which is the
+only reason the archive is approachable at all; `--source gfs` estimates **19.78 GiB** of peak on
+the defaults, so check before you commit a box to it.
+
+### Data sources (`--source`)
+
+| `--source` | store | notes |
+| --- | --- | --- |
+| `synthetic` *(default)* | offline **irradiance archive** written to a temp zarr | a clear-sky diurnal cycle under an advecting cloud field, shaped like the real one: deep sample chunks, a tiled field, and a tile grid that does not divide it; `--n-steps` / `--nlat` / `--nlon` / `--sample-chunk` size it |
+| `gfs` | dynamical.org's **NOAA GFS analysis** Icechunk repo on `s3://dynamical-noaa-gfs` | streamed anonymously (needs `--extra icechunk`); `--sample-range` defaults to 4 chunks = 5760 hourly analyses. **~20 GiB of RAM** |
+
+`dynamical_catalog.get_store("noaa-gfs-analysis")` returns the same zarr Store if you would
+rather address the archive by catalog id than by URL — the engine reads either. Note that the
+catalog's `*-virtual` datasets carry GRIB2 byte references and need the `gribberish` codec, which
+this example does not pull in.
+
+Only `train_torch.py` ships here — framework-neutrality is the advection example's job.
+
 ## hubble/ — denoising real telescope frames from FITS (no reshard)
 
 The **archival-format** showcase: the data never was zarr. [`hubble/`](hubble/data.py) indexes

--- a/examples/dynamical/__init__.py
+++ b/examples/dynamical/__init__.py
@@ -1,0 +1,16 @@
+"""Statistical downscaling on a dynamical.org Icechunk archive -- 1440 samples per chunk.
+
+The **deep-chunk** companion to ``examples/advection``. A sample is one hourly global field of
+surface solar irradiance, and on ``noaa-gfs-analysis`` 1440 of them live inside a single stored
+chunk: the geometry where fetch-and-decode-once is worth the most, and where a per-sample
+``__getitem__`` would re-read the same object for every sample it holds.
+
+The task is single-variable by necessity, and that is the lesson. A stored chunk here is
+**6.87 GiB resident**, so the residency floor is ~13.7 GiB *per variable* -- set by the shard,
+not by the batch size. ``print_summary()`` reports it before a byte moves, which is the only
+reason the archive is approachable at all.
+
+``data.py`` builds the store (synthetic irradiance, or the real GFS analysis), the dataset and
+the shared eval; ``train_torch.py`` trains a tiny CNN that beats bilinear upsampling by reading
+structure the coarse field's neighbourhood implies.
+"""

--- a/examples/dynamical/data.py
+++ b/examples/dynamical/data.py
@@ -1,0 +1,407 @@
+"""Shared data for the downscaling example: the store, the one dataset, the eval.
+
+**The task -- spatial downscaling of surface solar irradiance.** Each sample is one hourly
+field. The field is cropped to a European window, block-averaged to a coarse grid, and the
+model must put the fine structure back. Input and target are therefore two resolutions of the
+*same* array, which is what keeps this to **one variable** -- on ``noaa-gfs-analysis`` a second
+variable costs another 13.7 GiB of residency, because a stored chunk is 6.87 GiB and the
+residency floor is two blocks of it.
+
+**Bilinear upsampling is the no-model baseline** a useful model must beat -- the downscaling
+analog of persistence in the advection example. It is also a data fingerprint: its RMSE depends
+only on the field, so a change in it across runs means the loader handed over different data.
+
+On the synthetic store the sub-grid structure is a deterministic function of the smooth field,
+so a CNN beats bilinear by construction. On the real GFS archive the claim is "same pipeline,
+real data, no reshard" -- not SOTA downscaling.
+
+``downscaling_dataset`` returns one dataset whose label is always ``ghi`` regardless of the
+store, so the training file is store-agnostic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from collections.abc import Callable, Iterable
+from typing import Literal
+
+import numpy as np
+import zarr
+from zarr.abc.store import Store
+
+from insitubatch import (
+    Batch,
+    InSituDataset,
+    ensure_local_dir,
+    icechunk_store,
+    obstore_store,
+    open_geometries,
+    split_by_chunk,
+)
+
+from .._logging import add_log_level, configure_logging
+
+# dynamical.org's NOAA GFS analysis: hourly global 0.25-degree fields in a public Icechunk
+# repository, read anonymously. `dynamical_catalog.get_store("noaa-gfs-analysis")` returns the
+# same zarr Store if you would rather address it by catalog id than by URL.
+GFS_URL = "s3://dynamical-noaa-gfs/noaa-gfs-analysis/v0.1.0.icechunk"
+GFS_REGION = "us-west-2"
+GFS_VAR = "downward_short_wave_radiation_flux_surface"  # surface GHI, W/m^2
+GFS_SAMPLES_PER_CHUNK = 1440
+
+LABEL = "ghi"  # canonical dataset label (store-independent)
+
+# The model domain, as (south, north, west, east) degrees with longitude in [-180, 180). Both
+# grids run latitude 90 -> -90 and longitude 0 -> 360, so a European window wraps the prime
+# meridian -- `region_index` returns wrapping column indices rather than a slice.
+REGION = (35.0, 65.0, -15.0, 25.0)
+COARSEN = 4  # 0.25 degree -> 1 degree on GFS
+
+
+def _gfs_store() -> Store:
+    """Anonymous read-only session on dynamical.org's public GFS analysis repository."""
+    return icechunk_store(GFS_URL, anonymous=True, region=GFS_REGION)
+
+
+def region_index(
+    nlat: int, nlon: int, region: tuple[float, float, float, float] = REGION
+) -> tuple[np.ndarray, np.ndarray]:
+    """Row and (wrapping) column indices of a lat/lon box on a global equiangular grid.
+
+    Latitude runs 90 -> -90 over ``nlat`` points and longitude 0 -> 360 over ``nlon``, which is
+    how both the GFS archive and the synthetic store are laid out, so one window definition in
+    degrees serves every resolution. Columns are returned in west-to-east order and wrapped
+    modulo ``nlon``, since a European box straddles the prime meridian. Both are trimmed to a
+    multiple of :data:`COARSEN` so the block average divides evenly.
+    """
+    south, north, west, east = region
+    dlat, dlon = 180.0 / (nlat - 1), 360.0 / nlon
+    r0 = int(np.ceil((90.0 - north) / dlat))
+    n_rows = int(np.floor((90.0 - south) / dlat)) - r0 + 1
+    c0 = int(np.ceil((west % 360.0) / dlon))
+    n_cols = int(np.floor(((east - west) % 360.0) / dlon)) + 1
+    n_rows -= n_rows % COARSEN
+    n_cols -= n_cols % COARSEN
+    if n_rows < COARSEN or n_cols < COARSEN:
+        raise ValueError(
+            f"region {region} covers {n_rows}x{n_cols} cells of a {nlat}x{nlon} grid, which is "
+            f"smaller than the coarsening factor {COARSEN}. Widen the region or the grid."
+        )
+    return np.arange(r0, r0 + n_rows), (c0 + np.arange(n_cols)) % nlon
+
+
+def block_mean(field: np.ndarray, factor: int = COARSEN) -> np.ndarray:
+    """Average ``(B, H, W) -> (B, H//factor, W//factor)``. Both axes must divide evenly."""
+    b, h, w = field.shape
+    return field.reshape(b, h // factor, factor, w // factor, factor).mean(axis=(2, 4))
+
+
+def bilinear_upsample(coarse: np.ndarray, factor: int = COARSEN) -> np.ndarray:
+    """Bilinear upsample ``(B, h, w) -> (B, h*factor, w*factor)``, separable and vectorized.
+
+    Cell centres, edge-clamped: output cell ``j`` samples source position
+    ``(j + 0.5) / factor - 0.5``. This is the baseline prediction -- everything a downscaler
+    gets for free from the coarse field alone, with no model.
+    """
+
+    def axis_weights(n_out: int, n_in: int) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        pos = np.clip((np.arange(n_out) + 0.5) / factor - 0.5, 0, n_in - 1)
+        lo = np.floor(pos).astype(int)
+        hi = np.minimum(lo + 1, n_in - 1)
+        return lo, hi, (pos - lo).astype(np.float32)
+
+    lo_y, hi_y, wy = axis_weights(coarse.shape[1] * factor, coarse.shape[1])
+    lo_x, hi_x, wx = axis_weights(coarse.shape[2] * factor, coarse.shape[2])
+    rows = coarse[:, lo_y] * (1 - wy)[:, None] + coarse[:, hi_y] * wy[:, None]
+    return rows[:, :, lo_x] * (1 - wx) + rows[:, :, hi_x] * wx
+
+
+def downscaling_dataset(
+    store: Store,
+    *,
+    var: str = GFS_VAR,
+    sample_range: tuple[int, int] | None = None,
+    batch_size: int = 32,
+    block_chunks: int = 16,
+    max_inflight: int | None = None,
+    shuffle: bool = True,
+    cache_dir: str | None = None,
+) -> InSituDataset:
+    """One dataset holding one variable, labelled ``ghi``, sampled over time.
+
+    ``store`` is a zarr Store -- build it with :func:`~insitubatch.icechunk_store` for a
+    dynamical.org repository or :func:`~insitubatch.obstore_store` for a plain zarr URL.
+    ``var`` names the array in the store; the dataset's label is always ``ghi`` so the model
+    code is store-agnostic. ``sample_range`` restricts the split to a finite time window --
+    the way to try a deep-chunked archive without committing to all of it, remembering that a
+    range landing mid-chunk still pulls that chunk in whole.
+
+    ``block_chunks`` is the memory knob that matters here: the residency floor is two blocks of
+    stored chunks, so on GFS (6.87 GiB a chunk) anything above ``1`` will not fit a workstation.
+    """
+    opened = open_geometries(store, variables=[var])
+    geoms = {LABEL: opened[var]}
+    # Splits are chunk-granular, so the usual (0.8, 0.1, 0.1) rounds val and test to zero
+    # chunks on an archive this deep -- a quarter each is the smallest honest split here.
+    manifest = split_by_chunk(opened[var], fractions=(0.5, 0.25, 0.25), sample_range=sample_range)
+    return InSituDataset(
+        store,
+        manifest,
+        geometries=geoms,
+        batch_size=batch_size,
+        block_chunks=block_chunks,
+        max_inflight=max_inflight,
+        shuffle=shuffle,
+        cache_dir=cache_dir,
+    )
+
+
+def inputs_and_targets(batch: Batch, factor: int = COARSEN) -> tuple[np.ndarray, np.ndarray]:
+    """Split a ``Batch`` into ``(x, target)``: the upsampled coarse field and the native one.
+
+    ``ghi`` arrives as ``(B, nlat, nlon)`` -- the whole global field, because the field axes are
+    carried whole and the stored shard is the read unit. The model's domain is the European
+    window, so the crop happens here rather than in the loader. ``target`` is the native-
+    resolution crop; ``x`` is that crop block-averaged by ``factor`` and bilinearly restored to
+    the same shape, so both are ``(B, H, W)`` float32 in W/m^2 and ``x`` *is* the baseline
+    prediction.
+    """
+    field = batch.arrays[LABEL]
+    rows, cols = region_index(field.shape[1], field.shape[2])
+    target = field[:, rows][:, :, cols].astype("f4")
+    return bilinear_upsample(block_mean(target, factor), factor), target
+
+
+def rmse(pred: np.ndarray, target: np.ndarray) -> float:
+    """Root-mean-square error in W/m^2 over every cell of every sample."""
+    return float(np.sqrt(np.mean((pred.astype("f8") - target.astype("f8")) ** 2)))
+
+
+def evaluate(view: Iterable[Batch], predict: Callable[[Batch], np.ndarray]) -> tuple[float, float]:
+    """RMSE on a held-out split view (e.g. ``ds.val``): ``(model_rmse, bilinear_rmse)``.
+
+    ``predict`` maps a ``Batch`` to the model's ``(B, H, W)`` field, so this stays framework-
+    neutral. Bilinear upsampling -- the best the coarse field can do with no model -- is the
+    baseline. The view is deterministic (eval splits don't shuffle), so no epoch is set.
+    """
+    preds, targets, bilinears = [], [], []
+    for batch in view:
+        x, target = inputs_and_targets(batch)
+        preds.append(predict(batch))
+        targets.append(target)
+        bilinears.append(x)
+    if not preds:
+        raise RuntimeError(
+            "no batches to evaluate: the split this view covers is empty. A deep-chunked store "
+            "splits by whole chunks, so a narrow --sample-range can round a split to zero of "
+            "them -- widen the range. Reporting RMSE over no samples would be worse than "
+            "stopping here."
+        )
+    pred, target, bilinear = (np.concatenate(a) for a in (preds, targets, bilinears))
+    return rmse(pred, target), rmse(bilinear, target)
+
+
+def make_irradiance_store(
+    url: str,
+    *,
+    n_steps: int = 512,
+    nlat: int = 91,
+    nlon: int = 180,
+    sample_chunk: int = 128,
+    tile: int = 32,
+    seed: int = 0,
+    compress: bool = True,
+) -> None:
+    """Write a synthetic global irradiance archive shaped like the GFS one, only small.
+
+    ``(n_steps, nlat, nlon)`` chunked ``(sample_chunk, tile, tile)``: many samples inside one
+    stored chunk, the field tiled across several of them, and a tile grid that does *not*
+    divide the field -- the same three properties that make the real archive interesting and
+    expensive, at a size that runs anywhere.
+
+    Irradiance is a clear-sky diurnal cycle attenuated by an advecting cloud field. The cloud
+    carries structure below the coarsening scale (``sin`` of the smooth field, which oscillates
+    rapidly wherever the smooth field has a gradient), and that structure is a *deterministic*
+    function of the smooth field -- so block-averaging destroys it while a CNN can infer it
+    back, and the example has real headroom over bilinear by construction.
+    """
+    rng = np.random.default_rng(seed)
+    t = np.arange(n_steps, dtype="f8")[:, None, None]
+    la = np.deg2rad(np.linspace(90.0, -90.0, nlat))[None, :, None]
+    lo = np.deg2rad(np.linspace(0.0, 360.0, nlon, endpoint=False))[None, None, :]
+
+    decl = np.deg2rad(23.44) * np.sin(2 * np.pi * t / (24 * 365.25))
+    hour_angle = 2 * np.pi * ((t % 24) / 24) + lo - np.pi
+    clear = 1100.0 * np.clip(
+        np.sin(la) * np.sin(decl) + np.cos(la) * np.cos(decl) * np.cos(hour_angle), 0.0, None
+    )
+
+    smooth = np.zeros_like(clear)
+    for _ in range(4):
+        kx, ky = rng.integers(1, 4, size=2)
+        smooth += rng.normal() * np.cos(
+            kx * lo + ky * la + rng.uniform(0, 2 * np.pi) + rng.uniform(-0.05, 0.05) * t
+        )
+    smooth = (smooth - smooth.min()) / (smooth.max() - smooth.min() + 1e-9)
+    cloud = np.clip(smooth + 0.25 * np.sin(9.0 * np.pi * smooth), 0.0, 1.0)
+    ghi = (clear * (1.0 - 0.8 * cloud)).astype("f4")
+
+    ensure_local_dir(url)
+    group = zarr.open_group(store=obstore_store(url, read_only=False), mode="w")
+    compressors: Literal["auto"] | None = "auto" if compress else None
+    print(
+        f"make_irradiance_store: {url}\n"
+        f"  {GFS_VAR} ({n_steps}, {nlat}, {nlon}) chunks ({sample_chunk}, {tile}, {tile})  "
+        f"~{ghi.nbytes / 1e6:.0f} MB  compress={'auto' if compress else 'none'}",
+        flush=True,
+    )
+    t0 = time.perf_counter()
+    arr = group.create_array(
+        GFS_VAR,
+        shape=ghi.shape,
+        chunks=(sample_chunk, tile, tile),
+        dtype="f4",
+        compressors=compressors,
+        dimension_names=("time", "latitude", "longitude"),
+    )
+    arr[:] = ghi
+    print(f"  done: {url} in {time.perf_counter() - t0:.1f}s", flush=True)
+
+
+def _synthetic_ready(url: str, n_steps: int, nlat: int, nlon: int, sample_chunk: int) -> bool:
+    """True if a synthetic store with the requested geometry already exists at ``url``.
+
+    A mismatch in shape or sample chunking, or any open failure (absent / partial), returns
+    False so a changed request regenerates rather than training on a stale store.
+    """
+    try:
+        arr = zarr.open_group(store=obstore_store(url), mode="r")[GFS_VAR]
+        return (
+            isinstance(arr, zarr.Array)
+            and arr.shape == (n_steps, nlat, nlon)
+            and arr.chunks[0] == sample_chunk
+        )
+    except Exception:
+        return False
+
+
+def _range(s: str) -> tuple[int, int]:
+    start, stop = (int(x) for x in s.split(","))
+    return (start, stop)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """The shared example CLI (source, device, dataset geometry)."""
+    p = argparse.ArgumentParser(description="Solar irradiance downscaling on a deep-chunked store")
+    p.add_argument(
+        "--source",
+        choices=("synthetic", "gfs"),
+        default="synthetic",
+        help="offline synthetic irradiance | dynamical.org's NOAA GFS analysis (streamed "
+        "anonymously; needs insitubatch[icechunk] and ~20 GiB of RAM)",
+    )
+    p.add_argument(
+        "--device", default="cpu", help="cpu or cuda -- the train loop moves tensors there"
+    )
+    p.add_argument(
+        "--sample-range",
+        type=_range,
+        default=None,
+        metavar="START,STOP",
+        help="finite training window on the time axis (default: 4 chunks on --source gfs)",
+    )
+    p.add_argument("--epochs", type=int, default=8)
+    p.add_argument("--batch-size", type=int, default=32)
+    p.add_argument(
+        "--block-chunks",
+        type=int,
+        default=None,
+        help="shuffle window in chunks; the residency floor is two blocks of stored chunks "
+        "(default: 1 on --source gfs, where one chunk is 6.87 GiB)",
+    )
+    p.add_argument("--n-steps", type=int, default=512, help="synthetic archive length (time)")
+    p.add_argument("--nlat", type=int, default=91, help="synthetic grid rows")
+    p.add_argument("--nlon", type=int, default=180, help="synthetic grid columns")
+    p.add_argument("--sample-chunk", type=int, default=128, help="synthetic samples per chunk")
+    p.add_argument(
+        "--url",
+        default=None,
+        help="synthetic store path (file:// temp default; gs://... / s3://... for a cloud store)",
+    )
+    p.add_argument(
+        "--regenerate",
+        action="store_true",
+        help="force-rewrite the synthetic store even if one with the same geometry exists",
+    )
+    p.add_argument(
+        "--cache-dir",
+        default=None,
+        help="spill the decoded-chunk cache here (e.g. NVMe) for cross-epoch reuse",
+    )
+    p.add_argument(
+        "--max-inflight",
+        type=int,
+        default=None,
+        help="throttle read-ahead depth; each slot costs a whole stored chunk on this geometry",
+    )
+    p.add_argument(
+        "--print-summary",
+        action="store_true",
+        help="print the full memory and geometry report before training (fetches nothing)",
+    )
+    add_log_level(p)
+    return p
+
+
+def cli() -> argparse.Namespace:
+    """Parse the shared CLI."""
+    args = build_parser().parse_args()
+    configure_logging(args.log_level)
+    return args
+
+
+def build_datasets(args: argparse.Namespace) -> InSituDataset:
+    """One downscaling dataset from CLI args -- iterate ``ds.train`` / ``ds.val``.
+
+    ``--source`` picks the offline synthetic archive (written fresh) or dynamical.org's real
+    GFS analysis. The GFS defaults are the conservative ones: four chunks of the time axis, one
+    chunk per block, two reads in flight. It still estimates ~20 GiB of peak, which is what
+    ``--print-summary`` is for -- the report opens no store and fetches nothing, so checking
+    before you commit costs a second.
+    """
+    if args.source == "gfs":
+        ds = downscaling_dataset(
+            _gfs_store(),
+            sample_range=args.sample_range or (0, GFS_SAMPLES_PER_CHUNK * 4),
+            batch_size=args.batch_size,
+            block_chunks=args.block_chunks or 1,
+            max_inflight=args.max_inflight or 2,
+            cache_dir=args.cache_dir,
+        )
+    else:
+        url = args.url or "file:///tmp/insitu_irradiance.zarr"
+        if args.regenerate or not _synthetic_ready(
+            url, args.n_steps, args.nlat, args.nlon, args.sample_chunk
+        ):
+            make_irradiance_store(
+                url,
+                n_steps=args.n_steps,
+                nlat=args.nlat,
+                nlon=args.nlon,
+                sample_chunk=args.sample_chunk,
+            )
+        ds = downscaling_dataset(
+            obstore_store(url),
+            sample_range=args.sample_range,
+            batch_size=args.batch_size,
+            block_chunks=args.block_chunks or 16,
+            max_inflight=args.max_inflight,
+            cache_dir=args.cache_dir,
+        )
+    if args.print_summary:
+        ds.print_summary()
+    else:
+        peak = ds.describe()["memory"]["estimated_peak_bytes"]
+        print(f"estimated peak {peak / 2**30:.2f} GiB -- --print-summary for the full report")
+    return ds

--- a/examples/dynamical/train_torch.py
+++ b/examples/dynamical/train_torch.py
@@ -1,0 +1,92 @@
+"""Downscale solar irradiance with a tiny CNN, in **PyTorch**, on one insitu dataset.
+
+Only this file is torch: ``to_torch`` is a zero-copy DLPack hand-off and the train loop moves
+each batch to ``--device``. The model is handed the bilinearly upsampled coarse field and
+predicts a *residual*, so beating the bilinear baseline means it recovered sub-grid structure
+the interpolation cannot -- the cloud edges the block average washed out.
+
+Sources (``--source synthetic|gfs``), the finite time window (``--sample-range``), the
+residency knobs and GPU placement are documented in ``examples/README.md``; the framework-
+neutral data layer is ``examples/dynamical/data.py``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from torch import nn
+
+from insitubatch import Batch, InSituDataset
+
+from .data import build_datasets, cli, evaluate, inputs_and_targets
+
+
+class ResidualCNN(nn.Module):
+    """1 input channel -> 1 residual channel. The input is standardized, four 3x3 convolutions
+    (circular padding in longitude, replicate in latitude -- the globe wraps east-west but not
+    north-south) give a receptive field of 9, and the output is added back to the interpolated
+    field, so the model only has to learn what bilinear upsampling left out."""
+
+    def __init__(self, hidden: int = 32) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Conv2d(1, hidden, 3, padding=1, padding_mode="replicate"),
+            nn.ReLU(),
+            nn.Conv2d(hidden, hidden, 3, padding=1, padding_mode="replicate"),
+            nn.ReLU(),
+            nn.Conv2d(hidden, hidden, 3, padding=1, padding_mode="replicate"),
+            nn.ReLU(),
+            nn.Conv2d(hidden, 1, 3, padding=1, padding_mode="replicate"),
+        )
+        self.scale = 300.0  # W/m^2: keeps the standardized residual near unit magnitude
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # (B, 1, H, W) -> (B, 1, H, W) W/m^2
+        xn = (x - x.mean((0, 2, 3), keepdim=True)) / (x.std((0, 2, 3), keepdim=True) + 1e-6)
+        return x + self.scale * self.net(xn)
+
+
+def _predict(model: ResidualCNN, batch: Batch, device: torch.device) -> torch.Tensor:
+    """The model's field for one batch, in W/m^2.
+
+    The crop and the block average happen in numpy (``inputs_and_targets``) because they define
+    the task, not the model; placement on ``device`` is the loop's job, not the dataset's.
+    """
+    x, _target = inputs_and_targets(batch)
+    return model(torch.from_numpy(x).unsqueeze(1).to(device))
+
+
+def train(ds: InSituDataset, *, epochs: int, device: str = "cpu") -> tuple[float, float]:
+    """Train the CNN; return ``(model_rmse, bilinear_rmse)`` in W/m^2 on val."""
+    dev = torch.device(device)
+    model = ResidualCNN().to(dev)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    for epoch in range(epochs):
+        ds.set_epoch(epoch)
+        model.train()
+        last = 0.0
+        for batch in ds.train:
+            _x, target = inputs_and_targets(batch)
+            y = torch.from_numpy(target).unsqueeze(1).to(dev)  # (B, 1, H, W) W/m^2
+            loss = nn.functional.mse_loss(_predict(model, batch, dev), y)
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            last = loss.item()
+        print(f"epoch {epoch}  train mse {last:9.1f}  (rmse {np.sqrt(last):6.1f} W/m2)")
+    model.eval()
+    with torch.no_grad():
+        return evaluate(ds.val, lambda b: _predict(model, b, dev).squeeze(1).cpu().numpy())
+
+
+def main() -> None:
+    args = cli()
+    ds = build_datasets(args)
+    model_rmse, bilinear_rmse = train(ds, epochs=args.epochs, device=args.device)
+    print(
+        f"\ndownscaling RMSE on held-out data: model {model_rmse:.2f}  vs  "
+        f"bilinear {bilinear_rmse:.2f} W/m2  ({model_rmse - bilinear_rmse:+.2f})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dynamical.py
+++ b/tests/test_dynamical.py
@@ -1,0 +1,101 @@
+"""Downscaling example: deep sample chunks, a wrapping region crop, and the model learns.
+
+One fixture builds a small synthetic irradiance archive with the three properties that make
+dynamical.org's GFS analysis interesting -- many samples inside one stored chunk, a field tiled
+across several stored chunks, and a tile grid that does not divide the field. The tests assert
+the engine batches off that geometry, that the region crop wraps the prime meridian, and that
+the torch model beats the bilinear baseline it can only beat by reading spatial context.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from examples.dynamical.data import (
+    COARSEN,
+    GFS_VAR,
+    LABEL,
+    REGION,
+    bilinear_upsample,
+    block_mean,
+    downscaling_dataset,
+    inputs_and_targets,
+    make_irradiance_store,
+    region_index,
+    rmse,
+)
+from insitubatch import obstore_store, open_geometries
+
+N_STEPS, NLAT, NLON, SAMPLE_CHUNK, TILE = 192, 91, 180, 64, 32
+
+
+@pytest.fixture
+def irradiance_store(tmp_path) -> str:
+    """A small synthetic archive with GFS-shaped chunking (fast: short, coarse grid)."""
+    url = f"file://{tmp_path}/irradiance.zarr"
+    make_irradiance_store(
+        url, n_steps=N_STEPS, nlat=NLAT, nlon=NLON, sample_chunk=SAMPLE_CHUNK, tile=TILE, seed=0
+    )
+    return url
+
+
+def test_geometry_is_deep_and_tiled(irradiance_store) -> None:
+    geom = open_geometries(obstore_store(irradiance_store), variables=[GFS_VAR])[GFS_VAR]
+    # Many samples behind one stored chunk -- the property the whole example is about.
+    assert geom.sample_chunk_size == SAMPLE_CHUNK
+    assert geom.n_chunks == N_STEPS // SAMPLE_CHUNK
+    # The field spans several stored chunks, on a tile grid that does not divide it, so the
+    # slot carries padding: residency exceeds the logical chunk, exactly as it does on GFS.
+    assert geom.n_inner_chunks(0) == -(-NLAT // TILE) * -(-NLON // TILE)
+    assert geom.chunk_bytes > SAMPLE_CHUNK * NLAT * NLON * 4
+
+
+def test_region_crop_wraps_the_prime_meridian() -> None:
+    rows, cols = region_index(NLAT, NLON, REGION)
+    assert rows.size % COARSEN == 0 and cols.size % COARSEN == 0
+    # The European window runs west of 0 and east of it, so the columns wrap and are not
+    # monotonic -- a plain slice would silently take the long way round the globe instead.
+    assert cols[0] > cols[-1]
+    assert (np.diff(cols) != 1).sum() == 1  # exactly one discontinuity: the wrap itself
+    assert cols.max() < NLON and cols.min() >= 0
+
+
+def test_bilinear_baseline_reconstructs_a_smooth_field_exactly() -> None:
+    # Validate the instrument before the subject: on a field that is linear in both axes,
+    # bilinear upsampling of the block mean is exact, so any RMSE the eval reports later is
+    # the model's or the data's -- not the baseline's arithmetic.
+    y, x = np.mgrid[0:16, 0:24].astype("f4")
+    field = (2.0 * y + 3.0 * x)[None]
+    restored = bilinear_upsample(block_mean(field, COARSEN), COARSEN)
+    assert restored.shape == field.shape
+    # Cell-centre bilinear is exact on a linear ramp away from the clamped outer half-cells.
+    inner = (slice(None), slice(COARSEN, -COARSEN), slice(COARSEN, -COARSEN))
+    assert rmse(restored[inner], field[inner]) < 1e-3
+
+
+def test_batches_carry_the_whole_field_and_crop_to_the_region(irradiance_store) -> None:
+    ds = downscaling_dataset(
+        obstore_store(irradiance_store), batch_size=8, block_chunks=1, shuffle=False
+    )
+    ds.set_epoch(0)
+    batch = next(iter(ds.train))
+    assert set(batch.arrays) == {LABEL}
+    assert batch.arrays[LABEL].shape == (8, NLAT, NLON)  # field axes carried whole
+
+    x, target = inputs_and_targets(batch)
+    rows, cols = region_index(NLAT, NLON)
+    assert x.shape == target.shape == (8, rows.size, cols.size)
+    assert x.dtype == target.dtype == np.dtype("f4")
+    assert target.min() >= 0.0  # irradiance is non-negative
+    # The baseline leaves real headroom: the sub-grid cloud structure is gone from x.
+    assert rmse(x, target) > 1.0
+
+
+def test_torch_beats_bilinear(irradiance_store) -> None:
+    pytest.importorskip("torch")
+    from examples.dynamical.train_torch import train
+
+    ds = downscaling_dataset(obstore_store(irradiance_store), batch_size=8, block_chunks=1)
+    model_rmse, bilinear_rmse = train(ds, epochs=8)
+    assert model_rmse < bilinear_rmse


### PR DESCRIPTION
## Summary

Adds `examples/dynamical/` — spatial downscaling of surface solar irradiance on
[dynamical.org](https://dynamical.org)'s public NOAA GFS analysis, an Icechunk repository whose
stored chunk holds **1440 consecutive hourly global fields**. It is the deep-chunk end of the
example set: one fetch and one decode serve 1440 samples, where a per-sample `__getitem__` would
re-read the same object every time.

It exists because pointing the README quickstart at one of these archives fails three ways
before a byte moves, and none of them raise:

1. the stores are **Icechunk**, so `obstore_store()` is the wrong constructor
2. `variables=` stops being optional at 25–146 arrays per store (and `sample_axis=` then raises
   on the 1-D coordinate arrays)
3. the quickstart's `block_chunks=16` is sized to a 63 MiB chunk; NOAA GFS analysis has a
   **6.87 GiB** one, and three variables at those defaults asks `print_summary()` for **860 GiB**
   of estimated peak — which it truthfully reports

**The example reads one variable on purpose.** A stored chunk is 878.9 MiB and assembles to
6.87 GiB resident; the floor is two blocks of them, so each variable costs ~13.7 GiB whatever the
batch size, and a shrinking `chunk_transform` cannot buy it back (`slot_charge_bytes` takes
`max(source tiles, assembled output)`, because the pool holds the source tiles until the fill
completes — so a `Coarsen(4)` leaves residency unchanged and raises peak). Picking a smaller
store would have hidden the one thing this geometry is here to teach.

Task is downscaling over a European window; baseline is **bilinear upsampling** — what the coarse
field gives you with no model, and a data fingerprint besides, since its RMSE depends only on the
bytes the loader handed over. Follows the `microscopy/` shape: `data.py` framework-neutral,
`train_torch.py` the only framework file, offline synthetic `--source` so it runs with no network
or credentials.

Docs, `examples/README.md` and a CHANGELOG bullet included. No engine code is touched — this is
examples, tests and docs only.

## For reviewers

Most valuable second look:

- **The residency claim in the docs and CHANGELOG.** I read it out of `slot_charge_bytes` rather
  than measuring a shrinking transform's peak RSS directly; the `describe()` numbers agree with
  the reading, but the arithmetic is worth a check.
- **`region_index()`** — the European window wraps the prime meridian, so it returns wrapping
  column indices rather than a slice. `test_region_crop_wraps_the_prime_meridian` asserts exactly
  one discontinuity; a plain slice would silently take the long way round the globe.
- **Whether the synthetic store earns its construction.** Its sub-grid structure is a
  deterministic function of the smooth field, so the CNN beats bilinear by construction, which is
  what makes the test fast and deterministic. That is stated in the docstring rather than implied.

Confident in: the geometry assertions, and that the real-archive path runs (log below).

## Verification

All green locally on this branch:

- `uv run ruff check src tests bench examples` ✅
- `uv run ruff format --check src tests bench examples` ✅
- `uv run mypy src bench examples` ✅
- `uv run pytest -q` → **673 passed, 9 skipped** ✅
- `uv run --extra docs mkdocs build --strict` ✅

Example runs (these are *demonstration* runs, not a performance claim — no baseline engine is
being compared against):

| run | result |
|---|---|
| `--source synthetic` (offline, 8 epochs) | model **28.6** vs bilinear **35.4** W/m² |
| `--source gfs` (2 epochs, default 4-chunk range) | model **22.65** vs bilinear **25.10** W/m² |

The GFS run, on an 8 vCPU / 31 GiB `n2-standard-8` in GCP reading `s3://dynamical-noaa-gfs` in
`us-west-2` (cross-cloud, so pessimistic): 90 batches in **102.7 s** cold at 0% chunk hit, then
**93.0 s** at **100%** chunk hit with zero fetches and zero decodes. `print_summary()` estimated
**19.78 GiB** of peak on the defaults, which is what it took.

## Author attestation

- [ ] I have reviewed every change in this PR, I can explain why each one is correct, and I
      have verified the claims made in this description.

Left unchecked deliberately — this was AI-assisted and the attestation is the human author's to
tick.

## Checklist

- [x] Tests added or updated — `tests/test_dynamical.py`, 5 tests, synthetic only (11 s)
- [x] `ruff check`, `ruff format --check`, `mypy`, `pytest -q` and `mkdocs build --strict` green
      locally
- [x] Docstrings for the new public surface (all of `examples/dynamical/data.py`)
- [x] User-facing behavior documented — `docs/examples.md` (table row + section) and
      `examples/README.md`
- [x] A bullet added under `## Unreleased` in `CHANGELOG.md`
- [x] No load-bearing invariant broken — examples/tests/docs only, no engine change; `Batch`
      stays numpy, no dask, no reshard, no `xr.DataArray`
- [x] Does not touch `ChunkPool`, the scheduler, or cross-thread readiness
- [x] No performance claim made — the numbers above are demonstration runs with their hardware
      and store stated, not a comparison against another engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eLANSQjFGbLQprE7LbyTJ
